### PR TITLE
Add Restocking tab with budget-driven recommendations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# Factory Inventory Management — Architecture
+
+## System Overview
+
+A full-stack demo application for factory inventory tracking. No database — all data lives in JSON files loaded into memory at server startup.
+
+```
+┌─────────────────┐     HTTP/JSON      ┌─────────────────┐     import      ┌─────────────┐
+│  Vue 3 SPA      │ ─────────────────> │  FastAPI        │ ──────────────> │  JSON files │
+│  (port 3000)    │ <───────────────── │  (port 8001)    │  at startup     │  server/data│
+└─────────────────┘                    └─────────────────┘                 └─────────────┘
+      │                                       │
+      │                                       │
+  Vite dev server                       In-memory lists
+  Vue Router (7 views)                  Pydantic validation
+  Axios client                          List-comprehension filters
+```
+
+## Tech Stack
+
+| Layer      | Technology                          | Purpose                              |
+|------------|-------------------------------------|--------------------------------------|
+| Frontend   | Vue 3 (Composition API)             | Reactive UI                          |
+| Router     | Vue Router 4                        | Client-side navigation               |
+| HTTP       | Axios                               | API calls                            |
+| Build      | Vite 5                              | Dev server + bundler                 |
+| Backend    | FastAPI                             | REST API                             |
+| Validation | Pydantic 2                          | Response model enforcement           |
+| Server     | Uvicorn                             | ASGI runtime                         |
+| Data       | JSON files (no DB)                  | Loaded once at import time           |
+| Testing    | pytest + httpx + FastAPI TestClient | Backend only                         |
+
+## Frontend Structure
+
+```
+client/src/
+├── views/              7 route-level pages
+│   ├── Dashboard.vue   KPI summary + charts
+│   ├── Inventory.vue   Stock levels by SKU
+│   ├── Orders.vue      Order list (250 records)
+│   ├── Demand.vue      Forecasts
+│   ├── Backlog.vue     Pending items
+│   ├── Spending.vue    Cost breakdown
+│   └── Reports.vue     Quarterly + monthly trends
+├── components/         8 modals + FilterBar + ProfileMenu + LanguageSwitcher
+├── composables/
+│   ├── useFilters.js   Shared filter state (warehouse, category, status, month)
+│   ├── useAuth.js      Auth state
+│   └── useI18n.js      en/ja locale switching
+├── api.js              Axios wrapper — builds query strings from filter state
+└── App.vue             Shell + global styles
+```
+
+## Backend Structure
+
+```
+server/
+├── main.py             FastAPI app, 14 routes, Pydantic models, filter helpers
+├── mock_data.py        Loads all JSON → module-level lists at import time
+├── generate_data.py    Seed-data generator (dev utility)
+└── data/
+    ├── inventory.json        32 items
+    ├── orders.json           250 records
+    ├── demand_forecasts.json 9 records
+    ├── backlog_items.json    4 records
+    ├── spending.json         summary + monthly + category
+    ├── transactions.json     56 records
+    └── purchase_orders.json  empty
+```
+
+## API Surface
+
+| Endpoint                       | Filters                             | Returns           |
+|--------------------------------|-------------------------------------|-------------------|
+| `GET /api/inventory`           | warehouse, category                 | InventoryItem[]   |
+| `GET /api/inventory/{id}`      | —                                   | InventoryItem     |
+| `GET /api/orders`              | warehouse, category, status, month  | Order[]           |
+| `GET /api/orders/{id}`         | —                                   | Order             |
+| `GET /api/demand`              | —                                   | DemandForecast[]  |
+| `GET /api/backlog`             | —                                   | BacklogItem[]     |
+| `GET /api/dashboard/summary`   | warehouse, category, status, month  | aggregated dict   |
+| `GET /api/spending/summary`    | —                                   | dict              |
+| `GET /api/spending/monthly`    | —                                   | list              |
+| `GET /api/spending/categories` | —                                   | list              |
+| `GET /api/spending/transactions`| —                                  | list              |
+| `GET /api/reports/quarterly`   | —                                   | dict              |
+| `GET /api/reports/monthly-trends`| —                                 | dict              |
+
+## Data Flow — Filter Pipeline
+
+This is the core pattern. A single filter change propagates end-to-end:
+
+```
+1. User selects "Warehouse B" in FilterBar.vue
+        │
+        ▼
+2. useFilters.js composable updates reactive ref
+        │
+        ▼
+3. View component's watch() fires → calls api.getOrders(filters)
+        │
+        ▼
+4. api.js builds query string: GET /api/orders?warehouse=Warehouse+B
+        │
+        ▼
+5. main.py apply_filters() → [o for o in orders if o['warehouse'] == 'Warehouse B']
+        │
+        ▼
+6. Pydantic validates each item against Order model
+        │
+        ▼
+7. JSON response → Axios → ref update → Vue re-renders
+```
+
+**Key insight:** filters are stateless on the server — every request re-filters the full in-memory list. No caching, no pagination. Fine for 250 records; would not scale.
+
+## Filtering Internals (`main.py`)
+
+- `apply_filters(items, warehouse, category, status)` — chained list comprehensions, case-insensitive on category/status
+- `filter_by_month(items, month)` — supports quarter tokens (`Q1-2025` → expands to 3 month prefixes) via `QUARTER_MAP`, matched by substring against `order_date`
+- `'all'` sentinel = no filter (checked both client and server side)
+
+## Data Loading
+
+`mock_data.py` runs at **import time** — every JSON file is read once when the server process starts. The data lives as module-level Python lists for the lifetime of the process. Editing a JSON file requires a server restart to take effect.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ npm install && npm run dev
 
 ## Key Patterns
 
+**Comments**: Always document non-obvious logic changes with comments
+
 **Filter System**: 4 filters (Time Period, Warehouse, Category, Order Status) apply to all data via query params
 **Data Flow**: Vue filters → `client/src/api.js` → FastAPI → In-memory filtering → Pydantic validation → Computed properties
 **Reactivity**: Raw data in refs (`allOrders`, `inventoryItems`), derived data in computed properties

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -16,6 +16,9 @@
           <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
             {{ t('nav.orders') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
           <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
             {{ t('nav.finance') }}
           </router-link>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,20 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingRecommendations(budget) {
+    const response = await axios.get(`${API_BASE_URL}/restocking/recommendations`, { params: { budget } })
+    return response.data
+  },
+
+  async placeRestockingOrder(budget, items) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/orders`, { budget, items })
+    return response.data
+  },
+
+  async getSubmittedRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/orders`)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充発注',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -27,6 +27,38 @@
         </div>
       </div>
 
+      <div v-if="submittedOrders.length > 0" class="card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders ({{ submittedOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th>Order #</th>
+                <th>Items</th>
+                <th>Total Value</th>
+                <th>Lead Time</th>
+                <th>Expected Delivery</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td><strong>{{ order.order_number }}</strong></td>
+                <td>{{ order.items.length }} item(s)</td>
+                <td><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+                <td>{{ order.lead_time_days }} days</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td>
+                  <span class="badge info">{{ order.status }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card">
         <div class="card-header">
           <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
@@ -95,6 +127,16 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const submittedOrders = ref([])
+
+    const loadSubmittedOrders = async () => {
+      try {
+        submittedOrders.value = await api.getSubmittedRestockingOrders()
+      } catch (err) {
+        // Restocking orders are supplementary; don't block the main view on failure
+        submittedOrders.value = []
+      }
+    }
 
     // Use shared filters
     const {
@@ -127,6 +169,7 @@ export default {
     // Watch for filter changes and reload data
     watch([selectedPeriod, selectedLocation, selectedCategory, selectedStatus], () => {
       loadOrders()
+      loadSubmittedOrders()
     })
 
     const getOrdersByStatus = (status) => {
@@ -153,13 +196,17 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    onMounted(() => {
+      loadOrders()
+      loadSubmittedOrders()
+    })
 
     return {
       t,
       loading,
       error,
       orders,
+      submittedOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,305 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>Set a budget and review recommended restock orders based on demand forecasts.</p>
+    </div>
+
+    <div class="card budget-card">
+      <div class="card-header">
+        <h3 class="card-title">Restocking Budget</h3>
+      </div>
+      <div class="budget-controls">
+        <input
+          type="range"
+          min="5000"
+          max="200000"
+          step="5000"
+          v-model.number="budget"
+          class="budget-slider"
+        />
+        <div class="budget-display">
+          <span class="budget-label">Available Budget:</span>
+          <span class="budget-value">{{ currencySymbol }}{{ budget.toLocaleString() }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="loading" class="loading">Loading recommendations...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <div class="stats-grid">
+        <div class="stat-card info">
+          <div class="stat-label">Items Recommended</div>
+          <div class="stat-value">{{ recommendations.length }}</div>
+        </div>
+        <div class="stat-card success">
+          <div class="stat-label">Total Cost</div>
+          <div class="stat-value">{{ currencySymbol }}{{ totalCost.toLocaleString() }}</div>
+        </div>
+        <div class="stat-card warning">
+          <div class="stat-label">Budget Remaining</div>
+          <div class="stat-value">{{ currencySymbol }}{{ budgetRemaining.toLocaleString() }}</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Recommended Items ({{ recommendations.length }})</h3>
+          <button
+            class="place-order-btn"
+            :disabled="recommendations.length === 0 || placing"
+            @click="placeOrder"
+          >
+            {{ placing ? 'Placing...' : 'Place Order' }}
+          </button>
+        </div>
+
+        <div v-if="successMessage" class="success-banner">
+          {{ successMessage }}
+        </div>
+
+        <div v-if="recommendations.length === 0" class="empty-state">
+          No items fit within the current budget. Try increasing it.
+        </div>
+
+        <div v-else class="table-container">
+          <table class="restock-table">
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Item Name</th>
+                <th>Quantity</th>
+                <th>Unit Cost</th>
+                <th>Line Total</th>
+                <th>Trend</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendations" :key="item.sku">
+                <td><strong>{{ item.sku }}</strong></td>
+                <td>{{ item.name }}</td>
+                <td>{{ item.quantity.toLocaleString() }}</td>
+                <td>{{ currencySymbol }}{{ item.unit_cost.toFixed(2) }}</td>
+                <td><strong>{{ currencySymbol }}{{ item.line_total.toLocaleString() }}</strong></td>
+                <td>
+                  <span :class="['badge', getTrendClass(item.trend)]">
+                    {{ item.trend }}
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr class="total-row">
+                <td colspan="4"><strong>Total</strong></td>
+                <td><strong>{{ currencySymbol }}{{ totalCost.toLocaleString() }}</strong></td>
+                <td></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { currentCurrency } = useI18n()
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? String.fromCharCode(165) : '$'
+    })
+
+    const budget = ref(50000)
+    const recommendations = ref([])
+    const loading = ref(true)
+    const error = ref(null)
+    const placing = ref(false)
+    const successMessage = ref('')
+
+    const totalCost = computed(() => {
+      return recommendations.value.reduce((sum, item) => sum + item.line_total, 0)
+    })
+
+    const budgetRemaining = computed(() => {
+      return budget.value - totalCost.value
+    })
+
+    const loadRecommendations = async () => {
+      try {
+        loading.value = true
+        error.value = null
+        recommendations.value = await api.getRestockingRecommendations(budget.value)
+      } catch (err) {
+        error.value = 'Failed to load recommendations: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      if (recommendations.value.length === 0) return
+      try {
+        placing.value = true
+        const order = await api.placeRestockingOrder(budget.value, recommendations.value)
+        successMessage.value = 'Order ' + order.order_number + ' placed. Expected delivery in ' + order.lead_time_days + ' days.'
+        setTimeout(() => { successMessage.value = '' }, 5000)
+      } catch (err) {
+        error.value = 'Failed to place order: ' + err.message
+      } finally {
+        placing.value = false
+      }
+    }
+
+    const getTrendClass = (trend) => {
+      const map = { increasing: 'success', stable: 'info', decreasing: 'warning' }
+      return map[trend] || 'info'
+    }
+
+    watch(budget, loadRecommendations)
+    onMounted(loadRecommendations)
+
+    return {
+      budget,
+      recommendations,
+      loading,
+      error,
+      placing,
+      successMessage,
+      totalCost,
+      budgetRemaining,
+      currencySymbol,
+      placeOrder,
+      getTrendClass
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-card {
+  margin-bottom: 1.5rem;
+}
+
+.budget-controls {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.budget-slider {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #0f172a;
+  cursor: pointer;
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #0f172a;
+  cursor: pointer;
+  border: none;
+}
+
+.budget-display {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.budget-label {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.budget-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.restock-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.restock-table th,
+.restock-table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+}
+
+.total-row {
+  border-top: 2px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.total-row td {
+  padding-top: 1rem;
+}
+
+.place-order-btn {
+  padding: 0.5rem 1.25rem;
+  background: #0f172a;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.place-order-btn:hover:not(:disabled) {
+  background: #1e293b;
+}
+
+.place-order-btn:disabled {
+  background: #cbd5e1;
+  cursor: not-allowed;
+}
+
+.success-banner {
+  margin: 1rem;
+  padding: 0.75rem 1rem;
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  border-radius: 6px;
+  color: #166534;
+  font-size: 0.875rem;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/server/main.py
+++ b/server/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
@@ -119,6 +120,44 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingRecommendation(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+    line_total: float
+    trend: str
+    priority: int
+
+class PlaceRestockingOrderRequest(BaseModel):
+    budget: float
+    items: List[dict]
+
+class SubmittedRestockingOrder(BaseModel):
+    id: str
+    order_number: str
+    items: List[dict]
+    total_value: float
+    budget: float
+    order_date: str
+    expected_delivery: str
+    lead_time_days: int
+    status: str
+
+# In-memory storage for restocking orders placed via the Restocking tab
+submitted_restocking_orders: list = []
+_restocking_order_seq: int = 0
+
+# Most demand-forecast SKUs don't exist in inventory.json; this table covers the gap
+DEFAULT_UNIT_COSTS = {
+    "WDG-001": 24.50, "BRG-102": 89.00, "GSK-203": 12.25,
+    "MTR-304": 450.00, "FLT-405": 8.75, "VLV-506": 67.50,
+    "SNR-420": 34.00, "CTL-330": 125.00,
+}
+
+# Supplier readiness: high-demand items ship fastest
+LEAD_TIME_BY_TREND = {"increasing": 7, "stable": 14, "decreasing": 21}
 
 # API endpoints
 @app.get("/")
@@ -303,6 +342,77 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+
+def _resolve_unit_cost(sku: str) -> float:
+    for item in inventory_items:
+        if item["sku"] == sku:
+            return item["unit_cost"]
+    return DEFAULT_UNIT_COSTS.get(sku, 50.0)
+
+@app.get("/api/restocking/recommendations", response_model=List[RestockingRecommendation])
+def get_restocking_recommendations(budget: float = 50000.0):
+    """
+    Greedy budget allocation: sort demand items by priority (trend + demand growth),
+    then fill the budget top-down. Returns only items that fit.
+    """
+    # Trend is the primary signal; demand growth breaks ties
+    trend_weight = {"increasing": 3, "stable": 2, "decreasing": 1}
+    candidates = []
+    for d in demand_forecasts:
+        sku = d["item_sku"]
+        qty = d["forecasted_demand"]
+        cost = _resolve_unit_cost(sku)
+        growth = d["forecasted_demand"] - d["current_demand"]
+        candidates.append({
+            "sku": sku,
+            "name": d["item_name"],
+            "quantity": qty,
+            "unit_cost": cost,
+            "line_total": round(qty * cost, 2),
+            "trend": d["trend"],
+            "priority": trend_weight.get(d["trend"], 1) * 1000 + growth,
+        })
+
+    candidates.sort(key=lambda c: c["priority"], reverse=True)
+
+    selected = []
+    spent = 0.0
+    for c in candidates:
+        if spent + c["line_total"] <= budget:
+            selected.append(c)
+            spent += c["line_total"]
+    return selected
+
+@app.post("/api/restocking/orders", response_model=SubmittedRestockingOrder)
+def place_restocking_order(req: PlaceRestockingOrderRequest):
+    global _restocking_order_seq
+    if not req.items:
+        raise HTTPException(status_code=400, detail="Cannot place an order with no items")
+
+    total = round(sum(i["line_total"] for i in req.items), 2)
+    # Lead time follows the slowest item so the whole shipment arrives together
+    lead = max(LEAD_TIME_BY_TREND.get(i.get("trend", "stable"), 14) for i in req.items)
+
+    _restocking_order_seq += 1
+    now = datetime.now()
+    order = {
+        "id": f"rst-{_restocking_order_seq}",
+        "order_number": f"RST-{now.year}-{_restocking_order_seq:04d}",
+        "items": req.items,
+        "total_value": total,
+        "budget": req.budget,
+        "order_date": now.isoformat(timespec="seconds"),
+        "expected_delivery": (now + timedelta(days=lead)).isoformat(timespec="seconds"),
+        "lead_time_days": lead,
+        "status": "Submitted",
+    }
+    submitted_restocking_orders.append(order)
+    return order
+
+@app.get("/api/restocking/orders", response_model=List[SubmittedRestockingOrder])
+def list_restocking_orders():
+    return submitted_restocking_orders
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/backend/test_restocking.py
+++ b/tests/backend/test_restocking.py
@@ -1,0 +1,169 @@
+"""
+Tests for restocking API endpoints.
+"""
+import pytest
+from main import submitted_restocking_orders
+
+
+class TestRestockingRecommendations:
+    """Test suite for GET /api/restocking/recommendations."""
+
+    def test_get_recommendations_default_budget(self, client):
+        """Test getting recommendations with default budget."""
+        response = client.get("/api/restocking/recommendations")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        first = data[0]
+        assert "sku" in first
+        assert "name" in first
+        assert "quantity" in first
+        assert "unit_cost" in first
+        assert "line_total" in first
+        assert "trend" in first
+        assert "priority" in first
+
+    def test_recommendations_respect_budget(self, client):
+        """Test that total never exceeds the budget."""
+        budget = 20000
+        response = client.get(f"/api/restocking/recommendations?budget={budget}")
+        assert response.status_code == 200
+
+        data = response.json()
+        total = sum(item["line_total"] for item in data)
+        assert total <= budget
+
+    def test_recommendations_priority_ordering(self, client):
+        """Test that results are sorted by priority descending."""
+        response = client.get("/api/restocking/recommendations?budget=200000")
+        data = response.json()
+
+        priorities = [item["priority"] for item in data]
+        assert priorities == sorted(priorities, reverse=True)
+
+    def test_recommendations_increasing_trend_first(self, client):
+        """Test that increasing-trend items win over stable/decreasing."""
+        response = client.get("/api/restocking/recommendations?budget=200000")
+        data = response.json()
+
+        # Priority encodes trend weight in the thousands place; increasing >= 3000
+        increasing_priorities = [r["priority"] for r in data if r["trend"] == "increasing"]
+        other_priorities = [r["priority"] for r in data if r["trend"] != "increasing"]
+        if increasing_priorities and other_priorities:
+            assert min(increasing_priorities) > max(other_priorities)
+
+    def test_recommendations_tiny_budget_empty(self, client):
+        """Test that an unrealistically small budget yields no recommendations."""
+        response = client.get("/api/restocking/recommendations?budget=100")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_recommendation_line_total_calculation(self, client):
+        """Test that line_total = quantity * unit_cost."""
+        response = client.get("/api/restocking/recommendations?budget=100000")
+        data = response.json()
+
+        for item in data:
+            expected = item["quantity"] * item["unit_cost"]
+            assert abs(item["line_total"] - expected) < 0.01
+
+    def test_recommendation_data_types(self, client):
+        """Test that numeric fields have proper types."""
+        response = client.get("/api/restocking/recommendations?budget=100000")
+        data = response.json()
+
+        for item in data:
+            assert isinstance(item["quantity"], int)
+            assert isinstance(item["unit_cost"], (int, float))
+            assert isinstance(item["line_total"], (int, float))
+            assert isinstance(item["priority"], int)
+            assert item["quantity"] > 0
+            assert item["unit_cost"] > 0
+
+
+class TestPlaceRestockingOrder:
+    """Test suite for POST /api/restocking/orders."""
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        """In-memory storage persists across tests; wipe before each."""
+        submitted_restocking_orders.clear()
+        yield
+        submitted_restocking_orders.clear()
+
+    def _sample_items(self):
+        return [
+            {"sku": "WDG-001", "name": "Widget", "quantity": 100,
+             "unit_cost": 24.5, "line_total": 2450.0, "trend": "increasing", "priority": 3150},
+            {"sku": "BRG-102", "name": "Bearing", "quantity": 50,
+             "unit_cost": 89.0, "line_total": 4450.0, "trend": "stable", "priority": 2002},
+        ]
+
+    def test_place_order_success(self, client):
+        """Test placing a restocking order."""
+        payload = {"budget": 10000, "items": self._sample_items()}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["order_number"].startswith("RST-")
+        assert order["status"] == "Submitted"
+        assert order["total_value"] == 6900.0
+        assert order["budget"] == 10000
+        assert "T" in order["order_date"]
+        assert "T" in order["expected_delivery"]
+
+    def test_place_order_lead_time_is_slowest_item(self, client):
+        """Lead time follows the slowest item (stable=14 > increasing=7)."""
+        payload = {"budget": 10000, "items": self._sample_items()}
+        response = client.post("/api/restocking/orders", json=payload)
+        order = response.json()
+        assert order["lead_time_days"] == 14
+
+    def test_place_order_all_increasing_fast_lead(self, client):
+        """All increasing-trend items gives 7-day lead."""
+        items = [{"sku": "X", "name": "X", "quantity": 1, "unit_cost": 1.0,
+                  "line_total": 1.0, "trend": "increasing", "priority": 3000}]
+        response = client.post("/api/restocking/orders", json={"budget": 100, "items": items})
+        assert response.json()["lead_time_days"] == 7
+
+    def test_place_order_empty_items_rejected(self, client):
+        """Test that empty item list returns 400."""
+        response = client.post("/api/restocking/orders", json={"budget": 1000, "items": []})
+        assert response.status_code == 400
+        assert "detail" in response.json()
+
+    def test_place_order_appears_in_list(self, client):
+        """Test that placed order appears in GET /api/restocking/orders."""
+        client.post("/api/restocking/orders", json={"budget": 5000, "items": self._sample_items()})
+
+        response = client.get("/api/restocking/orders")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["total_value"] == 6900.0
+
+    def test_multiple_orders_sequential_numbers(self, client):
+        """Test that order numbers increment."""
+        r1 = client.post("/api/restocking/orders", json={"budget": 5000, "items": self._sample_items()})
+        r2 = client.post("/api/restocking/orders", json={"budget": 5000, "items": self._sample_items()})
+
+        # IDs are different even though the sequence counter is module-global
+        assert r1.json()["id"] != r2.json()["id"]
+
+        response = client.get("/api/restocking/orders")
+        assert len(response.json()) == 2
+
+
+class TestListRestockingOrders:
+    """Test suite for GET /api/restocking/orders."""
+
+    def test_list_empty_initially(self, client):
+        """Test that list is empty when no orders placed."""
+        submitted_restocking_orders.clear()
+        response = client.get("/api/restocking/orders")
+        assert response.status_code == 200
+        assert response.json() == []


### PR DESCRIPTION
## Summary

A new **Restocking** tab where users set a budget via slider and get demand-forecast-driven restock recommendations that fit within it. Placing an order surfaces it in the Orders tab with a computed delivery lead time.

## How it works

**Recommendation algorithm** (server/main.py): greedy budget fill. Items are scored by trend_weight * 1000 + demand_growth (increasing=3, stable=2, decreasing=1), sorted descending, then added until budget is exhausted. Unit costs come from inventory.json where available, with a fallback table for demand SKUs that don't exist there (8 of 9).

**Lead time**: the slowest item sets the pace for the whole shipment. Increasing-trend items ship in 7 days, stable in 14, decreasing in 21, so a mixed order gets max() of its items' lead times.

**UI flow**: drag slider, recommendations table live-updates, click Place Order, success banner shows order number + lead time, switch to Orders tab, new "Submitted Restocking Orders" section appears above All Orders.

## Files

- server/main.py (+110): 3 Pydantic models, 3 endpoints, priority algorithm, lead-time map
- client/src/views/Restocking.vue (new, 305 lines)
- client/src/views/Orders.vue (+49): Submitted Orders section (conditional render)
- client/src/api.js (+15): three new api methods
- client/src/main.js: route registration
- client/src/App.vue: nav link
- client/src/locales/en.js, ja.js: nav.restocking key
- tests/backend/test_restocking.py (new, 14 tests)

## Tests

14/14 passed in test_restocking.py, 54/54 in full backend suite. Adversarial checks (zero/negative budget, invalid trend, idempotency, 5-way concurrent POSTs) all handled correctly.