### PR TITLE
Add restocking view, reports i18n, and new API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ npm install && npm run dev
 - `GET /api/spending/*` - Summary, monthly, categories, transactions
 
 ## Common Issues
+0. Always document non-obvious logic changes with comments
 1. Use unique keys in v-for (not `index`) - use `sku`, `month`, etc.
 2. Validate dates before `.getMonth()` calls
 3. Update Pydantic models when changing JSON data structure

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,8 +22,11 @@
           <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
             {{ t('nav.demandForecast') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
+            {{ t('nav.reports') }}
           </router-link>
         </nav>
         <LanguageSwitcher />

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,42 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getQuarterlyReports(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    if (filters.status && filters.status !== 'all') params.append('status', filters.status)
+    if (filters.month && filters.month !== 'all') params.append('month', filters.month)
+
+    const response = await axios.get(`${API_BASE_URL}/reports/quarterly?${params.toString()}`)
+    return response.data
+  },
+
+  async getMonthlyTrends(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    if (filters.status && filters.status !== 'all') params.append('status', filters.status)
+    if (filters.month && filters.month !== 'all') params.append('month', filters.month)
+
+    const response = await axios.get(`${API_BASE_URL}/reports/monthly-trends?${params.toString()}`)
+    return response.data
+  },
+
+  async getRestockingRecommendations() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/recommendations`)
+    return response.data
+  },
+
+  async submitRestockingOrder(data) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/orders`, data)
+    return response.data
+  },
+
+  async getSubmittedRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/submitted-orders`)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,8 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
+    reports: 'Reports',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -186,6 +188,64 @@ export default {
       trend: 'Trend',
       period: 'Period'
     }
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Set a budget and get priority-ranked recommendations from demand forecasts',
+    budget: 'Budget',
+    recommendations: 'Recommendations',
+    table: {
+      select: 'Select',
+      sku: 'SKU',
+      itemName: 'Item Name',
+      trend: 'Trend',
+      forecastedDemand: 'Forecasted Demand',
+      currentStock: 'Current Stock',
+      restockQty: 'Restock Qty',
+      unitCost: 'Unit Cost',
+      totalCost: 'Total Cost'
+    },
+    selectedItems: 'Selected Items',
+    totalCost: 'Total Cost',
+    remainingBudget: 'Remaining Budget',
+    placeOrder: 'Place Restocking Order',
+    orderSuccess: 'Restocking order placed successfully!',
+    orderNumber: 'Order Number',
+    noRecommendations: 'No restocking recommendations - all items are sufficiently stocked.',
+    submittedOrders: 'Submitted Restocking Orders',
+    noSubmittedOrders: 'No restocking orders have been submitted yet.',
+    items: 'Items',
+    status: 'Status',
+    orderDate: 'Order Date',
+    expectedDelivery: 'Expected Delivery',
+    leadTime: 'Lead Time',
+    totalValue: 'Total Value',
+    days: 'days'
+  },
+
+  // Reports
+  reports: {
+    title: 'Performance Reports',
+    description: 'View quarterly performance metrics and monthly trends',
+    quarterlyPerformance: 'Quarterly Performance',
+    monthlyRevenueTrend: 'Monthly Revenue Trend',
+    monthOverMonth: 'Month-over-Month Analysis',
+    quarter: 'Quarter',
+    totalOrders: 'Total Orders',
+    totalRevenue: 'Total Revenue',
+    avgOrderValue: 'Avg Order Value',
+    fulfillmentRate: 'Fulfillment Rate',
+    month: 'Month',
+    orders: 'Orders',
+    revenue: 'Revenue',
+    change: 'Change',
+    growthRate: 'Growth Rate',
+    totalRevenueYTD: 'Total Revenue (YTD)',
+    avgMonthlyRevenue: 'Avg Monthly Revenue',
+    totalOrdersYTD: 'Total Orders (YTD)',
+    bestPerformingQuarter: 'Best Performing Quarter'
   },
 
   // Filters

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,8 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充',
+    reports: 'レポート',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -186,6 +188,64 @@ export default {
       trend: 'トレンド',
       period: '期間'
     }
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充',
+    description: '予算を設定し、需要予測に基づく優先順位付きの補充提案を取得',
+    budget: '予算',
+    recommendations: '推奨事項',
+    table: {
+      select: '選択',
+      sku: 'SKU',
+      itemName: '品目名',
+      trend: 'トレンド',
+      forecastedDemand: '予測需要',
+      currentStock: '現在庫',
+      restockQty: '補充数量',
+      unitCost: '単価',
+      totalCost: '合計コスト'
+    },
+    selectedItems: '選択品目',
+    totalCost: '合計コスト',
+    remainingBudget: '残予算',
+    placeOrder: '補充注文を発注',
+    orderSuccess: '補充注文が正常に発注されました！',
+    orderNumber: '注文番号',
+    noRecommendations: '補充の推奨事項はありません - すべての品目は十分な在庫があります。',
+    submittedOrders: '発注済み補充注文',
+    noSubmittedOrders: 'まだ補充注文は発注されていません。',
+    items: '品目',
+    status: 'ステータス',
+    orderDate: '注文日',
+    expectedDelivery: '予定配達日',
+    leadTime: 'リードタイム',
+    totalValue: '合計金額',
+    days: '日'
+  },
+
+  // Reports
+  reports: {
+    title: 'パフォーマンスレポート',
+    description: '四半期業績指標と月次トレンドの表示',
+    quarterlyPerformance: '四半期業績',
+    monthlyRevenueTrend: '月次収益トレンド',
+    monthOverMonth: '月次比較分析',
+    quarter: '四半期',
+    totalOrders: '総注文数',
+    totalRevenue: '総収益',
+    avgOrderValue: '平均注文額',
+    fulfillmentRate: '履行率',
+    month: '月',
+    orders: '注文',
+    revenue: '収益',
+    change: '変化',
+    growthRate: '成長率',
+    totalRevenueYTD: '総収益（年初来）',
+    avgMonthlyRevenue: '平均月次収益',
+    totalOrdersYTD: '総注文数（年初来）',
+    bestPerformingQuarter: '最高業績四半期'
   },
 
   // Filters

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -74,6 +74,45 @@
           </table>
         </div>
       </div>
+
+      <div class="card" style="margin-top: 1.5rem;">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.submittedOrders') }}</h3>
+        </div>
+        <div v-if="submittedOrders.length === 0" class="empty-state">
+          {{ t('restocking.noSubmittedOrders') }}
+        </div>
+        <div v-else class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-items">{{ t('restocking.items') }}</th>
+                <th class="col-status">{{ t('restocking.status') }}</th>
+                <th class="col-date">{{ t('restocking.orderDate') }}</th>
+                <th class="col-date">{{ t('restocking.expectedDelivery') }}</th>
+                <th class="col-date">{{ t('restocking.leadTime') }}</th>
+                <th class="col-value">{{ t('restocking.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-items">{{ order.items.length }} {{ t('common.items') }}</td>
+                <td class="col-status">
+                  <span :class="['badge', getOrderStatusClass(order.status)]">
+                    {{ t(`status.${order.status.toLowerCase()}`) }}
+                  </span>
+                </td>
+                <td class="col-date">{{ formatDate(order.order_date) }}</td>
+                <td class="col-date">{{ formatDate(order.expected_delivery) }}</td>
+                <td class="col-date">{{ calculateLeadTime(order.order_date, order.expected_delivery) }} {{ t('restocking.days') }}</td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -95,6 +134,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const submittedOrders = ref([])
 
     // Use shared filters
     const {
@@ -122,6 +162,21 @@ export default {
       } finally {
         loading.value = false
       }
+    }
+
+    const loadSubmittedOrders = async () => {
+      try {
+        submittedOrders.value = await api.getSubmittedRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load submitted restocking orders:', err)
+      }
+    }
+
+    const calculateLeadTime = (orderDate, deliveryDate) => {
+      const start = new Date(orderDate)
+      const end = new Date(deliveryDate)
+      const diffTime = Math.abs(end - start)
+      return Math.ceil(diffTime / (1000 * 60 * 60 * 24))
     }
 
     // Watch for filter changes and reload data
@@ -153,16 +208,22 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    onMounted(() => {
+      loadOrders()
+      loadSubmittedOrders()
+    })
 
     return {
       t,
       loading,
       error,
       orders,
+      submittedOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,
+      calculateLeadTime,
+      loadSubmittedOrders,
       currencySymbol,
       translateProductName,
       translateCustomerName
@@ -274,6 +335,12 @@ export default {
 
 .item-meta {
   font-size: 0.813rem;
+  color: #64748b;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
   color: #64748b;
 }
 </style>

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="reports">
     <div class="page-header">
-      <h2>Performance Reports</h2>
-      <p>View quarterly performance metrics and monthly trends</p>
+      <h2>{{ t('reports.title') }}</h2>
+      <p>{{ t('reports.description') }}</p>
     </div>
 
     <div v-if="loading" class="loading">Loading reports...</div>
@@ -11,25 +11,25 @@
       <!-- Quarterly Performance -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Quarterly Performance</h3>
+          <h3 class="card-title">{{ t('reports.quarterlyPerformance') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Quarter</th>
-                <th>Total Orders</th>
-                <th>Total Revenue</th>
-                <th>Avg Order Value</th>
-                <th>Fulfillment Rate</th>
+                <th>{{ t('reports.quarter') }}</th>
+                <th>{{ t('reports.totalOrders') }}</th>
+                <th>{{ t('reports.totalRevenue') }}</th>
+                <th>{{ t('reports.avgOrderValue') }}</th>
+                <th>{{ t('reports.fulfillmentRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(q, index) in quarterlyData" :key="index">
+              <tr v-for="q in quarterlyData" :key="q.quarter">
                 <td><strong>{{ q.quarter }}</strong></td>
                 <td>{{ q.total_orders }}</td>
-                <td>${{ formatNumber(q.total_revenue) }}</td>
-                <td>${{ formatNumber(q.avg_order_value) }}</td>
+                <td>{{ currencySymbol }}{{ formatNumber(q.total_revenue) }}</td>
+                <td>{{ currencySymbol }}{{ formatNumber(q.avg_order_value) }}</td>
                 <td>
                   <span :class="getFulfillmentClass(q.fulfillment_rate)">
                     {{ q.fulfillment_rate }}%
@@ -44,16 +44,16 @@
       <!-- Monthly Trends Chart -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Monthly Revenue Trend</h3>
+          <h3 class="card-title">{{ t('reports.monthlyRevenueTrend') }}</h3>
         </div>
         <div class="chart-container">
           <div class="bar-chart">
-            <div v-for="(month, index) in monthlyData" :key="index" class="bar-wrapper">
+            <div v-for="month in monthlyData" :key="month.month" class="bar-wrapper">
               <div class="bar-container">
                 <div
                   class="bar"
                   :style="{ height: getBarHeight(month.revenue) + 'px' }"
-                  :title="'$' + formatNumber(month.revenue)"
+                  :title="currencySymbol + formatNumber(month.revenue)"
                 ></div>
               </div>
               <div class="bar-label">{{ formatMonth(month.month) }}</div>
@@ -65,24 +65,24 @@
       <!-- Month-over-Month Comparison -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Month-over-Month Analysis</h3>
+          <h3 class="card-title">{{ t('reports.monthOverMonth') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Month</th>
-                <th>Orders</th>
-                <th>Revenue</th>
-                <th>Change</th>
-                <th>Growth Rate</th>
+                <th>{{ t('reports.month') }}</th>
+                <th>{{ t('reports.orders') }}</th>
+                <th>{{ t('reports.revenue') }}</th>
+                <th>{{ t('reports.change') }}</th>
+                <th>{{ t('reports.growthRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(month, index) in monthlyData" :key="index">
+              <tr v-for="(month, index) in monthlyData" :key="month.month">
                 <td><strong>{{ formatMonth(month.month) }}</strong></td>
                 <td>{{ month.order_count }}</td>
-                <td>${{ formatNumber(month.revenue) }}</td>
+                <td>{{ currencySymbol }}{{ formatNumber(month.revenue) }}</td>
                 <td>
                   <span v-if="index > 0" :class="getChangeClass(month.revenue, monthlyData[index - 1].revenue)">
                     {{ getChangeValue(month.revenue, monthlyData[index - 1].revenue) }}
@@ -104,19 +104,19 @@
       <!-- Summary Stats -->
       <div class="stats-grid">
         <div class="stat-card">
-          <div class="stat-label">Total Revenue (YTD)</div>
-          <div class="stat-value">${{ formatNumber(totalRevenue) }}</div>
+          <div class="stat-label">{{ t('reports.totalRevenueYTD') }}</div>
+          <div class="stat-value">{{ currencySymbol }}{{ formatNumber(totalRevenue) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Avg Monthly Revenue</div>
-          <div class="stat-value">${{ formatNumber(avgMonthlyRevenue) }}</div>
+          <div class="stat-label">{{ t('reports.avgMonthlyRevenue') }}</div>
+          <div class="stat-value">{{ currencySymbol }}{{ formatNumber(avgMonthlyRevenue) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Orders (YTD)</div>
+          <div class="stat-label">{{ t('reports.totalOrdersYTD') }}</div>
           <div class="stat-value">{{ totalOrders }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Best Performing Quarter</div>
+          <div class="stat-label">{{ t('reports.bestPerformingQuarter') }}</div>
           <div class="stat-value">{{ bestQuarter }}</div>
         </div>
       </div>
@@ -125,192 +125,133 @@
 </template>
 
 <script>
-import axios from 'axios'
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+import { useFilters } from '../composables/useFilters'
 
 export default {
   name: 'Reports',
-  data() {
-    return {
-      loading: true,
-      error: null,
-      quarterlyData: [],
-      monthlyData: [],
-      totalRevenue: 0,
-      avgMonthlyRevenue: 0,
-      totalOrders: 0,
-      bestQuarter: ''
-    }
-  },
-  mounted() {
-    console.log('Reports component mounted')
-    this.loadData()
-  },
-  methods: {
-    async loadData() {
-      console.log('Loading reports data...')
+  setup() {
+    const { t, currentCurrency } = useI18n()
+    const { selectedPeriod, selectedLocation, selectedCategory, selectedStatus, getCurrentFilters } = useFilters()
+
+    const currencySymbol = computed(() => currentCurrency.value === 'JPY' ? '¥' : '$')
+
+    const loading = ref(true)
+    const error = ref(null)
+    const quarterlyData = ref([])
+    const monthlyData = ref([])
+
+    // Summary stats as computed properties derived from reactive data
+    const totalRevenue = computed(() =>
+      monthlyData.value.reduce((sum, m) => sum + m.revenue, 0)
+    )
+
+    const avgMonthlyRevenue = computed(() =>
+      monthlyData.value.length > 0 ? totalRevenue.value / monthlyData.value.length : 0
+    )
+
+    const totalOrders = computed(() =>
+      monthlyData.value.reduce((sum, m) => sum + m.order_count, 0)
+    )
+
+    const bestQuarter = computed(() => {
+      if (quarterlyData.value.length === 0) return ''
+      return quarterlyData.value.reduce((best, q) =>
+        q.total_revenue > best.total_revenue ? q : best
+      ).quarter
+    })
+
+    const loadData = async () => {
       try {
-        this.loading = true
-
-        // Fetch quarterly data
-        console.log('Fetching quarterly data...')
-        const quarterlyResponse = await axios.get('http://localhost:8001/api/reports/quarterly')
-        this.quarterlyData = quarterlyResponse.data
-        console.log('Quarterly data:', this.quarterlyData)
-
-        // Fetch monthly data
-        console.log('Fetching monthly data...')
-        const monthlyResponse = await axios.get('http://localhost:8001/api/reports/monthly-trends')
-        this.monthlyData = monthlyResponse.data
-        console.log('Monthly data:', this.monthlyData)
-
-        // Calculate summary stats
-        console.log('Calculating summary stats...')
-        this.calculateSummaryStats()
-        console.log('Summary stats calculated')
-
+        loading.value = true
+        error.value = null
+        const filters = getCurrentFilters()
+        const [quarterly, monthly] = await Promise.all([
+          api.getQuarterlyReports(filters),
+          api.getMonthlyTrends(filters)
+        ])
+        quarterlyData.value = quarterly
+        monthlyData.value = monthly
       } catch (err) {
-        console.log('Error loading reports:', err)
-        this.error = 'Failed to load reports: ' + err.message
+        error.value = 'Failed to load reports: ' + err.message
       } finally {
-        this.loading = false
-        console.log('Loading complete')
+        loading.value = false
       }
-    },
+    }
 
-    calculateSummaryStats() {
-      // Calculate total revenue
-      var total = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        total = total + this.monthlyData[i].revenue
-      }
-      this.totalRevenue = total
+    // Watch all global filters and reload data on any change
+    watch([selectedPeriod, selectedLocation, selectedCategory, selectedStatus], loadData)
 
-      // Calculate average monthly revenue
-      if (this.monthlyData.length > 0) {
-        this.avgMonthlyRevenue = total / this.monthlyData.length
-      } else {
-        this.avgMonthlyRevenue = 0
-      }
+    onMounted(loadData)
 
-      // Calculate total orders
-      var orders = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        orders = orders + this.monthlyData[i].order_count
-      }
-      this.totalOrders = orders
+    const formatNumber = (num) => {
+      return Number(num).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    }
 
-      // Find best quarter
-      var bestQ = ''
-      var bestRevenue = 0
-      for (var i = 0; i < this.quarterlyData.length; i++) {
-        if (this.quarterlyData[i].total_revenue > bestRevenue) {
-          bestRevenue = this.quarterlyData[i].total_revenue
-          bestQ = this.quarterlyData[i].quarter
-        }
-      }
-      this.bestQuarter = bestQ
-    },
+    const formatMonth = (monthStr) => {
+      // Convert YYYY-MM to readable format using i18n month keys
+      const parts = monthStr.split('-')
+      const year = parts[0]
+      const monthIndex = parseInt(parts[1]) - 1
+      const monthKeys = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+      return t('months.' + monthKeys[monthIndex]) + ' ' + year
+    }
 
-    formatNumber(num) {
-      console.log('Formatting number:', num)
-      // Format number with commas
-      var str = num.toString()
-      var parts = str.split('.')
-      var intPart = parts[0]
-      var decPart = parts.length > 1 ? parts[1] : '00'
+    const getBarHeight = (revenue) => {
+      // Calculate bar height proportional to max revenue (max height 200px)
+      const maxRevenue = Math.max(...monthlyData.value.map(m => m.revenue), 0)
+      if (maxRevenue === 0) return 0
+      return (revenue / maxRevenue) * 200
+    }
 
-      var formatted = ''
-      var count = 0
-      for (var i = intPart.length - 1; i >= 0; i--) {
-        if (count > 0 && count % 3 === 0) {
-          formatted = ',' + formatted
-        }
-        formatted = intPart[i] + formatted
-        count++
-      }
+    const getFulfillmentClass = (rate) => {
+      if (rate >= 90) return 'badge success'
+      if (rate >= 75) return 'badge warning'
+      return 'badge danger'
+    }
 
-      if (decPart.length === 1) {
-        decPart = decPart + '0'
-      }
-      if (decPart.length > 2) {
-        decPart = decPart.substring(0, 2)
-      }
+    const getChangeValue = (current, previous) => {
+      const change = current - previous
+      const sym = currencySymbol.value
+      if (change > 0) return '+' + sym + formatNumber(change)
+      if (change < 0) return '-' + sym + formatNumber(Math.abs(change))
+      return sym + '0.00'
+    }
 
-      return formatted + '.' + decPart
-    },
+    const getChangeClass = (current, previous) => {
+      const change = current - previous
+      if (change > 0) return 'positive-change'
+      if (change < 0) return 'negative-change'
+      return ''
+    }
 
-    formatMonth(monthStr) {
-      console.log('Formatting month:', monthStr)
-      // Convert YYYY-MM to readable format
-      var parts = monthStr.split('-')
-      var year = parts[0]
-      var month = parts[1]
-
-      var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-      var monthIndex = parseInt(month) - 1
-
-      return monthNames[monthIndex] + ' ' + year
-    },
-
-    getBarHeight(revenue) {
-      console.log('Calculating bar height for revenue:', revenue)
-      // Calculate bar height (max height 200px)
-      var maxRevenue = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        if (this.monthlyData[i].revenue > maxRevenue) {
-          maxRevenue = this.monthlyData[i].revenue
-        }
-      }
-
-      if (maxRevenue === 0) {
-        return 0
-      }
-
-      var height = (revenue / maxRevenue) * 200
-      return height
-    },
-
-    getFulfillmentClass(rate) {
-      if (rate >= 90) {
-        return 'badge success'
-      } else if (rate >= 75) {
-        return 'badge warning'
-      } else {
-        return 'badge danger'
-      }
-    },
-
-    getChangeValue(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return '+$' + this.formatNumber(change)
-      } else if (change < 0) {
-        return '-$' + this.formatNumber(Math.abs(change))
-      } else {
-        return '$0.00'
-      }
-    },
-
-    getChangeClass(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return 'positive-change'
-      } else if (change < 0) {
-        return 'negative-change'
-      } else {
-        return ''
-      }
-    },
-
-    getGrowthRate(current, previous) {
-      if (previous === 0) {
-        return 'N/A'
-      }
-
-      var rate = ((current - previous) / previous) * 100
-      var sign = rate > 0 ? '+' : ''
-
+    const getGrowthRate = (current, previous) => {
+      if (previous === 0) return 'N/A'
+      const rate = ((current - previous) / previous) * 100
+      const sign = rate > 0 ? '+' : ''
       return sign + rate.toFixed(1) + '%'
+    }
+
+    return {
+      t,
+      currencySymbol,
+      loading,
+      error,
+      quarterlyData,
+      monthlyData,
+      totalRevenue,
+      avgMonthlyRevenue,
+      totalOrders,
+      bestQuarter,
+      formatNumber,
+      formatMonth,
+      getBarHeight,
+      getFulfillmentClass,
+      getChangeValue,
+      getChangeClass,
+      getGrowthRate
     }
   }
 }

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,583 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <!-- Budget Slider -->
+    <div class="card budget-card">
+      <div class="budget-header">
+        <label class="budget-label" for="budget-slider">{{ t('restocking.budget') }}</label>
+        <span class="budget-value">{{ currencySymbol }}{{ budget.toLocaleString() }}</span>
+      </div>
+      <div class="slider-wrapper">
+        <span class="slider-min">{{ currencySymbol }}1,000</span>
+        <input
+          id="budget-slider"
+          type="range"
+          class="budget-slider"
+          :min="1000"
+          :max="50000"
+          :step="500"
+          v-model.number="budget"
+        />
+        <span class="slider-max">{{ currencySymbol }}50,000</span>
+      </div>
+      <div class="budget-ticks">
+        <span>{{ currencySymbol }}1K</span>
+        <span>{{ currencySymbol }}10K</span>
+        <span>{{ currencySymbol }}20K</span>
+        <span>{{ currencySymbol }}30K</span>
+        <span>{{ currencySymbol }}40K</span>
+        <span>{{ currencySymbol }}50K</span>
+      </div>
+    </div>
+
+    <!-- Recommendations -->
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Order success message -->
+      <div v-if="orderSuccess" class="success-banner">
+        {{ t('restocking.orderSuccess') }} — {{ t('restocking.orderNumber') }}: <strong>{{ lastOrderNumber }}</strong>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.recommendations') }}</h3>
+          <div class="budget-summary">
+            <span class="summary-item">
+              {{ t('restocking.selectedItems') }}: <strong>{{ selectedCount }}</strong>
+            </span>
+            <span class="summary-divider">|</span>
+            <span class="summary-item">
+              {{ t('restocking.totalCost') }}: <strong>{{ currencySymbol }}{{ selectedTotalCost.toLocaleString() }}</strong>
+            </span>
+            <span class="summary-divider">|</span>
+            <span class="summary-item" :class="{ 'over-budget': remainingBudget < 0 }">
+              {{ t('restocking.remainingBudget') }}: <strong>{{ currencySymbol }}{{ remainingBudget.toLocaleString() }}</strong>
+            </span>
+          </div>
+        </div>
+
+        <div v-if="recommendations.length === 0" class="empty-state">
+          {{ t('restocking.noRecommendations') }}
+        </div>
+        <div v-else class="table-container">
+          <table class="recommendations-table">
+            <thead>
+              <tr>
+                <th class="col-check">{{ t('restocking.table.select') }}</th>
+                <th class="col-sku">{{ t('restocking.table.sku') }}</th>
+                <th class="col-name">{{ t('restocking.table.itemName') }}</th>
+                <th class="col-trend">{{ t('restocking.table.trend') }}</th>
+                <th class="col-num">{{ t('restocking.table.forecastedDemand') }}</th>
+                <th class="col-num">{{ t('restocking.table.currentStock') }}</th>
+                <th class="col-num">{{ t('restocking.table.restockQty') }}</th>
+                <th class="col-cost">{{ t('restocking.table.unitCost') }}</th>
+                <th class="col-cost">{{ t('restocking.table.totalCost') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="item in recommendations"
+                :key="item.sku"
+                :class="{ 'row-selected': selectedSkus.has(item.sku), 'row-disabled': !selectedSkus.has(item.sku) && !canAfford(item) }"
+              >
+                <td class="col-check">
+                  <input
+                    type="checkbox"
+                    :checked="selectedSkus.has(item.sku)"
+                    @change="toggleItem(item)"
+                    class="row-checkbox"
+                  />
+                </td>
+                <td class="col-sku"><strong>{{ item.sku }}</strong></td>
+                <td class="col-name">{{ item.name }}</td>
+                <td class="col-trend">
+                  <span :class="['badge', item.trend]">{{ t('trends.' + item.trend) }}</span>
+                </td>
+                <td class="col-num">{{ item.forecasted_demand }}</td>
+                <td class="col-num">{{ item.current_stock }}</td>
+                <td class="col-num"><strong>{{ item.restock_qty }}</strong></td>
+                <td class="col-cost">{{ currencySymbol }}{{ item.unit_cost.toLocaleString() }}</td>
+                <td class="col-cost"><strong>{{ currencySymbol }}{{ itemTotalCost(item).toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card-footer">
+          <button
+            class="btn-primary"
+            :disabled="selectedCount === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? t('common.loading') : t('restocking.placeOrder') }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Submitted Orders -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.submittedOrders') }}</h3>
+        </div>
+
+        <div v-if="submittedOrdersLoading" class="loading">{{ t('common.loading') }}</div>
+        <div v-else-if="submittedOrders.length === 0" class="empty-state">
+          {{ t('restocking.noSubmittedOrders') }}
+        </div>
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>{{ t('restocking.orderNumber') }}</th>
+                <th>{{ t('restocking.items') }}</th>
+                <th>{{ t('restocking.status') }}</th>
+                <th>{{ t('restocking.orderDate') }}</th>
+                <th>{{ t('restocking.expectedDelivery') }}</th>
+                <th>{{ t('restocking.leadTime') }}</th>
+                <th>{{ t('restocking.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td><strong>{{ order.order_number }}</strong></td>
+                <td>{{ order.items_count }}</td>
+                <td>
+                  <span :class="['badge', getStatusClass(order.status)]">
+                    {{ t('status.processing') }}
+                  </span>
+                </td>
+                <td>{{ formatDate(order.order_date) }}</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td>{{ leadTimeDays(order.order_date, order.expected_delivery) }} {{ t('restocking.days') }}</td>
+                <td><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted, watch } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency, currentLocale } = useI18n()
+
+    const currencySymbol = computed(() => currentCurrency.value === 'JPY' ? '¥' : '$')
+
+    const budget = ref(10000)
+    const recommendations = ref([])
+    const submittedOrders = ref([])
+
+    const loading = ref(false)
+    const error = ref(null)
+    const submittedOrdersLoading = ref(false)
+    const submitting = ref(false)
+
+    const orderSuccess = ref(false)
+    const lastOrderNumber = ref('')
+
+    // Set of SKUs that are currently selected
+    const selectedSkus = ref(new Set())
+
+    // Run greedy auto-select: pick items in priority order until budget exhausted
+    const autoSelect = () => {
+      const selected = new Set()
+      let spent = 0
+
+      for (const item of recommendations.value) {
+        const cost = itemTotalCost(item)
+        if (spent + cost <= budget.value) {
+          selected.add(item.sku)
+          spent += cost
+        }
+      }
+
+      selectedSkus.value = selected
+    }
+
+    const itemTotalCost = (item) => {
+      return item.unit_cost * item.restock_qty
+    }
+
+    const selectedCount = computed(() => selectedSkus.value.size)
+
+    const selectedTotalCost = computed(() => {
+      return recommendations.value
+        .filter(item => selectedSkus.value.has(item.sku))
+        .reduce((sum, item) => sum + itemTotalCost(item), 0)
+    })
+
+    const remainingBudget = computed(() => budget.value - selectedTotalCost.value)
+
+    // Whether a non-selected item can be added within remaining budget
+    const canAfford = (item) => {
+      if (selectedSkus.value.has(item.sku)) return true
+      return itemTotalCost(item) <= remainingBudget.value
+    }
+
+    const toggleItem = (item) => {
+      // Create a new Set so Vue detects the change
+      const next = new Set(selectedSkus.value)
+      if (next.has(item.sku)) {
+        next.delete(item.sku)
+      } else {
+        next.add(item.sku)
+      }
+      selectedSkus.value = next
+    }
+
+    const getStatusClass = (status) => {
+      const map = {
+        'processing': 'warning',
+        'Processing': 'warning',
+        'delivered': 'success',
+        'Delivered': 'success',
+        'shipped': 'info',
+        'Shipped': 'info',
+        'cancelled': 'danger',
+        'Cancelled': 'danger'
+      }
+      return map[status] || 'warning'
+    }
+
+    const formatDate = (dateString) => {
+      const date = new Date(dateString)
+      if (isNaN(date.getTime())) return dateString
+      const locale = currentLocale.value === 'ja' ? 'ja-JP' : 'en-US'
+      return date.toLocaleDateString(locale, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      })
+    }
+
+    const leadTimeDays = (orderDate, deliveryDate) => {
+      const d1 = new Date(orderDate)
+      const d2 = new Date(deliveryDate)
+      if (isNaN(d1.getTime()) || isNaN(d2.getTime())) return '—'
+      return Math.round((d2 - d1) / (1000 * 60 * 60 * 24))
+    }
+
+    const loadRecommendations = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        recommendations.value = await api.getRestockingRecommendations()
+        autoSelect()
+      } catch (err) {
+        error.value = 'Failed to load restocking recommendations: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const loadSubmittedOrders = async () => {
+      submittedOrdersLoading.value = true
+      try {
+        submittedOrders.value = await api.getSubmittedRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load submitted orders:', err)
+      } finally {
+        submittedOrdersLoading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      if (selectedCount.value === 0) return
+      submitting.value = true
+      orderSuccess.value = false
+      try {
+        const items = recommendations.value
+          .filter(item => selectedSkus.value.has(item.sku))
+          .map(item => ({
+            sku: item.sku,
+            name: item.name,
+            quantity: item.restock_qty,
+            unit_cost: item.unit_cost
+          }))
+
+        const result = await api.submitRestockingOrder({ items, budget: budget.value })
+        lastOrderNumber.value = result.order_number || result.id || ''
+        orderSuccess.value = true
+
+        // Refresh both tables after placing order
+        await Promise.all([loadRecommendations(), loadSubmittedOrders()])
+      } catch (err) {
+        error.value = 'Failed to place restocking order: ' + err.message
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    // Re-run greedy auto-select whenever budget changes
+    watch(budget, () => {
+      autoSelect()
+    })
+
+    onMounted(() => {
+      loadRecommendations()
+      loadSubmittedOrders()
+    })
+
+    return {
+      t,
+      currencySymbol,
+      budget,
+      recommendations,
+      submittedOrders,
+      loading,
+      error,
+      submittedOrdersLoading,
+      submitting,
+      orderSuccess,
+      lastOrderNumber,
+      selectedSkus,
+      selectedCount,
+      selectedTotalCost,
+      remainingBudget,
+      canAfford,
+      toggleItem,
+      itemTotalCost,
+      getStatusClass,
+      formatDate,
+      leadTimeDays,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* Budget card */
+.budget-card {
+  margin-bottom: 1.5rem;
+}
+
+.budget-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.budget-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.budget-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.slider-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.slider-min,
+.slider-max {
+  font-size: 0.813rem;
+  color: #64748b;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.budget-slider {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(
+    to right,
+    #2563eb 0%,
+    #2563eb calc((var(--val, 10000) - 1000) / 49000 * 100%),
+    #e2e8f0 calc((var(--val, 10000) - 1000) / 49000 * 100%),
+    #e2e8f0 100%
+  );
+  outline: none;
+  cursor: pointer;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  border: 3px solid white;
+  box-shadow: 0 1px 4px rgba(37, 99, 235, 0.4);
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+}
+
+.budget-slider::-webkit-slider-thumb:hover {
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  border: 3px solid white;
+  box-shadow: 0 1px 4px rgba(37, 99, 235, 0.4);
+  cursor: pointer;
+}
+
+.budget-ticks {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.375rem;
+  padding: 0 0.25rem;
+}
+
+.budget-ticks span {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+/* Budget summary row */
+.budget-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.summary-item strong {
+  color: #0f172a;
+}
+
+.summary-divider {
+  color: #cbd5e1;
+}
+
+.summary-item.over-budget strong {
+  color: #dc2626;
+}
+
+/* Table column widths */
+.recommendations-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.col-check {
+  width: 48px;
+  text-align: center;
+}
+
+.col-sku {
+  width: 110px;
+}
+
+.col-name {
+  /* flexible */
+}
+
+.col-trend {
+  width: 110px;
+}
+
+.col-num {
+  width: 130px;
+  text-align: right;
+}
+
+.col-cost {
+  width: 120px;
+  text-align: right;
+}
+
+/* Row states */
+.row-selected {
+  background: #eff6ff;
+}
+
+.row-selected:hover {
+  background: #dbeafe !important;
+}
+
+.row-disabled {
+  opacity: 0.45;
+}
+
+.row-checkbox {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  accent-color: #2563eb;
+}
+
+/* Card footer with action button */
+.card-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
+  margin-top: 0.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.btn-primary {
+  padding: 0.625rem 1.5rem;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Success banner */
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 0.875rem 1.25rem;
+  border-radius: 8px;
+  margin-bottom: 1.25rem;
+  font-size: 0.938rem;
+  font-weight: 500;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 2.5rem;
+  color: #94a3b8;
+  font-size: 0.938rem;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>System Architecture - Factory Inventory Management</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f8fafc; color: #0f172a; line-height: 1.6; }
+    .container { max-width: 1200px; margin: 0 auto; padding: 40px 24px; }
+    h1 { font-size: 28px; font-weight: 700; margin-bottom: 4px; }
+    .subtitle { color: #64748b; font-size: 15px; margin-bottom: 40px; }
+    h2 { font-size: 18px; font-weight: 600; margin-bottom: 16px; color: #0f172a; }
+    h3 { font-size: 14px; font-weight: 600; margin-bottom: 8px; color: #334155; }
+
+    /* Section layout */
+    .section { margin-bottom: 40px; }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
+
+    /* Cards */
+    .card { background: #fff; border: 1px solid #e2e8f0; border-radius: 10px; padding: 24px; }
+    .card-sm { background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; }
+
+    /* Tags */
+    .tag { display: inline-block; padding: 2px 10px; border-radius: 4px; font-size: 12px; font-weight: 500; margin: 2px 4px 2px 0; }
+    .tag-blue { background: #eff6ff; color: #2563eb; }
+    .tag-green { background: #f0fdf4; color: #16a34a; }
+    .tag-purple { background: #faf5ff; color: #9333ea; }
+    .tag-orange { background: #fff7ed; color: #ea580c; }
+    .tag-slate { background: #f1f5f9; color: #475569; }
+    .tag-red { background: #fef2f2; color: #dc2626; }
+
+    /* Architecture diagram */
+    .arch-diagram { display: flex; flex-direction: column; gap: 12px; align-items: center; }
+    .arch-layer { width: 100%; border-radius: 10px; padding: 20px 28px; text-align: center; position: relative; }
+    .arch-layer-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
+    .arch-layer-detail { font-size: 13px; opacity: 0.85; }
+    .layer-frontend { background: #eff6ff; border: 1px solid #bfdbfe; color: #1e40af; }
+    .layer-api { background: #f0fdf4; border: 1px solid #bbf7d0; color: #166534; }
+    .layer-data { background: #faf5ff; border: 1px solid #e9d5ff; color: #6b21a8; }
+    .arrow { color: #94a3b8; font-size: 20px; line-height: 1; }
+
+    /* Data flow */
+    .flow { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+    .flow-step { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 500; white-space: nowrap; }
+    .flow-arrow { color: #94a3b8; font-size: 16px; }
+
+    /* File tree */
+    .file-tree { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 13px; line-height: 1.8; color: #334155; }
+    .file-tree .dir { color: #2563eb; font-weight: 600; }
+    .file-tree .file { color: #64748b; }
+    .file-tree .desc { color: #94a3b8; font-style: italic; }
+
+    /* Endpoint table */
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th { text-align: left; padding: 8px 12px; background: #f8fafc; color: #64748b; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid #e2e8f0; }
+    td { padding: 8px 12px; border-bottom: 1px solid #f1f5f9; }
+    td code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; background: #f1f5f9; padding: 2px 6px; border-radius: 3px; }
+    tr:last-child td { border-bottom: none; }
+
+    /* Filter diagram */
+    .filter-box { display: inline-block; background: #f1f5f9; border: 1px solid #cbd5e1; border-radius: 6px; padding: 4px 12px; font-size: 12px; font-weight: 500; margin: 3px; }
+    .filter-supported { background: #dcfce7; border-color: #86efac; color: #166534; }
+    .filter-unsupported { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
+
+    /* Legend */
+    .legend { display: flex; gap: 16px; margin-top: 8px; font-size: 12px; color: #64748b; }
+    .legend-item { display: flex; align-items: center; gap: 4px; }
+    .legend-dot { width: 10px; height: 10px; border-radius: 3px; }
+
+    .divider { border: none; border-top: 1px solid #e2e8f0; margin: 40px 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Factory Inventory Management System</h1>
+    <p class="subtitle">System Architecture &amp; Technical Overview</p>
+
+    <!-- Architecture Layers -->
+    <div class="section">
+      <h2>System Architecture</h2>
+      <div class="card">
+        <div class="arch-diagram">
+          <div class="arch-layer layer-frontend">
+            <div class="arch-layer-title">Frontend &mdash; Vue 3 + Vite</div>
+            <div class="arch-layer-detail">Composition API &middot; Vue Router &middot; Axios &middot; Port 3000</div>
+          </div>
+          <div class="arrow">&darr; &uarr; HTTP (REST JSON)</div>
+          <div class="arch-layer layer-api">
+            <div class="arch-layer-title">Backend API &mdash; Python FastAPI</div>
+            <div class="arch-layer-detail">Pydantic Models &middot; CORS &middot; Uvicorn &middot; Port 8001</div>
+          </div>
+          <div class="arrow">&darr; &uarr; In-memory read</div>
+          <div class="arch-layer layer-data">
+            <div class="arch-layer-title">Data Layer &mdash; JSON Files</div>
+            <div class="arch-layer-detail">inventory.json &middot; orders.json &middot; spending.json &middot; demand_forecasts.json &middot; backlog_items.json</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tech Stack -->
+    <div class="section">
+      <h2>Tech Stack</h2>
+      <div class="grid-3">
+        <div class="card-sm">
+          <h3>Frontend</h3>
+          <span class="tag tag-blue">Vue 3.4</span>
+          <span class="tag tag-blue">Vue Router 4.3</span>
+          <span class="tag tag-blue">Vite 5.2</span>
+          <span class="tag tag-blue">Axios 1.6</span>
+          <span class="tag tag-blue">Composition API</span>
+        </div>
+        <div class="card-sm">
+          <h3>Backend</h3>
+          <span class="tag tag-green">FastAPI 0.110</span>
+          <span class="tag tag-green">Uvicorn 0.24</span>
+          <span class="tag tag-green">Pydantic 2.5</span>
+          <span class="tag tag-green">Python 3.x</span>
+        </div>
+        <div class="card-sm">
+          <h3>Tooling &amp; Testing</h3>
+          <span class="tag tag-purple">uv</span>
+          <span class="tag tag-purple">pytest</span>
+          <span class="tag tag-purple">httpx</span>
+          <span class="tag tag-purple">pytest-cov</span>
+          <span class="tag tag-purple">npm</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Data Flow -->
+    <div class="section">
+      <h2>Data Flow</h2>
+      <div class="card">
+        <p style="font-size:13px; color:#64748b; margin-bottom:16px;">How a filtered request travels through the system</p>
+        <div class="flow">
+          <span class="flow-step">FilterBar.vue</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">useFilters()</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">api.js</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">FastAPI Endpoint</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">apply_filters()</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">Pydantic Model</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">JSON Response</span>
+        </div>
+        <div class="flow">
+          <span class="flow-step">JSON Response</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">ref() state</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">computed()</span>
+          <span class="flow-arrow">&rarr;</span>
+          <span class="flow-step">Template render</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Filter Support Matrix -->
+    <div class="section">
+      <h2>Filter Support by Endpoint</h2>
+      <div class="card">
+        <table>
+          <thead>
+            <tr><th>Endpoint</th><th>Warehouse</th><th>Category</th><th>Status</th><th>Month</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>GET /api/inventory</code></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+            </tr>
+            <tr>
+              <td><code>GET /api/orders</code></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+            </tr>
+            <tr>
+              <td><code>GET /api/dashboard/summary</code></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+              <td><span class="filter-box filter-supported">Yes</span></td>
+            </tr>
+            <tr>
+              <td><code>GET /api/demand</code></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+            </tr>
+            <tr>
+              <td><code>GET /api/backlog</code></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+            </tr>
+            <tr>
+              <td><code>GET /api/spending/*</code></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+              <td><span class="filter-box filter-unsupported">No</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Frontend Architecture -->
+    <div class="section">
+      <h2>Frontend Architecture</h2>
+      <div class="grid-2">
+        <div class="card-sm">
+          <h3>Views (Pages)</h3>
+          <span class="tag tag-blue">Dashboard</span>
+          <span class="tag tag-blue">Inventory</span>
+          <span class="tag tag-blue">Orders</span>
+          <span class="tag tag-blue">Demand</span>
+          <span class="tag tag-blue">Spending</span>
+          <span class="tag tag-blue">Reports</span>
+          <span class="tag tag-blue">Backlog</span>
+        </div>
+        <div class="card-sm">
+          <h3>Components</h3>
+          <span class="tag tag-slate">FilterBar</span>
+          <span class="tag tag-slate">InventoryDetailModal</span>
+          <span class="tag tag-slate">BacklogDetailModal</span>
+          <span class="tag tag-slate">ProductDetailModal</span>
+          <span class="tag tag-slate">CostDetailModal</span>
+          <span class="tag tag-slate">TasksModal</span>
+          <span class="tag tag-slate">ProfileMenu</span>
+          <span class="tag tag-slate">LanguageSwitcher</span>
+        </div>
+        <div class="card-sm">
+          <h3>Composables</h3>
+          <span class="tag tag-purple">useFilters</span>
+          <span class="tag tag-purple">useAuth</span>
+          <span class="tag tag-purple">useI18n</span>
+          <p style="font-size:12px; color:#94a3b8; margin-top:8px;">Singleton pattern for shared state across components</p>
+        </div>
+        <div class="card-sm">
+          <h3>Utilities</h3>
+          <span class="tag tag-orange">api.js</span>
+          <span class="tag tag-orange">currency.js</span>
+          <p style="font-size:12px; color:#94a3b8; margin-top:8px;">Centralized API client &amp; currency formatting (USD/JPY)</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Backend Models -->
+    <div class="section">
+      <h2>Backend Data Models</h2>
+      <div class="grid-3">
+        <div class="card-sm">
+          <h3>InventoryItem</h3>
+          <span class="tag tag-slate">id</span>
+          <span class="tag tag-slate">sku</span>
+          <span class="tag tag-slate">name</span>
+          <span class="tag tag-slate">category</span>
+          <span class="tag tag-slate">warehouse</span>
+          <span class="tag tag-slate">quantity_on_hand</span>
+          <span class="tag tag-slate">reorder_point</span>
+          <span class="tag tag-slate">unit_cost</span>
+        </div>
+        <div class="card-sm">
+          <h3>Order</h3>
+          <span class="tag tag-slate">id</span>
+          <span class="tag tag-slate">order_number</span>
+          <span class="tag tag-slate">customer</span>
+          <span class="tag tag-slate">items[]</span>
+          <span class="tag tag-slate">status</span>
+          <span class="tag tag-slate">warehouse</span>
+          <span class="tag tag-slate">total_value</span>
+        </div>
+        <div class="card-sm">
+          <h3>DemandForecast</h3>
+          <span class="tag tag-slate">item_sku</span>
+          <span class="tag tag-slate">item_name</span>
+          <span class="tag tag-slate">current_demand</span>
+          <span class="tag tag-slate">forecasted_demand</span>
+          <span class="tag tag-slate">trend</span>
+        </div>
+        <div class="card-sm">
+          <h3>BacklogItem</h3>
+          <span class="tag tag-slate">order_id</span>
+          <span class="tag tag-slate">item_sku</span>
+          <span class="tag tag-slate">quantity_needed</span>
+          <span class="tag tag-slate">quantity_available</span>
+          <span class="tag tag-slate">days_delayed</span>
+          <span class="tag tag-slate">priority</span>
+        </div>
+        <div class="card-sm">
+          <h3>PurchaseOrder</h3>
+          <span class="tag tag-slate">backlog_item_id</span>
+          <span class="tag tag-slate">supplier_name</span>
+          <span class="tag tag-slate">quantity</span>
+          <span class="tag tag-slate">unit_cost</span>
+          <span class="tag tag-slate">status</span>
+        </div>
+        <div class="card-sm">
+          <h3>SpendingSummary</h3>
+          <span class="tag tag-slate">total_costs</span>
+          <span class="tag tag-slate">procurement</span>
+          <span class="tag tag-slate">operational</span>
+          <span class="tag tag-slate">labor</span>
+          <span class="tag tag-slate">overhead</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Project Structure -->
+    <div class="section">
+      <h2>Project Structure</h2>
+      <div class="card">
+        <div class="file-tree">
+          <span class="dir">client/</span><br>
+          &nbsp;&nbsp;<span class="dir">src/</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="dir">views/</span> <span class="desc">&mdash; Dashboard, Inventory, Orders, Demand, Spending, Reports, Backlog</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="dir">components/</span> <span class="desc">&mdash; FilterBar, Modals, ProfileMenu, LanguageSwitcher</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="dir">composables/</span> <span class="desc">&mdash; useFilters, useAuth, useI18n</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="dir">locales/</span> <span class="desc">&mdash; en.js, ja.js (English + Japanese)</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="dir">utils/</span> <span class="desc">&mdash; currency.js</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="file">api.js</span> <span class="desc">&mdash; Centralized API client (Axios)</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="file">main.js</span> <span class="desc">&mdash; App entry + route definitions</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="file">App.vue</span> <span class="desc">&mdash; Root component + global styles</span><br>
+          <br>
+          <span class="dir">server/</span><br>
+          &nbsp;&nbsp;<span class="file">main.py</span> <span class="desc">&mdash; FastAPI app, endpoints, Pydantic models, filtering</span><br>
+          &nbsp;&nbsp;<span class="file">mock_data.py</span> <span class="desc">&mdash; Loads JSON files into memory at startup</span><br>
+          &nbsp;&nbsp;<span class="dir">data/</span> <span class="desc">&mdash; inventory, orders, spending, demand, backlog, transactions JSON</span><br>
+          <br>
+          <span class="dir">tests/backend/</span> <span class="desc">&mdash; pytest + FastAPI TestClient</span><br>
+          <span class="dir">docs/</span> <span class="desc">&mdash; Documentation and screenshots</span><br>
+          <span class="dir">scripts/</span> <span class="desc">&mdash; Start/stop helper scripts</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Key Patterns -->
+    <div class="section">
+      <h2>Key Design Patterns</h2>
+      <div class="grid-2">
+        <div class="card-sm">
+          <h3>Singleton Filter State</h3>
+          <p style="font-size:13px; color:#64748b;">useFilters() composable provides shared reactive state across all views. Filter changes trigger data reload via watchers.</p>
+        </div>
+        <div class="card-sm">
+          <h3>Reactive Data Flow</h3>
+          <p style="font-size:13px; color:#64748b;">Raw API data stored in ref(), derived/displayed data in computed(). Ensures UI stays in sync with minimal re-renders.</p>
+        </div>
+        <div class="card-sm">
+          <h3>In-Memory Data</h3>
+          <p style="font-size:13px; color:#64748b;">JSON files loaded once at server startup via mock_data.py. No database; all filtering happens on in-memory Python lists.</p>
+        </div>
+        <div class="card-sm">
+          <h3>I18n with Fallback</h3>
+          <p style="font-size:13px; color:#64748b;">English/Japanese support via useI18n() composable. Currency auto-switches (USD/JPY). Falls back to English for missing translations.</p>
+        </div>
+      </div>
+    </div>
+
+    <hr class="divider">
+    <p style="font-size:12px; color:#94a3b8; text-align:center;">Generated for Factory Inventory Management System</p>
+  </div>
+</body>
+</html>

--- a/server/data/inventory.json
+++ b/server/data/inventory.json
@@ -382,5 +382,101 @@
     "unit_cost": 185.50,
     "location": "Warehouse C-11",
     "last_updated": "2025-09-21T15:20:00"
+  },
+  {
+    "id": "33",
+    "sku": "WDG-001",
+    "name": "Industrial Widget Type A",
+    "category": "Mechanical Parts",
+    "warehouse": "San Francisco",
+    "quantity_on_hand": 120,
+    "reorder_point": 200,
+    "unit_cost": 15.50,
+    "location": "Warehouse A-18",
+    "last_updated": "2025-09-30T10:00:00"
+  },
+  {
+    "id": "34",
+    "sku": "BRG-102",
+    "name": "Steel Bearing Assembly",
+    "category": "Mechanical Parts",
+    "warehouse": "London",
+    "quantity_on_hand": 140,
+    "reorder_point": 100,
+    "unit_cost": 22.75,
+    "location": "Warehouse B-18",
+    "last_updated": "2025-09-28T14:00:00"
+  },
+  {
+    "id": "35",
+    "sku": "GSK-203",
+    "name": "High-Temperature Gasket",
+    "category": "Mechanical Parts",
+    "warehouse": "Tokyo",
+    "quantity_on_hand": 200,
+    "reorder_point": 250,
+    "unit_cost": 8.25,
+    "location": "Warehouse C-12",
+    "last_updated": "2025-09-27T09:30:00"
+  },
+  {
+    "id": "36",
+    "sku": "MTR-304",
+    "name": "Electric Motor 5HP",
+    "category": "Actuators",
+    "warehouse": "San Francisco",
+    "quantity_on_hand": 40,
+    "reorder_point": 20,
+    "unit_cost": 285.00,
+    "location": "Warehouse A-19",
+    "last_updated": "2025-09-26T11:15:00"
+  },
+  {
+    "id": "37",
+    "sku": "FLT-405",
+    "name": "Oil Filter Cartridge",
+    "category": "Mechanical Parts",
+    "warehouse": "London",
+    "quantity_on_hand": 350,
+    "reorder_point": 400,
+    "unit_cost": 6.50,
+    "location": "Warehouse B-19",
+    "last_updated": "2025-09-25T16:00:00"
+  },
+  {
+    "id": "38",
+    "sku": "VLV-506",
+    "name": "Pressure Relief Valve",
+    "category": "Mechanical Parts",
+    "warehouse": "Tokyo",
+    "quantity_on_hand": 110,
+    "reorder_point": 80,
+    "unit_cost": 45.00,
+    "location": "Warehouse C-13",
+    "last_updated": "2025-09-24T13:45:00"
+  },
+  {
+    "id": "39",
+    "sku": "SNR-420",
+    "name": "Temperature Sensor Module",
+    "category": "Sensors",
+    "warehouse": "San Francisco",
+    "quantity_on_hand": 160,
+    "reorder_point": 100,
+    "unit_cost": 32.00,
+    "location": "Warehouse A-20",
+    "last_updated": "2025-09-23T10:30:00"
+  },
+  {
+    "id": "40",
+    "sku": "CTL-330",
+    "name": "Logic Controller Board",
+    "category": "Controllers",
+    "warehouse": "London",
+    "quantity_on_hand": 85,
+    "reorder_point": 50,
+    "unit_cost": 55.00,
+    "location": "Warehouse B-20",
+    "last_updated": "2025-09-22T08:00:00"
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
@@ -120,6 +121,31 @@ class CreatePurchaseOrderRequest(BaseModel):
     expected_delivery_date: str
     notes: Optional[str] = None
 
+class RestockingRecommendation(BaseModel):
+    sku: str
+    name: str
+    trend: str
+    forecasted_demand: int
+    current_stock: int
+    restock_qty: int
+    unit_cost: float
+    total_cost: float
+    priority_score: int
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+
+class SubmitRestockingOrderRequest(BaseModel):
+    items: List[RestockingOrderItem]
+    budget: float
+
+# In-memory storage for restocking orders
+restocking_orders = []
+restocking_order_counter = 0
+
 # API endpoints
 @app.get("/")
 def root():
@@ -228,12 +254,19 @@ def get_recent_transactions():
     return recent_transactions
 
 @app.get("/api/reports/quarterly")
-def get_quarterly_reports():
-    """Get quarterly performance reports"""
-    # Calculate quarterly statistics from orders
+def get_quarterly_reports(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None,
+    status: Optional[str] = None,
+    month: Optional[str] = None
+):
+    """Get quarterly performance reports with optional filtering"""
+    filtered_orders = apply_filters(orders, warehouse, category, status)
+    filtered_orders = filter_by_month(filtered_orders, month)
+
     quarters = {}
 
-    for order in orders:
+    for order in filtered_orders:
         order_date = order.get('order_date', '')
         # Determine quarter
         if '2025-01' in order_date or '2025-02' in order_date or '2025-03' in order_date:
@@ -274,11 +307,19 @@ def get_quarterly_reports():
     return result
 
 @app.get("/api/reports/monthly-trends")
-def get_monthly_trends():
-    """Get month-over-month trends"""
+def get_monthly_trends(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None,
+    status: Optional[str] = None,
+    month: Optional[str] = None
+):
+    """Get month-over-month trends with optional filtering"""
+    filtered_orders = apply_filters(orders, warehouse, category, status)
+    filtered_orders = filter_by_month(filtered_orders, month)
+
     months = {}
 
-    for order in orders:
+    for order in filtered_orders:
         order_date = order.get('order_date', '')
         if not order_date:
             continue
@@ -303,6 +344,90 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking/recommendations", response_model=List[RestockingRecommendation])
+def get_restocking_recommendations():
+    """Join demand forecasts with inventory to produce priority-ranked restocking recommendations."""
+    # Build lookup of inventory by SKU
+    inventory_by_sku = {item["sku"]: item for item in inventory_items}
+
+    recommendations = []
+    for forecast in demand_forecasts:
+        sku = forecast["item_sku"]
+        inv = inventory_by_sku.get(sku)
+        if not inv:
+            continue
+
+        current_stock = inv["quantity_on_hand"]
+        forecasted_demand = forecast["forecasted_demand"]
+        restock_qty = max(0, forecasted_demand - current_stock)
+        if restock_qty == 0:
+            continue
+
+        unit_cost = inv["unit_cost"]
+        total_cost = round(restock_qty * unit_cost, 2)
+
+        # Priority: increasing=0, stable=1000, decreasing=2000, then subtract demand gap
+        trend = forecast["trend"]
+        trend_base = {"increasing": 0, "stable": 1000, "decreasing": 2000}.get(trend, 1000)
+        priority_score = trend_base - (forecasted_demand - current_stock)
+
+        recommendations.append({
+            "sku": sku,
+            "name": forecast["item_name"],
+            "trend": trend,
+            "forecasted_demand": forecasted_demand,
+            "current_stock": current_stock,
+            "restock_qty": restock_qty,
+            "unit_cost": unit_cost,
+            "total_cost": total_cost,
+            "priority_score": priority_score,
+        })
+
+    recommendations.sort(key=lambda r: r["priority_score"])
+    return recommendations
+
+
+@app.post("/api/restocking/orders")
+def submit_restocking_order(request: SubmitRestockingOrderRequest):
+    """Submit a restocking order from selected recommendations."""
+    global restocking_order_counter
+
+    total = sum(item.quantity * item.unit_cost for item in request.items)
+    if total > request.budget:
+        raise HTTPException(status_code=400, detail="Order total exceeds budget")
+
+    restocking_order_counter += 1
+    order_number = f"RST-2025-{restocking_order_counter:04d}"
+    now = datetime.now()
+    expected_delivery = now + timedelta(days=14)
+
+    order = {
+        "id": f"rst-{restocking_order_counter}",
+        "order_number": order_number,
+        "customer": "Internal Restocking",
+        "items": [
+            {"name": item.name, "quantity": item.quantity, "unit_price": item.unit_cost}
+            for item in request.items
+        ],
+        "status": "Processing",
+        "order_date": now.strftime("%Y-%m-%dT%H:%M:%S"),
+        "expected_delivery": expected_delivery.strftime("%Y-%m-%dT%H:%M:%S"),
+        "total_value": round(total, 2),
+        "warehouse": "San Francisco",
+        "category": "Restocking",
+    }
+
+    restocking_orders.append(order)
+    orders.append(order)
+    return order
+
+
+@app.get("/api/restocking/submitted-orders")
+def get_submitted_restocking_orders():
+    """Return all submitted restocking orders."""
+    return restocking_orders
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/backend/test_reports.py
+++ b/tests/backend/test_reports.py
@@ -1,0 +1,243 @@
+"""
+Tests for reports API endpoints.
+"""
+import pytest
+
+
+class TestQuarterlyReportsEndpoint:
+    """Test suite for GET /api/reports/quarterly."""
+
+    def test_get_quarterly_reports_unfiltered(self, client):
+        """Test getting all quarterly reports without filters."""
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    def test_quarterly_reports_structure(self, client):
+        """Test that quarterly reports have correct structure."""
+        response = client.get("/api/reports/quarterly")
+        data = response.json()
+
+        for quarter in data:
+            assert "quarter" in quarter
+            assert "total_orders" in quarter
+            assert "total_revenue" in quarter
+            assert "avg_order_value" in quarter
+            assert "fulfillment_rate" in quarter
+            assert isinstance(quarter["total_orders"], int)
+            assert isinstance(quarter["total_revenue"], (int, float))
+            assert isinstance(quarter["avg_order_value"], (int, float))
+            assert isinstance(quarter["fulfillment_rate"], (int, float))
+            assert quarter["total_orders"] > 0
+            assert quarter["total_revenue"] > 0
+
+    def test_quarterly_reports_sorted_by_quarter(self, client):
+        """Test that quarterly reports are sorted by quarter."""
+        response = client.get("/api/reports/quarterly")
+        data = response.json()
+
+        quarters = [q["quarter"] for q in data]
+        assert quarters == sorted(quarters)
+
+    def test_quarterly_reports_filter_by_warehouse(self, client):
+        """Test filtering quarterly reports by warehouse."""
+        response = client.get("/api/reports/quarterly?warehouse=Tokyo")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        # Filtered results should have fewer or equal orders than unfiltered
+        unfiltered = client.get("/api/reports/quarterly").json()
+        total_filtered_orders = sum(q["total_orders"] for q in data)
+        total_unfiltered_orders = sum(q["total_orders"] for q in unfiltered)
+        assert total_filtered_orders <= total_unfiltered_orders
+
+    def test_quarterly_reports_filter_by_category(self, client):
+        """Test filtering quarterly reports by category."""
+        response = client.get("/api/reports/quarterly?category=Sensors")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        unfiltered = client.get("/api/reports/quarterly").json()
+        total_filtered_orders = sum(q["total_orders"] for q in data)
+        total_unfiltered_orders = sum(q["total_orders"] for q in unfiltered)
+        assert total_filtered_orders <= total_unfiltered_orders
+
+    def test_quarterly_reports_filter_by_status(self, client):
+        """Test filtering quarterly reports by status."""
+        response = client.get("/api/reports/quarterly?status=Delivered")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+    def test_quarterly_reports_filter_by_month(self, client):
+        """Test filtering quarterly reports by month."""
+        response = client.get("/api/reports/quarterly?month=2025-01")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        # Only Q1-2025 should appear when filtering by January
+        for quarter in data:
+            assert quarter["quarter"] == "Q1-2025"
+
+    def test_quarterly_reports_filter_all_passes_through(self, client):
+        """Test that filter value 'all' returns same as unfiltered."""
+        unfiltered = client.get("/api/reports/quarterly").json()
+        filtered = client.get("/api/reports/quarterly?warehouse=all&category=all").json()
+
+        assert len(unfiltered) == len(filtered)
+
+    def test_quarterly_reports_avg_order_value_calculation(self, client):
+        """Test that avg_order_value equals total_revenue / total_orders."""
+        response = client.get("/api/reports/quarterly")
+        data = response.json()
+
+        for quarter in data:
+            expected_avg = round(quarter["total_revenue"] / quarter["total_orders"], 2)
+            assert abs(quarter["avg_order_value"] - expected_avg) < 0.01
+
+    def test_quarterly_reports_fulfillment_rate_range(self, client):
+        """Test that fulfillment rate is between 0 and 100."""
+        response = client.get("/api/reports/quarterly")
+        data = response.json()
+
+        for quarter in data:
+            assert 0 <= quarter["fulfillment_rate"] <= 100
+
+
+class TestMonthlyTrendsEndpoint:
+    """Test suite for GET /api/reports/monthly-trends."""
+
+    def test_get_monthly_trends_unfiltered(self, client):
+        """Test getting all monthly trends without filters."""
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    def test_monthly_trends_structure(self, client):
+        """Test that monthly trends have correct structure."""
+        response = client.get("/api/reports/monthly-trends")
+        data = response.json()
+
+        for month in data:
+            assert "month" in month
+            assert "order_count" in month
+            assert "revenue" in month
+            assert "delivered_count" in month
+            assert isinstance(month["order_count"], int)
+            assert isinstance(month["revenue"], (int, float))
+            assert isinstance(month["delivered_count"], int)
+            assert month["order_count"] > 0
+            assert month["revenue"] > 0
+
+    def test_monthly_trends_month_format(self, client):
+        """Test that month field is in YYYY-MM format."""
+        response = client.get("/api/reports/monthly-trends")
+        data = response.json()
+
+        for month in data:
+            assert len(month["month"]) == 7
+            assert month["month"][4] == "-"
+            assert month["month"][:4].isdigit()
+            assert month["month"][5:].isdigit()
+
+    def test_monthly_trends_sorted_by_month(self, client):
+        """Test that monthly trends are sorted chronologically."""
+        response = client.get("/api/reports/monthly-trends")
+        data = response.json()
+
+        months = [m["month"] for m in data]
+        assert months == sorted(months)
+
+    def test_monthly_trends_filter_by_warehouse(self, client):
+        """Test filtering monthly trends by warehouse."""
+        response = client.get("/api/reports/monthly-trends?warehouse=Tokyo")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        unfiltered = client.get("/api/reports/monthly-trends").json()
+        total_filtered_orders = sum(m["order_count"] for m in data)
+        total_unfiltered_orders = sum(m["order_count"] for m in unfiltered)
+        assert total_filtered_orders <= total_unfiltered_orders
+
+    def test_monthly_trends_filter_by_category(self, client):
+        """Test filtering monthly trends by category."""
+        response = client.get("/api/reports/monthly-trends?category=Power Supplies")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        unfiltered = client.get("/api/reports/monthly-trends").json()
+        total_filtered = sum(m["order_count"] for m in data)
+        total_unfiltered = sum(m["order_count"] for m in unfiltered)
+        assert total_filtered <= total_unfiltered
+
+    def test_monthly_trends_filter_by_status(self, client):
+        """Test filtering monthly trends by status."""
+        response = client.get("/api/reports/monthly-trends?status=Delivered")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        # When filtered to delivered only, delivered_count should equal order_count
+        for month in data:
+            assert month["delivered_count"] == month["order_count"]
+
+    def test_monthly_trends_filter_by_month(self, client):
+        """Test filtering monthly trends by specific month."""
+        response = client.get("/api/reports/monthly-trends?month=2025-03")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        # Should only contain March 2025
+        for month in data:
+            assert month["month"] == "2025-03"
+
+    def test_monthly_trends_filter_all_passes_through(self, client):
+        """Test that filter value 'all' returns same as unfiltered."""
+        unfiltered = client.get("/api/reports/monthly-trends").json()
+        filtered = client.get("/api/reports/monthly-trends?warehouse=all&category=all").json()
+
+        assert len(unfiltered) == len(filtered)
+
+    def test_monthly_trends_delivered_count_not_exceeds_total(self, client):
+        """Test that delivered_count never exceeds order_count."""
+        response = client.get("/api/reports/monthly-trends")
+        data = response.json()
+
+        for month in data:
+            assert month["delivered_count"] <= month["order_count"]
+
+    def test_monthly_trends_multiple_filters(self, client):
+        """Test filtering monthly trends with multiple filters."""
+        response = client.get(
+            "/api/reports/monthly-trends?warehouse=San Francisco&category=Sensors"
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        # Combined filters should produce fewer results
+        warehouse_only = client.get(
+            "/api/reports/monthly-trends?warehouse=San Francisco"
+        ).json()
+        total_combined = sum(m["order_count"] for m in data)
+        total_warehouse = sum(m["order_count"] for m in warehouse_only)
+        assert total_combined <= total_warehouse


### PR DESCRIPTION
## Summary
- Add new **Restocking** page with budget-based priority recommendations derived from demand forecasts, including order submission and tracking
- Refactor **Reports** view from Options API to Composition API with full i18n (English/Japanese) and filter support
- Add backend API endpoints for quarterly reports, monthly trends, restocking recommendations, and submitted orders
- Add submitted restocking orders section to the **Orders** view
- Expand inventory data with 8 new items (widgets, bearings, gaskets, motors, filters, valves, sensors, controllers)
- Add backend test coverage for reports endpoints

## Test plan
- [ ] Verify Restocking page loads recommendations and respects budget input
- [ ] Verify restocking order submission creates an order and appears in Orders view
- [ ] Verify Reports page displays quarterly and monthly data with filters applied
- [ ] Verify language switching works for all new restocking and reports translations
- [ ] Run `pytest tests/backend/test_reports.py` to confirm backend tests pass
- [ ] Verify new inventory items appear on the Inventory page

🤖 Generated with [Claude Code](https://claude.com/claude-code)