### PR TITLE
Redesign UI: collapsible sidebar nav and design-token system

### DIFF
--- a/.claude/skills/saas-redesign/SKILL.md
+++ b/.claude/skills/saas-redesign/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: saas-redesign
+description: Redesign the inventory app into a Stripe-style SaaS UI with a collapsible left sidebar, CSS design tokens, and consistent spacing. Use when asked to modernize the UI, switch to sidebar navigation, or apply a SaaS dashboard look.
+---
+
+# SaaS Redesign — Stripe-style Sidebar Layout
+
+This skill converts the Factory Inventory app from a horizontal top-nav layout to a modern SaaS interface with a **collapsible left sidebar**, **design-token spacing**, and **Stripe-inspired polish** (light surfaces, soft borders, indigo accent, generous whitespace).
+
+Target aesthetic: Stripe Dashboard — all-light, white sidebar, `#635bff` indigo accent, subtle shadows, rounded-lg cards.
+
+## Bundled Assets
+
+Read these files from this skill directory before making changes:
+
+| File | Use |
+|---|---|
+| `design-tokens.md` | Complete `:root` CSS-variable block + migration map |
+| `sidebar-template.vue` | Reference implementation for `SidebarNav.vue` |
+
+## Workflow — Follow In Order
+
+### Phase 1: Audit
+
+1. Read `client/src/App.vue` — note the current `<header class="top-nav">` block, the router-link list, and the global `<style>` section.
+2. Confirm these components exist (they will be relocated, not modified):
+   - `client/src/components/LanguageSwitcher.vue`
+   - `client/src/components/ProfileMenu.vue`
+   - `client/src/components/FilterBar.vue`
+3. List view files: `ls client/src/views/` — these get a spacing pass in Phase 5.
+
+### Phase 2: Install Design Tokens
+
+1. Read `.claude/skills/saas-redesign/design-tokens.md`.
+2. Edit `client/src/App.vue` — insert the full `:root { ... }` block at the top of the `<style>` tag, immediately before the `*` reset.
+3. Update `body` to use tokens: `background: var(--surface-subtle); color: var(--text);`
+
+### Phase 3: Create `useSidebar` Composable
+
+Create `client/src/composables/useSidebar.js` (follow the singleton pattern used in `useFilters.js`):
+
+```js
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'sidebar-collapsed'
+const isCollapsed = ref(localStorage.getItem(STORAGE_KEY) === 'true')
+
+export function useSidebar() {
+  const toggle = () => {
+    isCollapsed.value = !isCollapsed.value
+    localStorage.setItem(STORAGE_KEY, isCollapsed.value)
+  }
+  return { isCollapsed, toggle }
+}
+```
+
+### Phase 4: Create `SidebarNav` Component
+
+**MANDATORY:** Per project `CLAUDE.md`, creating a new `.vue` file must be delegated to the **vue-expert** subagent.
+
+Spawn `vue-expert` with this brief:
+
+> Create `client/src/components/SidebarNav.vue` using `.claude/skills/saas-redesign/sidebar-template.vue` as the starting point. Copy it verbatim, then verify:
+> - All 6 routes match `client/src/App.vue` router-links (`/`, `/inventory`, `/orders`, `/spending`, `/demand`, `/reports`)
+> - `nav.reports` i18n key exists in `client/src/locales/` — if not, fall back to literal `'Reports'`
+> - Imports resolve (`useSidebar`, `useI18n`, `LanguageSwitcher`, `ProfileMenu`)
+> - Emits `show-profile-details` and `show-tasks` pass through from `ProfileMenu`
+
+### Phase 5: Restructure `App.vue` Layout
+
+**MANDATORY:** This is a significant `.vue` modification — delegate to **vue-expert**.
+
+Target template:
+
+```html
+<template>
+  <div class="app" :class="{ 'sidebar-collapsed': isCollapsed }">
+    <SidebarNav
+      @show-profile-details="showProfileDetails = true"
+      @show-tasks="showTasks = true"
+    />
+    <div class="app-main">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
+    <ProfileDetailsModal :is-open="showProfileDetails" @close="showProfileDetails = false" />
+    <TasksModal ... />  <!-- keep existing props/handlers unchanged -->
+  </div>
+</template>
+```
+
+Script changes:
+- Import `SidebarNav` and `useSidebar`; register `SidebarNav` in `components`
+- In `setup()`: add `const { isCollapsed } = useSidebar()` and return `isCollapsed`
+- Remove `LanguageSwitcher` and `ProfileMenu` from imports/components (now owned by `SidebarNav`)
+- **Do not touch** task/modal logic (`tasks`, `addTask`, `deleteTask`, `toggleTask`, `loadTasks`)
+
+Style changes — replace the `.app`, `.top-nav`, `.nav-container`, `.nav-tabs*`, `.logo`, `.subtitle` rules with:
+
+```css
+.app {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  min-height: 100vh;
+  transition: grid-template-columns var(--transition);
+}
+
+.app.sidebar-collapsed {
+  grid-template-columns: var(--sidebar-w-rail) 1fr;
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.main-content {
+  flex: 1;
+  max-width: var(--content-max-w);
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-8);
+}
+```
+
+Then retrofit the remaining global rules (`.page-header`, `.stats-grid`, `.stat-card`, `.card`, `table`, `.badge`, `.loading`, `.error`) using the **migration map** in `design-tokens.md`. Specific adjustments:
+- `.card`, `.stat-card`: `border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); border: 1px solid var(--border);` — shadow always-on, drop the hover-only shadow
+- `.stat-card:hover`: `box-shadow: var(--shadow-md);` only
+- `.page-header`: `margin-bottom: var(--space-6)`
+- `.stats-grid`, `.card`: gap/margin → `var(--space-5)`
+
+### Phase 6: Spacing & Polish Pass
+
+For `client/src/components/FilterBar.vue` and each file in `client/src/views/`:
+
+1. In scoped `<style>` blocks, apply the migration map from `design-tokens.md` — replace literal hex colors, rem spacing, and px radii with token vars.
+2. FilterBar specifically: wrap in a white card (`background: var(--surface)`, `border-bottom: 1px solid var(--border)`, `padding: var(--space-4) var(--space-8)`).
+3. **Retrofit only** — do not change templates, scripts, or computed logic. Style edits only.
+
+Delegate any file with >20 lines of style changes to **vue-expert**.
+
+### Phase 7: Verify
+
+1. Start dev server: `cd client && npm run dev` (port 3000).
+2. Use Playwright MCP (`mcp__playwright__*`):
+   - Navigate to each route: `/`, `/inventory`, `/orders`, `/spending`, `/demand`, `/reports`
+   - Screenshot each; assert `.sidebar-nav` is visible and the matching `.nav-item` has `router-link-exact-active`
+   - Click `.collapse-btn` → assert `.app` has class `sidebar-collapsed` and `.nav-label` elements are hidden
+   - Reload page → assert collapsed state persists (localStorage)
+   - Change a FilterBar select → confirm dashboard stat values change (filter pipeline intact)
+3. Check browser console: zero Vue warnings or errors.
+4. Set viewport to 1280×800 → assert no horizontal scrollbar.
+
+## Rules
+
+**Do**
+- Use **vue-expert** subagent for every `.vue` file creation or significant edit
+- Keep all i18n keys (`t('nav.*')`) — add `nav.reports` to locales if missing
+- Use inline SVG for icons (provided in `sidebar-template.vue`)
+- Preserve all existing functionality: filters, modals, tasks, language switching
+
+**Don't**
+- Add npm dependencies (no icon libraries, no Tailwind, no UI kits)
+- Use emoji anywhere in the UI
+- Touch `server/`, `client/src/api.js`, or any composable except the new `useSidebar.js`
+- Rewrite view component logic — Phase 6 is style-only
+
+## Quick Reference
+
+| Item | Value |
+|---|---|
+| Sidebar width (expanded) | `240px` |
+| Sidebar width (rail) | `64px` |
+| Accent color | `#635bff` |
+| Card padding | `var(--space-5)` |
+| Grid gap | `var(--space-5)` |
+| Page padding | `var(--space-6) var(--space-8)` |
+| Card radius | `var(--radius-lg)` (8px) |
+| Default shadow | `var(--shadow-sm)` |

--- a/.claude/skills/saas-redesign/design-tokens.md
+++ b/.claude/skills/saas-redesign/design-tokens.md
@@ -1,0 +1,103 @@
+# Design Tokens — Stripe-style SaaS
+
+Paste this block at the **top** of the global `<style>` tag in `client/src/App.vue` (immediately after the opening `<style>` line, before the `*` reset).
+
+```css
+:root {
+  /* Surfaces */
+  --surface: #ffffff;
+  --surface-subtle: #f6f8fa;
+  --surface-hover: #f0f3f7;
+
+  /* Borders */
+  --border: #e3e8ee;
+  --border-strong: #d5dbe1;
+
+  /* Text */
+  --text: #1a1f36;
+  --text-muted: #697386;
+  --text-subtle: #8792a2;
+
+  /* Accent (Stripe indigo) */
+  --accent: #635bff;
+  --accent-hover: #5349e0;
+  --accent-subtle: #f5f4ff;
+
+  /* Status */
+  --success: #0e6245;
+  --success-bg: #d7f7c2;
+  --warning: #983705;
+  --warning-bg: #fcedb9;
+  --danger: #a41c4e;
+  --danger-bg: #ffe7f2;
+  --info: #3d4eac;
+  --info-bg: #e6e6fc;
+
+  /* Spacing (4px grid) */
+  --space-1: 0.25rem;   /* 4px */
+  --space-2: 0.5rem;    /* 8px */
+  --space-3: 0.75rem;   /* 12px */
+  --space-4: 1rem;      /* 16px */
+  --space-5: 1.25rem;   /* 20px */
+  --space-6: 1.5rem;    /* 24px */
+  --space-8: 2rem;      /* 32px */
+  --space-10: 2.5rem;   /* 40px */
+  --space-12: 3rem;     /* 48px */
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* Shadow */
+  --shadow-sm: 0 1px 3px rgba(26, 31, 54, 0.08);
+  --shadow-md: 0 4px 12px rgba(26, 31, 54, 0.1);
+  --shadow-lg: 0 12px 32px rgba(26, 31, 54, 0.12);
+
+  /* Typography */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 0.938rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+  --text-2xl: 1.75rem;
+
+  /* Layout */
+  --sidebar-w: 240px;
+  --sidebar-w-rail: 64px;
+  --content-max-w: 1400px;
+
+  /* Motion */
+  --transition: 0.18s ease;
+}
+```
+
+## Migration Map
+
+When retrofitting existing styles in `App.vue` and view files, replace literals with tokens:
+
+| Old value | Token |
+|---|---|
+| `#ffffff`, `white` | `var(--surface)` |
+| `#f8fafc` | `var(--surface-subtle)` |
+| `#f1f5f9` | `var(--surface-hover)` |
+| `#e2e8f0` | `var(--border)` |
+| `#cbd5e1` | `var(--border-strong)` |
+| `#0f172a`, `#1e293b`, `#334155` | `var(--text)` |
+| `#64748b`, `#475569` | `var(--text-muted)` |
+| `#2563eb` | `var(--accent)` |
+| `#eff6ff` | `var(--accent-subtle)` |
+| `0.25rem` | `var(--space-1)` |
+| `0.5rem` | `var(--space-2)` |
+| `0.75rem` | `var(--space-3)` |
+| `1rem` | `var(--space-4)` |
+| `1.25rem` | `var(--space-5)` |
+| `1.5rem` | `var(--space-6)` |
+| `2rem` | `var(--space-8)` |
+| `6px` (radius) | `var(--radius-md)` |
+| `8px`, `10px` (radius) | `var(--radius-lg)` |
+| `0 1px 3px ...`, `0 4px 12px ...` | `var(--shadow-sm)`, `var(--shadow-md)` |
+
+**Status badges** — remap existing `.badge.*` and `.stat-card.*` color classes to the status tokens above (e.g. `.badge.success { background: var(--success-bg); color: var(--success); }`).
+
+Only replace values used for **spacing, color, radius, and shadow**. Leave font-weights, letter-spacing, and percentage widths as-is.

--- a/.claude/skills/saas-redesign/sidebar-template.vue
+++ b/.claude/skills/saas-redesign/sidebar-template.vue
@@ -1,0 +1,220 @@
+<template>
+  <aside class="sidebar-nav" :class="{ collapsed: isCollapsed }">
+    <div class="sidebar-header">
+      <div class="logo" v-show="!isCollapsed">
+        <h1>{{ t('nav.companyName') }}</h1>
+        <span class="subtitle">{{ t('nav.subtitle') }}</span>
+      </div>
+      <button class="collapse-btn" @click="toggle" :aria-label="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+        <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8">
+          <path d="M11 5l-5 5 5 5M16 5l-5 5 5 5" />
+        </svg>
+      </button>
+    </div>
+
+    <nav class="nav-items">
+      <router-link
+        v-for="item in navItems"
+        :key="item.path"
+        :to="item.path"
+        class="nav-item"
+        :title="isCollapsed ? t(item.label) : null"
+      >
+        <span class="nav-icon" v-html="item.icon" />
+        <span class="nav-label">{{ t(item.label) }}</span>
+      </router-link>
+    </nav>
+
+    <div class="sidebar-footer">
+      <LanguageSwitcher v-show="!isCollapsed" />
+      <ProfileMenu
+        @show-profile-details="$emit('show-profile-details')"
+        @show-tasks="$emit('show-tasks')"
+      />
+    </div>
+  </aside>
+</template>
+
+<script>
+import { useSidebar } from '../composables/useSidebar'
+import { useI18n } from '../composables/useI18n'
+import LanguageSwitcher from './LanguageSwitcher.vue'
+import ProfileMenu from './ProfileMenu.vue'
+
+const ICONS = {
+  dashboard: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="6" height="8" rx="1"/><rect x="11" y="3" width="6" height="5" rx="1"/><rect x="11" y="10" width="6" height="7" rx="1"/><rect x="3" y="13" width="6" height="4" rx="1"/></svg>',
+  package: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M10 2l7 4v8l-7 4-7-4V6l7-4z"/><path d="M3 6l7 4 7-4M10 10v8"/></svg>',
+  cart: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 3h2l2 10h8l2-7H6"/><circle cx="8" cy="16" r="1.5"/><circle cx="14" cy="16" r="1.5"/></svg>',
+  dollar: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M10 3v14M13 6H8.5a2.5 2.5 0 000 5h3a2.5 2.5 0 010 5H6"/></svg>',
+  trending: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 14l4-4 3 3 7-7"/><path d="M13 6h4v4"/></svg>',
+  file: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M11 3H5a1 1 0 00-1 1v12a1 1 0 001 1h10a1 1 0 001-1V8l-5-5z"/><path d="M11 3v5h5M7 11h6M7 14h6"/></svg>'
+}
+
+export default {
+  name: 'SidebarNav',
+  components: { LanguageSwitcher, ProfileMenu },
+  emits: ['show-profile-details', 'show-tasks'],
+  setup() {
+    const { isCollapsed, toggle } = useSidebar()
+    const { t } = useI18n()
+
+    const navItems = [
+      { path: '/', label: 'nav.overview', icon: ICONS.dashboard },
+      { path: '/inventory', label: 'nav.inventory', icon: ICONS.package },
+      { path: '/orders', label: 'nav.orders', icon: ICONS.cart },
+      { path: '/spending', label: 'nav.finance', icon: ICONS.dollar },
+      { path: '/demand', label: 'nav.demandForecast', icon: ICONS.trending },
+      { path: '/reports', label: 'nav.reports', icon: ICONS.file }
+    ]
+
+    return { isCollapsed, toggle, t, navItems }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  min-height: 70px;
+}
+
+.logo h1 {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.025em;
+}
+
+.logo .subtitle {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.collapse-btn {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition);
+}
+
+.collapse-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.collapse-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.collapsed .collapse-btn svg {
+  transform: rotate(180deg);
+}
+
+.nav-items {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  overflow-y: auto;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  transition: all var(--transition);
+  position: relative;
+}
+
+.nav-item:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.nav-item.router-link-exact-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.nav-item.router-link-exact-active::before {
+  content: '';
+  position: absolute;
+  left: calc(-1 * var(--space-3));
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+}
+
+.nav-icon :deep(svg) {
+  width: 100%;
+  height: 100%;
+}
+
+.nav-label {
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.collapsed .nav-label {
+  display: none;
+}
+
+.collapsed .nav-item {
+  justify-content: center;
+  padding: var(--space-2);
+}
+
+.sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+
+.collapsed .sidebar-header {
+  justify-content: center;
+}
+</style>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,15 @@
 <template>
-  <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
-        <LanguageSwitcher />
-        <ProfileMenu
-          @show-profile-details="showProfileDetails = true"
-          @show-tasks="showTasks = true"
-        />
-      </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+  <div class="app" :class="{ 'sidebar-collapsed': isCollapsed }">
+    <SidebarNav
+      @show-profile-details="showProfileDetails = true"
+      @show-tasks="showTasks = true"
+    />
+    <div class="app-main">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -58,25 +31,23 @@
 import { ref, onMounted, computed } from 'vue'
 import { api } from './api'
 import { useAuth } from './composables/useAuth'
-import { useI18n } from './composables/useI18n'
+import { useSidebar } from './composables/useSidebar'
 import FilterBar from './components/FilterBar.vue'
-import ProfileMenu from './components/ProfileMenu.vue'
+import SidebarNav from './components/SidebarNav.vue'
 import ProfileDetailsModal from './components/ProfileDetailsModal.vue'
 import TasksModal from './components/TasksModal.vue'
-import LanguageSwitcher from './components/LanguageSwitcher.vue'
 
 export default {
   name: 'App',
   components: {
     FilterBar,
-    ProfileMenu,
+    SidebarNav,
     ProfileDetailsModal,
-    TasksModal,
-    LanguageSwitcher
+    TasksModal
   },
   setup() {
     const { currentUser } = useAuth()
-    const { t } = useI18n()
+    const { isCollapsed } = useSidebar()
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
@@ -149,7 +120,7 @@ export default {
     onMounted(loadTasks)
 
     return {
-      t,
+      isCollapsed,
       showProfileDetails,
       showTasks,
       tasks,
@@ -162,6 +133,74 @@ export default {
 </script>
 
 <style>
+:root {
+  /* Surfaces */
+  --surface: #ffffff;
+  --surface-subtle: #f6f8fa;
+  --surface-hover: #f0f3f7;
+
+  /* Borders */
+  --border: #e3e8ee;
+  --border-strong: #d5dbe1;
+
+  /* Text */
+  --text: #1a1f36;
+  --text-muted: #697386;
+  --text-subtle: #8792a2;
+
+  /* Accent (Stripe indigo) */
+  --accent: #635bff;
+  --accent-hover: #5349e0;
+  --accent-subtle: #f5f4ff;
+
+  /* Status */
+  --success: #0e6245;
+  --success-bg: #d7f7c2;
+  --warning: #983705;
+  --warning-bg: #fcedb9;
+  --danger: #a41c4e;
+  --danger-bg: #ffe7f2;
+  --info: #3d4eac;
+  --info-bg: #e6e6fc;
+
+  /* Spacing (4px grid) */
+  --space-1: 0.25rem;   /* 4px */
+  --space-2: 0.5rem;    /* 8px */
+  --space-3: 0.75rem;   /* 12px */
+  --space-4: 1rem;      /* 16px */
+  --space-5: 1.25rem;   /* 20px */
+  --space-6: 1.5rem;    /* 24px */
+  --space-8: 2rem;      /* 32px */
+  --space-10: 2.5rem;   /* 40px */
+  --space-12: 3rem;     /* 48px */
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* Shadow */
+  --shadow-sm: 0 1px 3px rgba(26, 31, 54, 0.08);
+  --shadow-md: 0 4px 12px rgba(26, 31, 54, 0.1);
+  --shadow-lg: 0 12px 32px rgba(26, 31, 54, 0.12);
+
+  /* Typography */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 0.938rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+  --text-2xl: 1.75rem;
+
+  /* Layout */
+  --sidebar-w: 240px;
+  --sidebar-w-rail: 64px;
+  --content-max-w: 1400px;
+
+  /* Motion */
+  --transition: 0.18s ease;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -170,200 +209,117 @@ export default {
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
+  background: var(--surface-subtle);
+  color: var(--text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 .app {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  min-height: 100vh;
+  transition: grid-template-columns var(--transition);
+}
+
+.app.sidebar-collapsed {
+  grid-template-columns: var(--sidebar-w-rail) 1fr;
+}
+
+.app-main {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-}
-
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
-}
-
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
-}
-
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
-}
-
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+  min-width: 0;
 }
 
 .main-content {
   flex: 1;
-  max-width: 1600px;
+  max-width: var(--content-max-w);
   width: 100%;
   margin: 0 auto;
-  padding: 1.5rem 2rem;
+  padding: var(--space-6) var(--space-8);
 }
 
 .page-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .page-header h2 {
-  font-size: 1.875rem;
+  font-size: var(--text-2xl);
   font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 0.375rem;
+  color: var(--text);
+  margin-bottom: var(--space-1);
   letter-spacing: -0.025em;
 }
 
 .page-header p {
-  color: #64748b;
-  font-size: 0.938rem;
+  color: var(--text-muted);
+  font-size: var(--text-base);
 }
 
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
 }
 
 .stat-card {
-  background: white;
-  padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  transition: all 0.2s ease;
+  background: var(--surface);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition);
 }
 
 .stat-card:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-md);
 }
 
 .stat-label {
-  color: #64748b;
-  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 0.625rem;
+  margin-bottom: var(--space-2);
 }
 
 .stat-value {
   font-size: 2.25rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text);
   letter-spacing: -0.025em;
 }
 
-.stat-card.warning .stat-value {
-  color: #ea580c;
-}
-
-.stat-card.success .stat-value {
-  color: #059669;
-}
-
-.stat-card.danger .stat-value {
-  color: #dc2626;
-}
-
-.stat-card.info .stat-value {
-  color: #2563eb;
-}
+.stat-card.warning .stat-value { color: var(--warning); }
+.stat-card.success .stat-value { color: var(--success); }
+.stat-card.danger .stat-value { color: var(--danger); }
+.stat-card.info .stat-value { color: var(--accent); }
 
 .card {
-  background: white;
-  border-radius: 10px;
-  padding: 1.25rem;
-  border: 1px solid #e2e8f0;
-  margin-bottom: 1.25rem;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-5);
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 0.875rem;
-  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
 }
 
 .card-title {
-  font-size: 1.125rem;
+  font-size: var(--text-lg);
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text);
   letter-spacing: -0.025em;
 }
 
@@ -377,110 +333,65 @@ table {
 }
 
 thead {
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--surface-subtle);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 }
 
 th {
   text-align: left;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   font-weight: 600;
-  color: #475569;
-  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 td {
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid #f1f5f9;
-  color: #334155;
-  font-size: 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--border);
+  color: var(--text);
+  font-size: var(--text-sm);
 }
 
 tbody tr {
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition);
 }
 
 tbody tr:hover {
-  background: #f8fafc;
+  background: var(--surface-subtle);
 }
 
 .badge {
   display: inline-block;
-  padding: 0.313rem 0.75rem;
-  border-radius: 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.025em;
 }
 
-.badge.success {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.badge.warning {
-  background: #fed7aa;
-  color: #92400e;
-}
-
-.badge.danger {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.info {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
-.badge.increasing {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.badge.decreasing {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.stable {
-  background: #e0e7ff;
-  color: #3730a3;
-}
-
-.badge.high {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.medium {
-  background: #fed7aa;
-  color: #92400e;
-}
-
-.badge.low {
-  background: #dbeafe;
-  color: #1e40af;
-}
+.badge.success, .badge.increasing { background: var(--success-bg); color: var(--success); }
+.badge.warning, .badge.medium { background: var(--warning-bg); color: var(--warning); }
+.badge.danger, .badge.decreasing, .badge.high { background: var(--danger-bg); color: var(--danger); }
+.badge.info, .badge.stable, .badge.low { background: var(--info-bg); color: var(--info); }
 
 .loading {
   text-align: center;
-  padding: 3rem;
-  color: #64748b;
-  font-size: 0.938rem;
+  padding: var(--space-12);
+  color: var(--text-muted);
+  font-size: var(--text-base);
 }
 
 .error {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
-  font-size: 0.938rem;
+  background: var(--danger-bg);
+  border: 1px solid var(--danger);
+  color: var(--danger);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  margin: var(--space-4) 0;
+  font-size: var(--text-base);
 }
 </style>

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -102,64 +102,63 @@ export default {
 
 <style scoped>
 .filters-bar {
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
-  padding: 0.75rem 0;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: var(--space-4) var(--space-8);
   position: sticky;
-  top: 70px;
+  top: 0;
   z-index: 90;
 }
 
 .filters-container {
-  max-width: 1600px;
+  max-width: var(--content-max-w);
   margin: 0 auto;
-  padding: 0 2rem;
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .filters-grid {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
   flex: 1;
 }
 
 .filter-group {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .filter-group label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   white-space: nowrap;
 }
 
 .filter-select {
-  padding: 0.4rem 0.75rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
+  padding: 0.4rem var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
   font-size: 0.813rem;
-  color: #0f172a;
-  background: white;
+  color: var(--text);
+  background: var(--surface);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--transition);
   font-weight: 500;
   min-width: 140px;
 }
 
 .filter-select:hover {
-  border-color: #94a3b8;
+  border-color: var(--text-subtle);
 }
 
 .filter-select:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(99, 91, 255, 0.1);
 }
 
 .reset-filters-btn {
@@ -167,19 +166,19 @@ export default {
   align-items: center;
   justify-content: center;
   padding: 0.4rem;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  color: #64748b;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--transition);
   flex-shrink: 0;
 }
 
 .reset-filters-btn:hover:not(:disabled) {
-  background: #f8fafc;
-  border-color: #cbd5e1;
-  color: #0f172a;
+  background: var(--surface-subtle);
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 .reset-filters-btn:disabled {

--- a/client/src/components/SidebarNav.vue
+++ b/client/src/components/SidebarNav.vue
@@ -1,0 +1,220 @@
+<template>
+  <aside class="sidebar-nav" :class="{ collapsed: isCollapsed }">
+    <div class="sidebar-header">
+      <div class="logo" v-show="!isCollapsed">
+        <h1>{{ t('nav.companyName') }}</h1>
+        <span class="subtitle">{{ t('nav.subtitle') }}</span>
+      </div>
+      <button class="collapse-btn" @click="toggle" :aria-label="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+        <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8">
+          <path d="M11 5l-5 5 5 5M16 5l-5 5 5 5" />
+        </svg>
+      </button>
+    </div>
+
+    <nav class="nav-items">
+      <router-link
+        v-for="item in navItems"
+        :key="item.path"
+        :to="item.path"
+        class="nav-item"
+        :title="isCollapsed ? t(item.label) : null"
+      >
+        <span class="nav-icon" v-html="item.icon" />
+        <span class="nav-label">{{ t(item.label) }}</span>
+      </router-link>
+    </nav>
+
+    <div class="sidebar-footer">
+      <LanguageSwitcher v-show="!isCollapsed" />
+      <ProfileMenu
+        @show-profile-details="$emit('show-profile-details')"
+        @show-tasks="$emit('show-tasks')"
+      />
+    </div>
+  </aside>
+</template>
+
+<script>
+import { useSidebar } from '../composables/useSidebar'
+import { useI18n } from '../composables/useI18n'
+import LanguageSwitcher from './LanguageSwitcher.vue'
+import ProfileMenu from './ProfileMenu.vue'
+
+const ICONS = {
+  dashboard: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="6" height="8" rx="1"/><rect x="11" y="3" width="6" height="5" rx="1"/><rect x="11" y="10" width="6" height="7" rx="1"/><rect x="3" y="13" width="6" height="4" rx="1"/></svg>',
+  package: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M10 2l7 4v8l-7 4-7-4V6l7-4z"/><path d="M3 6l7 4 7-4M10 10v8"/></svg>',
+  cart: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 3h2l2 10h8l2-7H6"/><circle cx="8" cy="16" r="1.5"/><circle cx="14" cy="16" r="1.5"/></svg>',
+  dollar: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M10 3v14M13 6H8.5a2.5 2.5 0 000 5h3a2.5 2.5 0 010 5H6"/></svg>',
+  trending: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 14l4-4 3 3 7-7"/><path d="M13 6h4v4"/></svg>',
+  file: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M11 3H5a1 1 0 00-1 1v12a1 1 0 001 1h10a1 1 0 001-1V8l-5-5z"/><path d="M11 3v5h5M7 11h6M7 14h6"/></svg>'
+}
+
+export default {
+  name: 'SidebarNav',
+  components: { LanguageSwitcher, ProfileMenu },
+  emits: ['show-profile-details', 'show-tasks'],
+  setup() {
+    const { isCollapsed, toggle } = useSidebar()
+    const { t } = useI18n()
+
+    const navItems = [
+      { path: '/', label: 'nav.overview', icon: ICONS.dashboard },
+      { path: '/inventory', label: 'nav.inventory', icon: ICONS.package },
+      { path: '/orders', label: 'nav.orders', icon: ICONS.cart },
+      { path: '/spending', label: 'nav.finance', icon: ICONS.dollar },
+      { path: '/demand', label: 'nav.demandForecast', icon: ICONS.trending },
+      { path: '/reports', label: 'nav.reports', icon: ICONS.file }
+    ]
+
+    return { isCollapsed, toggle, t, navItems }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  min-height: 70px;
+}
+
+.logo h1 {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.025em;
+}
+
+.logo .subtitle {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.collapse-btn {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition);
+}
+
+.collapse-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.collapse-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.collapsed .collapse-btn svg {
+  transform: rotate(180deg);
+}
+
+.nav-items {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  overflow-y: auto;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  transition: all var(--transition);
+  position: relative;
+}
+
+.nav-item:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.nav-item.router-link-exact-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.nav-item.router-link-exact-active::before {
+  content: '';
+  position: absolute;
+  left: calc(-1 * var(--space-3));
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+}
+
+.nav-icon :deep(svg) {
+  width: 100%;
+  height: 100%;
+}
+
+.nav-label {
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.collapsed .nav-label {
+  display: none;
+}
+
+.collapsed .nav-item {
+  justify-content: center;
+  padding: var(--space-2);
+}
+
+.sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+
+.collapsed .sidebar-header {
+  justify-content: center;
+}
+</style>

--- a/client/src/composables/useSidebar.js
+++ b/client/src/composables/useSidebar.js
@@ -1,0 +1,12 @@
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'sidebar-collapsed'
+const isCollapsed = ref(localStorage.getItem(STORAGE_KEY) === 'true')
+
+export function useSidebar() {
+  const toggle = () => {
+    isCollapsed.value = !isCollapsed.value
+    localStorage.setItem(STORAGE_KEY, isCollapsed.value)
+  }
+  return { isCollapsed, toggle }
+}

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    reports: 'Reports',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    reports: 'レポート',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -304,12 +304,14 @@ import { useI18n } from '../composables/useI18n'
 import { formatCurrency } from '../utils/currency'
 import ProductDetailModal from '../components/ProductDetailModal.vue'
 import BacklogDetailModal from '../components/BacklogDetailModal.vue'
+import PurchaseOrderModal from '../components/PurchaseOrderModal.vue'
 
 export default {
   name: 'Dashboard',
   components: {
     ProductDetailModal,
     BacklogDetailModal,
+    PurchaseOrderModal,
   },
   setup() {
     const { t, currentCurrency, translateProductName, translateWarehouse } = useI18n()
@@ -731,48 +733,48 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
 }
 
 .header-meta {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .kpi-section {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .section-title {
-  font-size: 1rem;
+  font-size: var(--text-base);
   font-weight: 600;
-  color: #475569;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
 }
 
 .kpi-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .kpi-card {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
 }
 
 .kpi-header {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
 }
 
 .kpi-label {
   font-size: 0.813rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.025em;
 }
@@ -780,28 +782,28 @@ export default {
 .kpi-value {
   font-size: 2rem;
   font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 0.5rem;
+  color: var(--text);
+  margin-bottom: var(--space-2);
   letter-spacing: -0.025em;
 }
 
 .kpi-goal {
   font-size: 0.813rem;
-  color: #64748b;
-  margin-bottom: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: var(--space-3);
 }
 
 .kpi-progress-bar {
   width: 100%;
   height: 6px;
-  background: #f1f5f9;
+  background: var(--surface-hover);
   border-radius: 3px;
   overflow: hidden;
 }
 
 .kpi-progress {
   height: 100%;
-  background: #3b82f6;
+  background: var(--accent);
   border-radius: 3px;
   transition: width 0.6s ease;
 }
@@ -813,8 +815,8 @@ export default {
 .charts-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: var(--space-5);
+  margin-bottom: var(--space-6);
 }
 
 .chart-card.full-width {
@@ -822,7 +824,7 @@ export default {
 }
 
 .chart-content {
-  padding: 1rem;
+  padding: var(--space-4);
 }
 
 .donut-chart {
@@ -840,15 +842,15 @@ export default {
 .donut-legend {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
   gap: 0.625rem;
-  font-size: 0.875rem;
-  color: #475569;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
 }
 
 .legend-dot {
@@ -861,9 +863,9 @@ export default {
 .order-health-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  gap: var(--space-6);
   align-items: center;
-  padding: 1rem;
+  padding: var(--space-4);
   min-height: 240px;
 }
 
@@ -872,8 +874,8 @@ export default {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  padding: 0 1rem;
+  gap: var(--space-4);
+  padding: 0 var(--space-4);
 }
 
 .donut-svg-compact {
@@ -883,7 +885,7 @@ export default {
 
 .donut-center-label {
   font-size: 12px;
-  fill: #64748b;
+  fill: var(--text-muted);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -891,29 +893,29 @@ export default {
 
 .donut-center-value {
   font-size: 36px;
-  fill: #0f172a;
+  fill: var(--text);
   font-weight: 700;
 }
 
 .donut-legend-compact {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 0.625rem 1.25rem;
+  gap: 0.625rem var(--space-5);
 }
 
 .legend-item-compact {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-  color: #475569;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
   font-weight: 500;
 }
 
 .order-health-metrics {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: var(--space-5);
   justify-content: center;
   align-items: center;
 }
@@ -928,7 +930,7 @@ export default {
 
 .health-metric-label {
   font-size: 0.688rem;
-  color: #64748b;
+  color: var(--text-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -937,7 +939,7 @@ export default {
 .health-metric-value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text);
   letter-spacing: -0.025em;
 }
 
@@ -956,30 +958,30 @@ export default {
 .horizontal-bar-chart {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 0 1rem;
+  gap: var(--space-6);
+  padding: 0 var(--space-4);
 }
 
 .h-bar-item {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .h-bar-label {
   width: 120px;
   min-width: 120px;
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-weight: 600;
-  color: #475569;
+  color: var(--text-muted);
   flex-shrink: 0;
 }
 
 .h-bar-container {
   flex: 1;
   height: 32px;
-  background: #f8fafc;
-  border-radius: 6px;
+  background: var(--surface-subtle);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -988,7 +990,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding-right: 0.75rem;
+  padding-right: var(--space-3);
   transition: width 0.6s ease;
 }
 
@@ -1000,7 +1002,7 @@ export default {
 
 .line-chart {
   display: flex;
-  gap: 1.5rem;
+  gap: var(--space-6);
   height: 280px;
 }
 
@@ -1008,10 +1010,10 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-right: 1rem;
-  font-size: 0.75rem;
-  color: #94a3b8;
-  border-right: 1px solid #e2e8f0;
+  padding-right: var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  border-right: 1px solid var(--border);
 }
 
 .line-chart-area {
@@ -1019,7 +1021,7 @@ export default {
   display: flex;
   align-items: flex-end;
   justify-content: space-around;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .line-bar-group {
@@ -1028,7 +1030,7 @@ export default {
   align-items: center;
   flex: 1;
   max-width: 80px;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .line-bar-wrapper {
@@ -1044,50 +1046,50 @@ export default {
   width: 100%;
   max-width: 60px;
   min-height: 8px;
-  background: #3b82f6;
-  border-radius: 6px 6px 0 0;
+  background: var(--accent);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   transition: all 0.3s ease;
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
+  box-shadow: var(--shadow-sm);
 }
 
 .line-bar.empty-bar {
-  background: #e2e8f0;
+  background: var(--border);
   box-shadow: none;
   min-height: 4px;
 }
 
 .line-bar:hover {
-  background: #2563eb;
+  background: var(--accent-hover);
   transform: scaleY(1.05);
 }
 
 .line-bar.empty-bar:hover {
-  background: #cbd5e1;
+  background: var(--border-strong);
   transform: none;
 }
 
 .line-bar-label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   white-space: nowrap;
 }
 
 .no-data {
-  padding: 2rem;
+  padding: var(--space-8);
   text-align: center;
-  color: #94a3b8;
-  font-size: 0.875rem;
+  color: var(--text-subtle);
+  font-size: var(--text-sm);
 }
 
 .no-backlog {
-  padding: 3rem;
+  padding: var(--space-12);
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .success-icon {
@@ -1097,7 +1099,7 @@ export default {
 }
 
 .no-backlog-text {
-  font-size: 1.125rem;
+  font-size: var(--text-lg);
   color: #10b981;
   font-weight: 600;
   margin: 0;
@@ -1105,35 +1107,35 @@ export default {
 
 .clickable-row {
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition);
 }
 
 .clickable-row:hover {
-  background: #eff6ff !important;
+  background: var(--accent-subtle) !important;
 }
 
 /* Tasks Card Styles */
 .tasks-card {
-  margin-bottom: 2rem;
+  margin-bottom: var(--space-8);
 }
 
 .tasks-content {
-  padding: 1.5rem;
+  padding: var(--space-6);
 }
 
 .task-input-container {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
 }
 
 .task-input {
   flex: 1;
-  padding: 0.75rem;
-  border: 2px solid #e2e8f0;
-  border-radius: 8px;
+  padding: var(--space-3);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-lg);
   font-size: 0.95rem;
-  transition: border-color 0.2s ease;
+  transition: border-color var(--transition);
 }
 
 .task-input:focus {
@@ -1142,14 +1144,14 @@ export default {
 }
 
 .task-add-btn {
-  padding: 0.75rem 1.5rem;
+  padding: var(--space-3) var(--space-6);
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  transition: transform var(--transition), opacity var(--transition);
 }
 
 .task-add-btn:hover:not(:disabled) {
@@ -1163,31 +1165,31 @@ export default {
 
 .no-tasks {
   text-align: center;
-  padding: 2rem;
-  color: #64748b;
+  padding: var(--space-8);
+  color: var(--text-muted);
   font-style: italic;
 }
 
 .tasks-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .task-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  background: #f8fafc;
-  border-radius: 8px;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--surface-subtle);
+  border-radius: var(--radius-lg);
   border: 2px solid transparent;
-  transition: all 0.2s ease;
+  transition: all var(--transition);
 }
 
 .task-item:hover {
-  border-color: #e2e8f0;
-  background: white;
+  border-color: var(--border);
+  background: var(--surface);
 }
 
 .task-item.completed {
@@ -1196,7 +1198,7 @@ export default {
 
 .task-item.completed .task-text {
   text-decoration: line-through;
-  color: #94a3b8;
+  color: var(--text-subtle);
 }
 
 .task-checkbox {
@@ -1210,7 +1212,7 @@ export default {
   flex: 1;
   cursor: pointer;
   user-select: none;
-  color: #0f172a;
+  color: var(--text);
   font-size: 0.95rem;
 }
 
@@ -1220,11 +1222,11 @@ export default {
   background: #ef4444;
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--transition);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1237,35 +1239,35 @@ export default {
 }
 
 .po-button {
-  padding: 0.5rem 1rem;
+  padding: var(--space-2) var(--space-4);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.813rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--transition);
   white-space: nowrap;
 }
 
 .po-button.create {
-  background: #3b82f6;
+  background: var(--accent);
   color: white;
 }
 
 .po-button.create:hover {
-  background: #2563eb;
+  background: var(--accent-hover);
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
+  box-shadow: var(--shadow-sm);
 }
 
 .po-button.view {
-  background: #64748b;
+  background: var(--text-muted);
   color: white;
 }
 
 .po-button.view:hover {
-  background: #475569;
+  background: var(--text);
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(100, 116, 139, 0.3);
+  box-shadow: var(--shadow-sm);
 }
 </style>

--- a/client/src/views/Demand.vue
+++ b/client/src/views/Demand.vue
@@ -227,20 +227,20 @@ export default {
 .demand-trend-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 2rem;
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
 }
 
 .trend-card {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 1.5rem;
-  transition: all 0.2s ease;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  transition: all var(--transition);
 }
 
 .trend-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-md);
 }
 
 .increasing-card {
@@ -248,7 +248,7 @@ export default {
 }
 
 .stable-card {
-  border-left: 4px solid #3b82f6;
+  border-left: 4px solid var(--accent);
 }
 
 .decreasing-card {
@@ -258,10 +258,10 @@ export default {
 .trend-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid #f1f5f9;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--surface-hover);
 }
 
 .trend-icon {
@@ -270,31 +270,31 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   font-size: 1.75rem;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .increasing-card .trend-icon {
-  background: #d1fae5;
-  color: #059669;
+  background: var(--success-bg);
+  color: var(--success);
 }
 
 .stable-card .trend-icon {
-  background: #dbeafe;
-  color: #2563eb;
+  background: var(--info-bg);
+  color: var(--info);
 }
 
 .decreasing-card .trend-icon {
-  background: #fee2e2;
-  color: #dc2626;
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .trend-label {
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -302,39 +302,39 @@ export default {
 .trend-count {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #0f172a;
-  margin-top: 0.25rem;
+  color: var(--text);
+  margin-top: var(--space-1);
 }
 
 .trend-items {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .trend-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0.75rem;
-  background: #f8fafc;
-  border-radius: 6px;
-  transition: background 0.2s;
+  padding: var(--space-2) var(--space-3);
+  background: var(--surface-subtle);
+  border-radius: var(--radius-md);
+  transition: background var(--transition);
 }
 
 .trend-item:hover {
-  background: #f1f5f9;
+  background: var(--surface-hover);
 }
 
 .item-name {
-  font-size: 0.875rem;
-  color: #0f172a;
+  font-size: var(--text-sm);
+  color: var(--text);
   font-weight: 500;
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: 1rem;
+  margin-right: var(--space-4);
 }
 
 .item-change {
@@ -344,26 +344,26 @@ export default {
 }
 
 .increasing-card .item-change {
-  color: #059669;
+  color: var(--success);
 }
 
 .stable-card .item-change {
-  color: #3b82f6;
+  color: var(--accent);
 }
 
 .decreasing-card .item-change {
-  color: #dc2626;
+  color: var(--danger);
 }
 
 .item-change.neutral {
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .more-items {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--text-muted);
   font-style: italic;
   text-align: center;
-  padding: 0.5rem;
+  padding: var(--space-2);
 }
 </style>

--- a/client/src/views/Inventory.vue
+++ b/client/src/views/Inventory.vue
@@ -226,31 +226,31 @@ export default {
 
 <style scoped>
 .page-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .page-header h2 {
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 .page-header p {
-  color: #64748b;
-  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1.5rem;
-  padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
+  gap: var(--space-6);
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--border);
 }
 
 .card-title {
-  font-size: 1rem;
+  font-size: var(--text-base);
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text);
   margin: 0;
 }
 
@@ -263,53 +263,53 @@ export default {
 
 .search-icon {
   position: absolute;
-  left: 0.75rem;
+  left: var(--space-3);
   width: 18px;
   height: 18px;
-  color: #94a3b8;
+  color: var(--text-subtle);
   pointer-events: none;
 }
 
 .search-input {
   width: 100%;
-  padding: 0.5rem 2.5rem 0.5rem 2.5rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  font-size: 0.875rem;
-  color: #0f172a;
-  background: #f8fafc;
-  transition: all 0.2s;
+  padding: var(--space-2) 2.5rem var(--space-2) 2.5rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
+  color: var(--text);
+  background: var(--surface-subtle);
+  transition: all var(--transition);
 }
 
 .search-input:focus {
   outline: none;
-  border-color: #3b82f6;
-  background: white;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--accent);
+  background: var(--surface);
+  box-shadow: 0 0 0 3px rgba(99, 91, 255, 0.1);
 }
 
 .search-input::placeholder {
-  color: #94a3b8;
+  color: var(--text-subtle);
 }
 
 .clear-search {
   position: absolute;
-  right: 0.5rem;
+  right: var(--space-2);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem;
+  padding: var(--space-1);
   background: transparent;
   border: none;
-  border-radius: 4px;
-  color: #94a3b8;
+  border-radius: var(--radius-sm);
+  color: var(--text-subtle);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--transition);
 }
 
 .clear-search:hover {
-  background: #e2e8f0;
-  color: #64748b;
+  background: var(--border);
+  color: var(--text-muted);
 }
 
 .clear-search svg {
@@ -319,9 +319,9 @@ export default {
 
 .loading,
 .error {
-  padding: 2rem;
+  padding: var(--space-8);
   text-align: center;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .error {
@@ -330,10 +330,10 @@ export default {
 
 .clickable-row {
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition);
 }
 
 .clickable-row:hover {
-  background: #eff6ff !important;
+  background: var(--accent-subtle) !important;
 }
 </style>

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -210,7 +210,7 @@ export default {
 
 .items-summary {
   cursor: pointer;
-  color: #3b82f6;
+  color: var(--accent);
   font-weight: 500;
   list-style: none;
   user-select: none;
@@ -225,8 +225,8 @@ export default {
   content: '▶';
   display: inline-block;
   margin-right: 0.375rem;
-  font-size: 0.75rem;
-  transition: transform 0.2s;
+  font-size: var(--text-xs);
+  transition: transform var(--transition);
 }
 
 .items-details[open] .items-summary::before {
@@ -234,7 +234,7 @@ export default {
 }
 
 .items-summary:hover {
-  color: #2563eb;
+  color: var(--accent-hover);
   text-decoration: underline;
 }
 
@@ -243,12 +243,12 @@ export default {
   position: absolute;
   top: 100%;
   left: 0;
-  margin-top: 0.5rem;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  padding: 0.75rem;
+  margin-top: var(--space-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-3);
   z-index: 10;
   min-width: 300px;
   max-width: 400px;
@@ -257,9 +257,9 @@ export default {
 .item-entry {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.5rem;
-  border-bottom: 1px solid #f1f5f9;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--surface-hover);
 }
 
 .item-entry:last-child {
@@ -267,13 +267,13 @@ export default {
 }
 
 .item-name {
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-weight: 500;
-  color: #0f172a;
+  color: var(--text);
 }
 
 .item-meta {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 </style>

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -142,38 +142,28 @@ export default {
     }
   },
   mounted() {
-    console.log('Reports component mounted')
     this.loadData()
   },
   methods: {
     async loadData() {
-      console.log('Loading reports data...')
       try {
         this.loading = true
 
         // Fetch quarterly data
-        console.log('Fetching quarterly data...')
         const quarterlyResponse = await axios.get('http://localhost:8001/api/reports/quarterly')
         this.quarterlyData = quarterlyResponse.data
-        console.log('Quarterly data:', this.quarterlyData)
 
         // Fetch monthly data
-        console.log('Fetching monthly data...')
         const monthlyResponse = await axios.get('http://localhost:8001/api/reports/monthly-trends')
         this.monthlyData = monthlyResponse.data
-        console.log('Monthly data:', this.monthlyData)
 
         // Calculate summary stats
-        console.log('Calculating summary stats...')
         this.calculateSummaryStats()
-        console.log('Summary stats calculated')
 
       } catch (err) {
-        console.log('Error loading reports:', err)
         this.error = 'Failed to load reports: ' + err.message
       } finally {
         this.loading = false
-        console.log('Loading complete')
       }
     },
 
@@ -212,7 +202,6 @@ export default {
     },
 
     formatNumber(num) {
-      console.log('Formatting number:', num)
       // Format number with commas
       var str = num.toString()
       var parts = str.split('.')
@@ -240,7 +229,6 @@ export default {
     },
 
     formatMonth(monthStr) {
-      console.log('Formatting month:', monthStr)
       // Convert YYYY-MM to readable format
       var parts = monthStr.split('-')
       var year = parts[0]
@@ -253,7 +241,6 @@ export default {
     },
 
     getBarHeight(revenue) {
-      console.log('Calculating bar height for revenue:', revenue)
       // Calculate bar height (max height 200px)
       var maxRevenue = 0
       for (var i = 0; i < this.monthlyData.length; i++) {
@@ -322,21 +309,21 @@ export default {
 }
 
 .card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  margin-bottom: var(--space-6);
+  box-shadow: var(--shadow-sm);
 }
 
 .card-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .card-title {
-  font-size: 1.25rem;
+  font-size: var(--text-xl);
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text);
   margin: 0;
 }
 
@@ -346,25 +333,25 @@ export default {
 }
 
 .reports-table th {
-  background: #f8fafc;
-  padding: 0.75rem;
+  background: var(--surface-subtle);
+  padding: var(--space-3);
   text-align: left;
   font-weight: 600;
-  color: #64748b;
-  border-bottom: 2px solid #e2e8f0;
+  color: var(--text-muted);
+  border-bottom: 2px solid var(--border);
 }
 
 .reports-table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid #e2e8f0;
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
 }
 
 .reports-table tr:hover {
-  background: #f8fafc;
+  background: var(--surface-subtle);
 }
 
 .chart-container {
-  padding: 2rem 1rem;
+  padding: var(--space-8) var(--space-4);
   min-height: 300px;
 }
 
@@ -373,7 +360,7 @@ export default {
   align-items: flex-end;
   justify-content: space-around;
   height: 250px;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .bar-wrapper {
@@ -393,73 +380,73 @@ export default {
 
 .bar {
   width: 100%;
-  background: linear-gradient(to top, #3b82f6, #60a5fa);
-  border-radius: 4px 4px 0 0;
+  background: linear-gradient(to top, var(--accent), #a5a1ff);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   transition: all 0.3s;
   cursor: pointer;
 }
 
 .bar:hover {
-  background: linear-gradient(to top, #2563eb, #3b82f6);
+  background: linear-gradient(to top, var(--accent-hover), var(--accent));
 }
 
 .bar-label {
-  margin-top: 0.5rem;
-  font-size: 0.75rem;
-  color: #64748b;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
   text-align: center;
   transform: rotate(-45deg);
   white-space: nowrap;
-  margin-top: 1.5rem;
+  margin-top: var(--space-6);
 }
 
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-  margin-top: 1.5rem;
+  gap: var(--space-4);
+  margin-top: var(--space-6);
 }
 
 .stat-card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border-left: 4px solid #3b82f6;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  border-left: 4px solid var(--accent);
 }
 
 .stat-label {
-  font-size: 0.875rem;
-  color: #64748b;
-  margin-bottom: 0.5rem;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  margin-bottom: var(--space-2);
 }
 
 .stat-value {
   font-size: 1.875rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text);
 }
 
 .badge {
-  padding: 0.25rem 0.75rem;
+  padding: var(--space-1) var(--space-3);
   border-radius: 9999px;
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-weight: 500;
 }
 
 .badge.success {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success);
 }
 
 .badge.warning {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--warning);
 }
 
 .badge.danger {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .positive-change {
@@ -474,15 +461,15 @@ export default {
 
 .loading {
   text-align: center;
-  padding: 3rem;
-  color: #64748b;
+  padding: var(--space-12);
+  color: var(--text-muted);
 }
 
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
+  background: var(--danger-bg);
+  color: var(--danger);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  margin: var(--space-4) 0;
 }
 </style>

--- a/client/src/views/Spending.vue
+++ b/client/src/views/Spending.vue
@@ -493,11 +493,11 @@ export default {
 
 <style scoped>
 .stat-change {
-  margin-top: 0.75rem;
-  font-size: 0.875rem;
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .stat-change.positive {
@@ -510,7 +510,7 @@ export default {
 
 .change-icon {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: var(--text-base);
 }
 
 .chart-card {
@@ -519,15 +519,15 @@ export default {
 
 .chart-legend {
   display: flex;
-  gap: 1.5rem;
-  font-size: 0.875rem;
+  gap: var(--space-6);
+  font-size: var(--text-sm);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  color: #64748b;
+  gap: var(--space-2);
+  color: var(--text-muted);
 }
 
 .legend-dot {
@@ -536,22 +536,22 @@ export default {
   border-radius: 3px;
 }
 
-.legend-dot.procurement { background: #3b82f6; }
+.legend-dot.procurement { background: var(--accent); }
 .legend-dot.operational { background: #8b5cf6; }
 .legend-dot.labor { background: #10b981; }
 .legend-dot.overhead { background: #f59e0b; }
-.legend-dot.revenue-color { background: #0f172a; }
+.legend-dot.revenue-color { background: var(--text); }
 .legend-dot.cost-color { background: #ef4444; }
 
 .stats-grid-finance {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 2rem;
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
 }
 
 .revenue-card {
-  border-left: 4px solid #0f172a;
+  border-left: 4px solid var(--text);
 }
 
 .cost-card {
@@ -559,13 +559,13 @@ export default {
 }
 
 .profit-card {
-  border-left: 4px solid #3b82f6;
+  border-left: 4px solid var(--accent);
 }
 
 .stat-meta {
-  margin-top: 0.5rem;
+  margin-top: var(--space-2);
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .bar-group-revenue {
@@ -584,20 +584,20 @@ export default {
   justify-content: center;
   align-items: flex-end;
   height: 100%;
-  padding-bottom: 2rem;
+  padding-bottom: var(--space-8);
 }
 
 .revenue-bar, .cost-bar {
   width: 50%;
   max-width: 30px;
-  border-radius: 6px 6px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   transition: all 0.3s ease;
   cursor: pointer;
   min-height: 4px;
 }
 
 .revenue-bar {
-  background: #0f172a;
+  background: var(--text);
 }
 
 .cost-bar {
@@ -610,12 +610,12 @@ export default {
 }
 
 .chart-container {
-  padding: 1.5rem 0;
+  padding: var(--space-6) 0;
 }
 
 .bar-chart {
   display: flex;
-  gap: 1.5rem;
+  gap: var(--space-6);
   height: 350px;
 }
 
@@ -623,10 +623,10 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-right: 1rem;
-  font-size: 0.75rem;
-  color: #94a3b8;
-  border-right: 1px solid #e2e8f0;
+  padding-right: var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  border-right: 1px solid var(--border);
 }
 
 .chart-area {
@@ -634,7 +634,7 @@ export default {
   display: flex;
   align-items: flex-end;
   justify-content: space-around;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .bar-group {
@@ -652,9 +652,9 @@ export default {
   flex-direction: column-reverse;
   align-items: stretch;
   height: 100%;
-  padding-bottom: 2rem;
+  padding-bottom: var(--space-8);
   cursor: pointer;
-  transition: opacity 0.2s ease;
+  transition: opacity var(--transition);
 }
 
 .stacked-bar:hover {
@@ -669,14 +669,14 @@ export default {
 }
 
 .bar-segment:first-child {
-  border-radius: 0 0 6px 6px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .bar-segment:last-child {
-  border-radius: 6px 6px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
-.bar-segment.procurement { background: #3b82f6; }
+.bar-segment.procurement { background: var(--accent); }
 .bar-segment.operational { background: #8b5cf6; }
 .bar-segment.labor { background: #10b981; }
 .bar-segment.overhead { background: #f59e0b; }
@@ -686,10 +686,10 @@ export default {
 }
 
 .bar-label {
-  margin-top: 0.5rem;
-  font-size: 0.75rem;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .two-column-grid {
@@ -701,13 +701,13 @@ export default {
 .category-list {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--space-6);
 }
 
 .category-item {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .category-info {
@@ -718,27 +718,27 @@ export default {
 
 .category-name {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text);
 }
 
 .category-amount {
   font-weight: 700;
-  color: #2563eb;
-  font-size: 1.125rem;
+  color: var(--accent);
+  font-size: var(--text-lg);
 }
 
 .category-bar-container {
   width: 100%;
   height: 8px;
-  background: #f1f5f9;
-  border-radius: 4px;
+  background: var(--surface-hover);
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
 .category-bar {
   height: 100%;
-  background: linear-gradient(90deg, #3b82f6 0%, #2563eb 100%);
-  border-radius: 4px;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-hover) 100%);
+  border-radius: var(--radius-sm);
   transition: width 0.6s ease;
 }
 
@@ -749,7 +749,7 @@ export default {
 }
 
 .percentage {
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .change {
@@ -782,19 +782,19 @@ export default {
 .transactions-table thead {
   position: sticky;
   top: 0;
-  background: #f8fafc;
+  background: var(--surface-subtle);
   z-index: 1;
 }
 
 .transactions-table th {
   text-align: left;
-  padding: 0.625rem 0.75rem;
+  padding: 0.625rem var(--space-3);
   font-weight: 600;
-  color: #475569;
-  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--border);
 }
 
 .transactions-table th.text-right {
@@ -802,48 +802,48 @@ export default {
 }
 
 .transactions-table td {
-  padding: 0.75rem 0.75rem;
-  border-bottom: 1px solid #f1f5f9;
-  font-size: 0.875rem;
+  padding: var(--space-3) var(--space-3);
+  border-bottom: 1px solid var(--surface-hover);
+  font-size: var(--text-sm);
 }
 
 .transactions-table tbody tr {
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition);
 }
 
 .transactions-table tbody tr:hover {
-  background: #f8fafc;
+  background: var(--surface-subtle);
 }
 
 .transactions-table tbody tr.clickable-row:hover {
-  background: #eff6ff;
+  background: var(--accent-subtle);
 }
 
 .transaction-id {
-  color: #64748b;
+  color: var(--text-muted);
   font-weight: 500;
   font-family: 'Monaco', 'Courier New', monospace;
   font-size: 0.813rem;
 }
 
 .transaction-description {
-  color: #0f172a;
+  color: var(--text);
   font-weight: 500;
 }
 
 .transaction-vendor {
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .transaction-date {
-  color: #64748b;
+  color: var(--text-muted);
   font-size: 0.813rem;
 }
 
 .transaction-amount {
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text);
 }
 
 .text-right {


### PR DESCRIPTION
## Summary
- Replaces the horizontal top nav with a collapsible left `SidebarNav` (240px ⇄ 64px icon rail), backed by a new `useSidebar` composable that persists state to localStorage
- Introduces a `:root` CSS design-token block in `App.vue` (Stripe-inspired palette `#635bff`, 4px spacing scale, radius/shadow/typography) and migrates global card/stat/table/badge styles onto tokens
- Retrofits `FilterBar` and six view components to consume token vars instead of hard-coded hex/rem literals (~325 `var(--*)` references, all resolved)
- Adds `nav.reports` to en/ja locales; ships `.claude/skills/saas-redesign` documenting the workflow with token reference and sidebar template

## Test plan
- [x] `cd client && npm run build` — clean, 118 modules, no warnings
- [ ] `npm run dev` → sidebar renders on all routes with correct active highlighting
- [ ] Collapse toggle hides labels and shrinks to 64px rail; state survives page reload
- [ ] FilterBar selections still update dashboard data
- [ ] Language switch (EN ⇄ JA) updates sidebar labels including Reports
- [ ] No Vue console warnings; no horizontal scroll at 1280px