### PR TITLE
Add Restocking page with budget-aware recommendations and restock ord…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,6 @@ npm install && npm run dev
 - Status: green/blue/yellow/red
 - Charts: Custom SVG, CSS Grid for layouts
 - No emojis in UI
+
+## Code Style
+- Always document non-obvious logic changes with comments

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,6 +25,9 @@
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            Restocking
+          </router-link>
         </nav>
         <LanguageSwitcher />
         <ProfileMenu

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,15 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restock-orders`)
+    return response.data
+  },
+
+  async createRestockOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/restock-orders`, orderData)
+    return response.data
   }
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -74,6 +74,44 @@
           </table>
         </div>
       </div>
+
+      <div v-if="restockOrders.length > 0" class="card restock-orders-card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders ({{ restockOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="restock-table">
+            <thead>
+              <tr>
+                <th>Order</th>
+                <th>Items</th>
+                <th>Total Value</th>
+                <th>Status</th>
+                <th>Expected Delivery</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in restockOrders" :key="order.id">
+                <td><strong>{{ order.id }}</strong></td>
+                <td>
+                  <details class="items-details">
+                    <summary class="items-summary">{{ order.items.length }} item{{ order.items.length !== 1 ? 's' : '' }}</summary>
+                    <div class="items-dropdown">
+                      <div v-for="item in order.items" :key="item.sku" class="item-entry">
+                        <span class="item-name">{{ item.name }}</span>
+                        <span class="item-meta">{{ item.sku }} · Qty: {{ item.quantity }} @ ${{ item.unit_cost }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td><strong>${{ order.total_value.toLocaleString() }}</strong></td>
+                <td><span class="badge info">{{ order.status }}</span></td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -95,6 +133,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockOrders = ref([])
 
     // Use shared filters
     const {
@@ -153,7 +192,18 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    const loadRestockOrders = async () => {
+      try {
+        restockOrders.value = await api.getRestockOrders()
+      } catch (err) {
+        console.error('Failed to load restock orders:', err)
+      }
+    }
+
+    onMounted(() => {
+      loadOrders()
+      loadRestockOrders()
+    })
 
     return {
       t,
@@ -165,7 +215,8 @@ export default {
       formatDate,
       currencySymbol,
       translateProductName,
-      translateCustomerName
+      translateCustomerName,
+      restockOrders
     }
   }
 }
@@ -275,5 +326,14 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+.restock-orders-card {
+  margin-top: 1.25rem;
+}
+
+.restock-table {
+  table-layout: fixed;
+  width: 100%;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,386 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>AI-recommended restocking orders based on demand forecasts</p>
+    </div>
+
+    <div v-if="loading" class="loading">Loading forecasts...</div>
+    <div v-else>
+      <!-- Budget Slider -->
+      <div class="card">
+        <div class="budget-slider-row">
+          <label class="budget-label" for="budget-slider">Available Budget</label>
+          <span class="budget-display">{{ formatCurrency(budget) }}</span>
+        </div>
+        <input
+          id="budget-slider"
+          type="range"
+          min="0"
+          max="200000"
+          step="5000"
+          v-model.number="budget"
+          class="budget-range"
+        />
+        <div class="budget-range-hints">
+          <span>{{ currencySymbol }}0</span>
+          <span>{{ currencySymbol }}200,000</span>
+        </div>
+      </div>
+
+      <!-- Budget Meter -->
+      <div class="card">
+        <div class="meter-header">
+          <span class="meter-label">Budget Usage</span>
+          <span class="meter-text">
+            {{ Math.round(budgetPercent) }}% of budget used &middot;
+            {{ formatCurrency(totalCost) }} of {{ formatCurrency(budget) }}
+          </span>
+        </div>
+        <div class="progress-track">
+          <div
+            class="progress-fill"
+            :class="meterColorClass"
+            :style="{ width: budgetPercent + '%' }"
+          ></div>
+        </div>
+      </div>
+
+      <!-- Recommendations Table -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Recommended Items</h3>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Item Name</th>
+                <th>SKU</th>
+                <th>Trend</th>
+                <th>Qty to Order</th>
+                <th>Unit Cost</th>
+                <th>Total Cost</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendations" :key="item.item_sku">
+                <td>{{ item.item_name }}</td>
+                <td><strong>{{ item.item_sku }}</strong></td>
+                <td>
+                  <span :class="['badge', item.trend]">{{ item.trend }}</span>
+                </td>
+                <td>{{ item.forecasted_demand }}</td>
+                <td>{{ formatCurrency(item.unit_cost) }}</td>
+                <td>{{ formatCurrency(item.totalCost) }}</td>
+                <td>
+                  <span v-if="item.included" class="badge success">Included</span>
+                  <span v-else class="badge over-budget">Over Budget</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <!-- Table Footer -->
+        <div class="table-footer">
+          <span>{{ includedItems.length }} of {{ recommendations.length }} items</span>
+          <span class="footer-total">Total: {{ formatCurrency(totalCost) }}</span>
+        </div>
+      </div>
+
+      <!-- Place Order Button -->
+      <div class="action-area">
+        <button
+          class="btn-primary"
+          :disabled="includedItems.length === 0 || placing"
+          @click="placeOrder"
+        >
+          {{ placing ? 'Placing Order...' : 'Place Restocking Order' }}
+        </button>
+        <div v-if="successMessage" class="success-banner">
+          {{ successMessage }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+// Priority order for greedy algorithm: increasing items first, then stable, then decreasing
+const TREND_PRIORITY = { increasing: 0, stable: 1, decreasing: 2 }
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency } = useI18n()
+
+    const allForecasts = ref([])
+    const loading = ref(false)
+    const placing = ref(false)
+    const successMessage = ref('')
+    const budget = ref(100000)
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? '¥' : '$'
+    })
+
+    const formatCurrency = (value) => {
+      return value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0
+      })
+    }
+
+    // Greedy recommendation algorithm: sort by trend priority, include items while under budget
+    const recommendations = computed(() => {
+      const sorted = [...allForecasts.value].sort((a, b) => {
+        const pa = TREND_PRIORITY[a.trend] ?? 99
+        const pb = TREND_PRIORITY[b.trend] ?? 99
+        return pa - pb
+      })
+
+      let runningTotal = 0
+      return sorted.map(forecast => {
+        const totalCost = forecast.forecasted_demand * forecast.unit_cost
+        const canInclude = (runningTotal + totalCost) <= budget.value
+        if (canInclude) {
+          runningTotal += totalCost
+        }
+        return {
+          ...forecast,
+          totalCost,
+          included: canInclude
+        }
+      })
+    })
+
+    const includedItems = computed(() => {
+      return recommendations.value.filter(item => item.included)
+    })
+
+    const totalCost = computed(() => {
+      return includedItems.value.reduce((sum, item) => sum + item.totalCost, 0)
+    })
+
+    // Clamp to 100 for display (overage shouldn't occur due to algorithm, but guard anyway)
+    const budgetPercent = computed(() => {
+      if (budget.value === 0) return 0
+      return Math.min((totalCost.value / budget.value) * 100, 100)
+    })
+
+    const meterColorClass = computed(() => {
+      const pct = budgetPercent.value
+      if (pct >= 80) return 'meter-yellow'
+      return 'meter-green'
+    })
+
+    const loadForecasts = async () => {
+      loading.value = true
+      try {
+        allForecasts.value = await api.getDemandForecasts()
+      } catch (err) {
+        console.error('Failed to load demand forecasts:', err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      placing.value = true
+      successMessage.value = ''
+      try {
+        const orderItems = includedItems.value.map(f => ({
+          sku: f.item_sku,
+          name: f.item_name,
+          quantity: f.forecasted_demand,
+          unit_cost: f.unit_cost
+        }))
+        const order = await api.createRestockOrder({ items: orderItems })
+        successMessage.value = `Restocking order ${order.id} placed successfully`
+        budget.value = 100000
+      } catch (err) {
+        console.error('Failed to place restock order:', err)
+      } finally {
+        placing.value = false
+      }
+    }
+
+    onMounted(loadForecasts)
+
+    return {
+      t,
+      allForecasts,
+      loading,
+      placing,
+      successMessage,
+      budget,
+      currencySymbol,
+      formatCurrency,
+      recommendations,
+      includedItems,
+      totalCost,
+      budgetPercent,
+      meterColorClass,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.restocking {
+  /* Inherits .main-content padding from App.vue */
+}
+
+/* Budget Slider Card */
+.budget-slider-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.budget-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.budget-display {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.budget-range {
+  width: 100%;
+  height: 6px;
+  accent-color: #2563eb;
+  cursor: pointer;
+  margin-bottom: 0.375rem;
+}
+
+.budget-range-hints {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+/* Budget Meter Card */
+.meter-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.meter-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.meter-text {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.progress-track {
+  width: 100%;
+  height: 10px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease, background-color 0.3s ease;
+}
+
+.progress-fill.meter-green {
+  background: #10b981;
+}
+
+.progress-fill.meter-yellow {
+  background: #f59e0b;
+}
+
+/* Table Footer */
+.table-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.625rem 0.75rem;
+  border-top: 1px solid #e2e8f0;
+  background: #f8fafc;
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+  border-radius: 0 0 8px 8px;
+}
+
+.footer-total {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+/* Over Budget badge — scoped gray style */
+.badge.over-budget {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+/* Action Area */
+.action-area {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.btn-primary {
+  padding: 0.625rem 1.5rem;
+  background: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.success-banner {
+  padding: 0.75rem 1.25rem;
+  background: #d1fae5;
+  color: #065f46;
+  border: 1px solid #6ee7b7;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  font-weight: 500;
+}
+</style>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -6,7 +6,8 @@
     "current_demand": 300,
     "forecasted_demand": 450,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 95.00
   },
   {
     "id": "2",
@@ -15,7 +16,8 @@
     "current_demand": 150,
     "forecasted_demand": 152,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 45.00
   },
   {
     "id": "3",
@@ -24,7 +26,8 @@
     "current_demand": 500,
     "forecasted_demand": 600,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 18.50
   },
   {
     "id": "4",
@@ -33,7 +36,8 @@
     "current_demand": 50,
     "forecasted_demand": 35,
     "trend": "decreasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 285.00
   },
   {
     "id": "5",
@@ -42,7 +46,8 @@
     "current_demand": 800,
     "forecasted_demand": 950,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 22.75
   },
   {
     "id": "6",
@@ -51,7 +56,8 @@
     "current_demand": 120,
     "forecasted_demand": 121,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 67.00
   },
   {
     "id": "7",
@@ -60,7 +66,8 @@
     "current_demand": 250,
     "forecasted_demand": 252,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 89.00
   },
   {
     "id": "8",
@@ -69,7 +76,8 @@
     "current_demand": 180,
     "forecasted_demand": 182,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 34.50
   },
   {
     "id": "9",
@@ -78,6 +86,7 @@
     "current_demand": 95,
     "forecasted_demand": 96,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 125.00
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
-from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders, restock_orders
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -89,6 +89,7 @@ class DemandForecast(BaseModel):
     forecasted_demand: int
     trend: str
     period: str
+    unit_cost: float
 
 class BacklogItem(BaseModel):
     id: str
@@ -119,6 +120,23 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+
+class RestockOrder(BaseModel):
+    id: str
+    items: List[RestockOrderItem]
+    total_value: float
+    status: str
+    order_date: str
+    expected_delivery: str
+
+class CreateRestockOrderRequest(BaseModel):
+    items: List[RestockOrderItem]
 
 # API endpoints
 @app.get("/")
@@ -303,6 +321,31 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.post("/api/restock-orders", response_model=RestockOrder, status_code=201)
+def create_restock_order(request: CreateRestockOrderRequest):
+    """Create a new restocking order from recommended items"""
+    from datetime import datetime, timedelta
+
+    order_id = f"RST-{len(restock_orders) + 1:03d}"
+    now = datetime.utcnow()
+    total_value = sum(item.quantity * item.unit_cost for item in request.items)
+
+    new_order = {
+        "id": order_id,
+        "items": [item.model_dump() for item in request.items],
+        "total_value": round(total_value, 2),
+        "status": "Submitted",
+        "order_date": now.isoformat(),
+        "expected_delivery": (now + timedelta(days=14)).isoformat()
+    }
+    restock_orders.append(new_order)
+    return new_order
+
+@app.get("/api/restock-orders", response_model=List[RestockOrder])
+def get_restock_orders():
+    """Get all submitted restock orders"""
+    return restock_orders
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/mock_data.py
+++ b/server/mock_data.py
@@ -35,5 +35,8 @@ recent_transactions = load_json_file('transactions.json')
 # Load purchase orders
 purchase_orders = load_json_file('purchase_orders.json')
 
+# In-memory store for restock orders (not persisted to disk)
+restock_orders = []
+
 # All data is now loaded from JSON files in the data/ directory
 # This allows for easier maintenance and updates of the sample data


### PR DESCRIPTION
…ers API

- Add Restocking view with budget slider, greedy algorithm that prioritizes increasing/stable demand items, and budget usage meter
- Add /api/restock-orders POST and GET endpoints with in-memory storage
- Add unit_cost field to demand_forecasts.json and DemandForecast Pydantic model (was missing, causing TypeError on the Restocking page)
- Wire up Restocking route in router and nav link in App.vue
- Show submitted restock orders in Orders view with expandable item details
- Add createRestockOrder and getRestockOrders methods to api.js