### PR TITLE
Add Restocking tab with budget-based order placement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,6 @@ npm install && npm run dev
 - Status: green/blue/yellow/red
 - Charts: Custom SVG, CSS Grid for layouts
 - No emojis in UI
+
+## Code Style
+- Always document non-obvious logic changes with comments

--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,669 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventory Management — System Architecture</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f172a;
+      --surface: #1e293b;
+      --surface2: #263348;
+      --border: #334155;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --accent-blue: #3b82f6;
+      --accent-green: #22c55e;
+      --accent-yellow: #eab308;
+      --accent-purple: #a855f7;
+      --accent-orange: #f97316;
+      --accent-teal: #14b8a6;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      padding: 2.5rem 1.5rem;
+    }
+
+    .page { max-width: 1100px; margin: 0 auto; }
+
+    /* Header */
+    .header { margin-bottom: 3rem; }
+    .header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    .header p { color: var(--muted); margin-top: 0.4rem; font-size: 0.95rem; }
+    .badge-row { display: flex; gap: 0.5rem; margin-top: 0.9rem; flex-wrap: wrap; }
+    .badge {
+      font-size: 0.72rem; font-weight: 600; padding: 0.25rem 0.65rem;
+      border-radius: 9999px; letter-spacing: 0.04em; text-transform: uppercase;
+    }
+    .badge-blue   { background: #1d4ed8; color: #bfdbfe; }
+    .badge-green  { background: #166534; color: #bbf7d0; }
+    .badge-purple { background: #6b21a8; color: #e9d5ff; }
+
+    /* Sections */
+    section { margin-bottom: 3rem; }
+    h2 {
+      font-size: 0.7rem; font-weight: 700; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--muted);
+      border-bottom: 1px solid var(--border); padding-bottom: 0.6rem;
+      margin-bottom: 1.25rem;
+    }
+
+    /* Stack Cards */
+    .stack-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+    .stack-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.1rem 1.25rem;
+    }
+    .stack-card .label {
+      font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--muted); margin-bottom: 0.45rem;
+    }
+    .stack-card .tech { font-size: 1rem; font-weight: 600; color: #f8fafc; }
+    .stack-card .detail { font-size: 0.8rem; color: var(--muted); margin-top: 0.25rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 0.45rem; }
+    .dot-blue   { background: var(--accent-blue); }
+    .dot-green  { background: var(--accent-green); }
+    .dot-yellow { background: var(--accent-yellow); }
+    .dot-purple { background: var(--accent-purple); }
+    .dot-orange { background: var(--accent-orange); }
+    .dot-teal   { background: var(--accent-teal); }
+
+    /* Architecture Diagram */
+    .arch-diagram {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2rem;
+      overflow-x: auto;
+    }
+    .arch-row {
+      display: flex;
+      align-items: stretch;
+      gap: 0;
+      margin-bottom: 0;
+    }
+    .arch-col {
+      flex: 1;
+      min-width: 160px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
+    .arch-col-label {
+      font-size: 0.65rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.1em; color: var(--muted); text-align: center;
+      margin-bottom: 0.5rem;
+    }
+    .arch-box {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.6rem 0.8rem;
+      font-size: 0.78rem;
+      text-align: center;
+    }
+    .arch-box .name { font-weight: 600; color: #f8fafc; }
+    .arch-box .sub  { font-size: 0.68rem; color: var(--muted); margin-top: 0.15rem; }
+    .arch-box.blue   { border-color: #3b82f680; background: #1e3a5f; }
+    .arch-box.green  { border-color: #22c55e80; background: #14361f; }
+    .arch-box.yellow { border-color: #eab30880; background: #362800; }
+    .arch-box.purple { border-color: #a855f780; background: #2e1a47; }
+    .arch-box.teal   { border-color: #14b8a680; background: #0f2e2b; }
+
+    .arch-arrow {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 56px;
+      flex-shrink: 0;
+      padding-top: 1.6rem;
+    }
+    .arch-arrow-inner {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.2rem;
+    }
+    .arrow-line {
+      width: 2px;
+      height: 20px;
+      background: var(--border);
+    }
+    .arrow-label {
+      font-size: 0.6rem;
+      color: var(--muted);
+      text-align: center;
+      white-space: nowrap;
+    }
+    .arrow-head { font-size: 0.8rem; color: var(--muted); line-height: 1; }
+
+    /* Horizontal flow */
+    .flow {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      padding-bottom: 0.5rem;
+    }
+    .flow-box {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.65rem 1rem;
+      font-size: 0.8rem;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .flow-box .name { font-weight: 600; color: #f8fafc; }
+    .flow-box .sub  { font-size: 0.68rem; color: var(--muted); }
+    .flow-box.blue   { border-color: #3b82f680; background: #1e3a5f; }
+    .flow-box.green  { border-color: #22c55e80; background: #14361f; }
+    .flow-box.yellow { border-color: #eab30880; background: #362800; }
+    .flow-box.purple { border-color: #a855f780; background: #2e1a47; }
+    .flow-arrow {
+      color: var(--muted);
+      font-size: 1rem;
+      padding: 0 0.5rem;
+      flex-shrink: 0;
+    }
+    .flow-arrow-label {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 0.3rem;
+      flex-shrink: 0;
+    }
+    .flow-arrow-label .lbl {
+      font-size: 0.6rem; color: var(--muted); white-space: nowrap;
+    }
+
+    /* Two-col layout */
+    .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+    @media (max-width: 700px) { .two-col { grid-template-columns: 1fr; } }
+
+    /* Table */
+    .table-wrap {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    thead th {
+      background: var(--surface2); color: var(--muted); font-weight: 600;
+      font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.07em;
+      padding: 0.65rem 1rem; text-align: left;
+    }
+    tbody tr { border-top: 1px solid var(--border); }
+    tbody tr:hover { background: #ffffff08; }
+    td { padding: 0.65rem 1rem; vertical-align: top; }
+    td:first-child { font-weight: 600; color: #f8fafc; white-space: nowrap; }
+    .method {
+      font-size: 0.65rem; font-weight: 700; padding: 0.15rem 0.4rem;
+      border-radius: 4px; margin-right: 0.35rem; font-family: monospace;
+    }
+    .get  { background: #14532d; color: #86efac; }
+    .post { background: #1e3a5f; color: #93c5fd; }
+    .patch { background: #362800; color: #fde68a; }
+    .delete { background: #450a0a; color: #fca5a5; }
+    code {
+      font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+      font-size: 0.78em;
+      background: #0f172a;
+      border: 1px solid var(--border);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      color: #a5b4fc;
+    }
+    .pill {
+      display: inline-block; font-size: 0.65rem; font-weight: 600;
+      padding: 0.1rem 0.4rem; border-radius: 9999px; margin: 0.1rem 0.1rem 0 0;
+    }
+    .pill-blue   { background: #1d4ed820; border: 1px solid #3b82f660; color: #93c5fd; }
+    .pill-yellow { background: #71500020; border: 1px solid #eab30860; color: #fde68a; }
+    .pill-green  { background: #14532d20; border: 1px solid #22c55e60; color: #86efac; }
+    .pill-red    { background: #450a0a20; border: 1px solid #ef444460; color: #fca5a5; }
+
+    /* File tree */
+    .filetree {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.25rem 1.5rem;
+      font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+      font-size: 0.78rem;
+      line-height: 1.9;
+    }
+    .filetree .dir  { color: var(--accent-blue); font-weight: 600; }
+    .filetree .file { color: var(--text); }
+    .filetree .comment { color: var(--muted); }
+    .filetree .indent { padding-left: 1.25rem; }
+    .filetree .indent2 { padding-left: 2.5rem; }
+    .filetree .indent3 { padding-left: 3.75rem; }
+
+    /* Composables list */
+    .composable-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1rem; }
+    .composable-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.1rem 1.25rem;
+    }
+    .composable-card h3 { font-size: 0.85rem; font-weight: 700; color: #f8fafc; margin-bottom: 0.5rem; }
+    .composable-card ul { list-style: none; }
+    .composable-card ul li { font-size: 0.78rem; color: var(--muted); padding: 0.15rem 0; }
+    .composable-card ul li::before { content: "—"; margin-right: 0.45rem; color: var(--border); }
+
+    /* Footer */
+    .footer { margin-top: 4rem; text-align: center; color: var(--muted); font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Header -->
+  <div class="header">
+    <h1>Factory Inventory Management — System Architecture</h1>
+    <p>Full-stack demo application with Vue 3 frontend, Python FastAPI backend, and in-memory JSON data.</p>
+    <div class="badge-row">
+      <span class="badge badge-blue">Vue 3</span>
+      <span class="badge badge-green">FastAPI</span>
+      <span class="badge badge-purple">Pydantic v2</span>
+      <span class="badge badge-blue">Vite</span>
+      <span class="badge badge-green">Uvicorn</span>
+    </div>
+  </div>
+
+  <!-- Tech Stack -->
+  <section>
+    <h2>Tech Stack</h2>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="label">Frontend</div>
+        <div class="tech"><span class="dot dot-blue"></span>Vue 3</div>
+        <div class="detail">Composition API + Vue Router 4<br>Port 3000 · Vite dev server</div>
+      </div>
+      <div class="stack-card">
+        <div class="label">Backend</div>
+        <div class="tech"><span class="dot dot-green"></span>FastAPI</div>
+        <div class="detail">Python · Uvicorn ASGI<br>Port 8001 · Auto OpenAPI docs</div>
+      </div>
+      <div class="stack-card">
+        <div class="label">Data Layer</div>
+        <div class="tech"><span class="dot dot-yellow"></span>In-Memory JSON</div>
+        <div class="detail">7 JSON files in <code>server/data/</code><br>Loaded at startup · No DB</div>
+      </div>
+      <div class="stack-card">
+        <div class="label">Validation</div>
+        <div class="tech"><span class="dot dot-purple"></span>Pydantic v2</div>
+        <div class="detail">Request/response models<br>Automatic serialization</div>
+      </div>
+      <div class="stack-card">
+        <div class="label">HTTP Client</div>
+        <div class="tech"><span class="dot dot-orange"></span>Axios</div>
+        <div class="detail">Centralized in <code>api.js</code><br>Base URL: localhost:8001/api</div>
+      </div>
+      <div class="stack-card">
+        <div class="label">Testing</div>
+        <div class="tech"><span class="dot dot-teal"></span>pytest</div>
+        <div class="detail">FastAPI TestClient<br><code>tests/backend/</code> · 30+ tests</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- System Diagram -->
+  <section>
+    <h2>System Layers</h2>
+    <div class="arch-diagram">
+      <div style="display:grid; grid-template-columns: 1fr 60px 1fr 60px 1fr; gap:0; align-items:start;">
+
+        <!-- Browser -->
+        <div>
+          <div class="arch-col-label">Browser (Port 3000)</div>
+          <div style="display:flex;flex-direction:column;gap:0.5rem;">
+            <div class="arch-box blue"><div class="name">App.vue</div><div class="sub">Root + Navigation + Modals</div></div>
+            <div class="arch-box blue"><div class="name">FilterBar.vue</div><div class="sub">4 global filters</div></div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.4rem;">
+              <div class="arch-box blue"><div class="name">Dashboard</div></div>
+              <div class="arch-box blue"><div class="name">Inventory</div></div>
+              <div class="arch-box blue"><div class="name">Orders</div></div>
+              <div class="arch-box blue"><div class="name">Spending</div></div>
+              <div class="arch-box blue"><div class="name">Demand</div></div>
+              <div class="arch-box blue"><div class="name">Backlog</div></div>
+            </div>
+            <div class="arch-box purple"><div class="name">Composables</div><div class="sub">useFilters · useAuth · useI18n</div></div>
+            <div class="arch-box purple"><div class="name">api.js</div><div class="sub">Axios HTTP client</div></div>
+          </div>
+        </div>
+
+        <!-- Arrow 1 -->
+        <div style="display:flex;align-items:center;justify-content:center;padding-top:3.5rem;flex-direction:column;gap:0.2rem;">
+          <div style="font-size:0.6rem;color:var(--muted);text-align:center;">HTTP<br>JSON</div>
+          <div style="font-size:1.2rem;color:var(--muted);">&#8644;</div>
+        </div>
+
+        <!-- FastAPI -->
+        <div>
+          <div class="arch-col-label">FastAPI (Port 8001)</div>
+          <div style="display:flex;flex-direction:column;gap:0.5rem;">
+            <div class="arch-box green"><div class="name">main.py</div><div class="sub">14 REST endpoints · CORS</div></div>
+            <div class="arch-box green"><div class="name">Filter Functions</div><div class="sub">apply_filters() · filter_by_month()</div></div>
+            <div class="arch-box green"><div class="name">Pydantic Models</div><div class="sub">InventoryItem · Order · BacklogItem</div></div>
+            <div class="arch-box green"><div class="name">mock_data.py</div><div class="sub">JSON loader · in-memory store</div></div>
+          </div>
+        </div>
+
+        <!-- Arrow 2 -->
+        <div style="display:flex;align-items:center;justify-content:center;padding-top:3.5rem;flex-direction:column;gap:0.2rem;">
+          <div style="font-size:0.6rem;color:var(--muted);text-align:center;">Read<br>only</div>
+          <div style="font-size:1.2rem;color:var(--muted);">&#8592;</div>
+        </div>
+
+        <!-- Data -->
+        <div>
+          <div class="arch-col-label">Data (server/data/)</div>
+          <div style="display:flex;flex-direction:column;gap:0.5rem;">
+            <div class="arch-box yellow"><div class="name">inventory.json</div><div class="sub">95 SKUs · 3 warehouses</div></div>
+            <div class="arch-box yellow"><div class="name">orders.json</div><div class="sub">~2,000 orders · Jan–Dec 2025</div></div>
+            <div class="arch-box yellow"><div class="name">spending.json</div><div class="sub">Monthly cost breakdown</div></div>
+            <div class="arch-box yellow"><div class="name">demand_forecasts.json</div><div class="sub">9 items · trend data</div></div>
+            <div class="arch-box yellow"><div class="name">backlog_items.json</div><div class="sub">4 shortage records</div></div>
+            <div class="arch-box yellow"><div class="name">transactions.json</div><div class="sub">40+ ledger entries</div></div>
+            <div class="arch-box yellow"><div class="name">purchase_orders.json</div><div class="sub">Writable at runtime</div></div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- Data Flow -->
+  <section>
+    <h2>Filter Data Flow</h2>
+    <div class="arch-diagram">
+      <div style="margin-bottom:0.75rem;font-size:0.75rem;color:var(--muted);">Example: User selects London warehouse + Sensors category + Q1-2025</div>
+      <div class="flow">
+        <div class="flow-box blue">
+          <div class="name">FilterBar.vue</div>
+          <div class="sub">User selects filters</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box purple">
+          <div class="name">useFilters.js</div>
+          <div class="sub">Reactive singleton state</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box blue">
+          <div class="name">View Component</div>
+          <div class="sub">Watches filter refs</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box blue">
+          <div class="name">api.js</div>
+          <div class="sub">Builds query string</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box green">
+          <div class="name">FastAPI endpoint</div>
+          <div class="sub">Receives query params</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box green">
+          <div class="name">apply_filters()</div>
+          <div class="sub">warehouse · category · status</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box green">
+          <div class="name">filter_by_month()</div>
+          <div class="sub">Q1-2025 &#8594; Jan/Feb/Mar</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box yellow">
+          <div class="name">JSON Response</div>
+          <div class="sub">Pydantic-validated</div>
+        </div>
+        <div class="flow-arrow">&#8594;</div>
+        <div class="flow-box blue">
+          <div class="name">Reactive refs</div>
+          <div class="sub">Vue re-renders UI</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- API Endpoints -->
+  <section>
+    <h2>API Endpoints</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Endpoint</th>
+            <th>Description</th>
+            <th>Filters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/inventory</code></td>
+            <td>All inventory SKUs with stock levels</td>
+            <td><span class="pill pill-blue">warehouse</span><span class="pill pill-green">category</span></td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/inventory/{id}</code></td>
+            <td>Single inventory item by ID</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/orders</code></td>
+            <td>Orders with customer, items, status, value</td>
+            <td><span class="pill pill-blue">warehouse</span><span class="pill pill-green">category</span><span class="pill pill-yellow">status</span><span class="pill pill-red">month</span></td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/orders/{id}</code></td>
+            <td>Single order by ID</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/dashboard/summary</code></td>
+            <td>KPI metrics: inventory value, low stock, pending orders</td>
+            <td><span class="pill pill-blue">warehouse</span><span class="pill pill-green">category</span><span class="pill pill-yellow">status</span><span class="pill pill-red">month</span></td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/demand</code></td>
+            <td>Demand forecasts grouped by trend</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/backlog</code></td>
+            <td>Shortage items with purchase order flag</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/spending/summary</code></td>
+            <td>Procurement, operational, labor, overhead totals</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/spending/monthly</code></td>
+            <td>12-month cost breakdown by type</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/spending/categories</code></td>
+            <td>Spending by category with % and change</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/spending/transactions</code></td>
+            <td>Transaction ledger</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/reports/quarterly</code></td>
+            <td>Quarterly performance metrics (Q1–Q4)</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method get">GET</span><code>/api/reports/monthly-trends</code></td>
+            <td>Month-over-month order count and revenue</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td><span class="method post">POST</span><code>/api/purchase-orders</code></td>
+            <td>Create purchase order for backlog item</td>
+            <td>—</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- Composables + File Tree -->
+  <section>
+    <h2>Frontend Architecture</h2>
+    <div class="two-col">
+      <div>
+        <div style="font-size:0.72rem;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:0.07em;margin-bottom:0.75rem;">Composables (Shared State)</div>
+        <div style="display:flex;flex-direction:column;gap:0.75rem;">
+          <div class="composable-card">
+            <h3>useFilters.js</h3>
+            <ul>
+              <li>Singleton reactive filter state</li>
+              <li>selectedPeriod, selectedLocation, selectedCategory, selectedStatus</li>
+              <li>getCurrentFilters() maps UI state to API params</li>
+              <li>hasActiveFilters computed for reset button</li>
+            </ul>
+          </div>
+          <div class="composable-card">
+            <h3>useAuth.js</h3>
+            <ul>
+              <li>Mock current user with name, role, department</li>
+              <li>4 pending tasks with priority and due dates</li>
+              <li>getInitials(), logout()</li>
+            </ul>
+          </div>
+          <div class="composable-card">
+            <h3>useI18n.js</h3>
+            <ul>
+              <li>English / Japanese locale toggle</li>
+              <li>Currency mapping: en&#8594;USD, ja&#8594;JPY</li>
+              <li>translateProductName(), translateWarehouse()</li>
+              <li>Placeholder replacement in translation strings</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size:0.72rem;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:0.07em;margin-bottom:0.75rem;">File Structure</div>
+        <div class="filetree">
+          <div><span class="dir">inventory-management/</span></div>
+          <div class="indent"><span class="dir">client/src/</span></div>
+          <div class="indent2"><span class="dir">views/</span> <span class="comment">— page components</span></div>
+          <div class="indent3"><span class="file">Dashboard.vue</span></div>
+          <div class="indent3"><span class="file">Inventory.vue</span></div>
+          <div class="indent3"><span class="file">Orders.vue</span></div>
+          <div class="indent3"><span class="file">Spending.vue</span></div>
+          <div class="indent3"><span class="file">Demand.vue</span></div>
+          <div class="indent3"><span class="file">Backlog.vue</span></div>
+          <div class="indent2"><span class="dir">components/</span> <span class="comment">— reusable UI</span></div>
+          <div class="indent3"><span class="file">FilterBar.vue</span></div>
+          <div class="indent3"><span class="file">*DetailModal.vue</span></div>
+          <div class="indent2"><span class="dir">composables/</span> <span class="comment">— shared logic</span></div>
+          <div class="indent3"><span class="file">useFilters.js</span></div>
+          <div class="indent3"><span class="file">useAuth.js</span></div>
+          <div class="indent3"><span class="file">useI18n.js</span></div>
+          <div class="indent2"><span class="file">api.js</span> <span class="comment">— Axios client</span></div>
+          <div class="indent2"><span class="file">App.vue</span> <span class="comment">— root + nav</span></div>
+          <div class="indent"><span class="dir">server/</span></div>
+          <div class="indent2"><span class="file">main.py</span> <span class="comment">— FastAPI app</span></div>
+          <div class="indent2"><span class="file">mock_data.py</span> <span class="comment">— JSON loader</span></div>
+          <div class="indent2"><span class="dir">data/</span> <span class="comment">— 7 JSON files</span></div>
+          <div class="indent"><span class="dir">tests/backend/</span></div>
+          <div class="indent2"><span class="file">test_inventory.py</span></div>
+          <div class="indent2"><span class="file">test_dashboard.py</span></div>
+          <div class="indent2"><span class="file">test_orders.py</span></div>
+          <div class="indent2"><span class="file">test_misc_endpoints.py</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Data Files -->
+  <section>
+    <h2>Data Files</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>File</th>
+            <th>Records</th>
+            <th>Key Fields</th>
+            <th>Filterable By</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>inventory.json</td>
+            <td style="color:var(--muted);">95 SKUs</td>
+            <td style="color:var(--muted);">sku, name, category, warehouse, quantity_on_hand, reorder_point, unit_cost</td>
+            <td><span class="pill pill-blue">warehouse</span><span class="pill pill-green">category</span></td>
+          </tr>
+          <tr>
+            <td>orders.json</td>
+            <td style="color:var(--muted);">~2,000</td>
+            <td style="color:var(--muted);">order_number, customer, items[], status, order_date, total_value</td>
+            <td><span class="pill pill-blue">warehouse</span><span class="pill pill-green">category</span><span class="pill pill-yellow">status</span><span class="pill pill-red">month</span></td>
+          </tr>
+          <tr>
+            <td>spending.json</td>
+            <td style="color:var(--muted);">Nested</td>
+            <td style="color:var(--muted);">spending_summary, monthly_spending[], category_spending[]</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td>demand_forecasts.json</td>
+            <td style="color:var(--muted);">9 items</td>
+            <td style="color:var(--muted);">item_sku, current_demand, forecasted_demand, trend</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td>backlog_items.json</td>
+            <td style="color:var(--muted);">4 items</td>
+            <td style="color:var(--muted);">order_id, item_sku, quantity_needed, quantity_available, priority</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td>transactions.json</td>
+            <td style="color:var(--muted);">40+</td>
+            <td style="color:var(--muted);">date, description, category, amount, vendor, type</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td>purchase_orders.json</td>
+            <td style="color:var(--muted);">Empty</td>
+            <td style="color:var(--muted);">Written at runtime via POST /api/purchase-orders</td>
+            <td>—</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="footer">Generated 2026-04-21 &nbsp;·&nbsp; Factory Inventory Management System</div>
+</div>
+</body>
+</html>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,6 +25,9 @@
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
         </nav>
         <LanguageSwitcher />
         <ProfileMenu

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,15 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking-orders`)
+    return response.data
+  },
+
+  async createRestockingOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/restocking-orders`, orderData)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -309,6 +310,32 @@ export default {
     english: 'English',
     japanese: 'Japanese',
     selectLanguage: 'Select Language'
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Auto-fill a restock order based on demand forecasts',
+    budgetLabel: 'Available Budget',
+    budgetUsed: 'Budget Used',
+    remaining: 'Remaining',
+    selectedItems: 'Selected Items',
+    noItems: 'No items to restock. All demand gaps are covered or trends are decreasing.',
+    sku: 'SKU',
+    itemName: 'Item Name',
+    trend: 'Trend',
+    restockQty: 'Restock Qty',
+    unitCost: 'Unit Cost',
+    lineTotal: 'Line Total',
+    totalCost: 'Total Cost',
+    placeOrder: 'Place Order',
+    orderPlaced: 'Order Placed',
+    orderSuccess: 'Restocking order {orderNumber} has been submitted.',
+    expectedDelivery: 'Expected delivery: {date}',
+    placeAnother: 'Place Another Order',
+    submittedSection: 'Submitted Restocking Orders',
+    submittedItems: '{count} items',
+    leadTime: '7-day delivery'
   },
 
   // Common

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -309,6 +310,32 @@ export default {
     english: 'English',
     japanese: '日本語',
     selectLanguage: '言語を選択'
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充',
+    description: '需要予測に基づいて補充注文を自動入力',
+    budgetLabel: '利用可能予算',
+    budgetUsed: '使用済み予算',
+    remaining: '残額',
+    selectedItems: '選択品目',
+    noItems: '補充対象品目がありません。すべての需要ギャップが満たされているか、トレンドが減少しています。',
+    sku: 'SKU',
+    itemName: '品目名',
+    trend: 'トレンド',
+    restockQty: '補充数量',
+    unitCost: '単価',
+    lineTotal: '小計',
+    totalCost: '合計コスト',
+    placeOrder: '注文する',
+    orderPlaced: '注文完了',
+    orderSuccess: '補充注文 {orderNumber} が送信されました。',
+    expectedDelivery: '予定配達日: {date}',
+    placeAnother: '別の注文をする',
+    submittedSection: '送信済み補充注文',
+    submittedItems: '{count}件',
+    leadTime: '7日間配達'
   },
 
   // Common

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -8,6 +8,38 @@
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
+      <!-- Submitted restocking orders — only visible after orders are placed from the Restocking tab -->
+      <div v-if="restockingOrders.length > 0" class="card restocking-section">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.submittedSection') }} ({{ restockingOrders.length }})</h3>
+          <span class="restocking-lead-time">{{ t('restocking.leadTime') }}</span>
+        </div>
+        <div class="table-container">
+          <table class="restocking-orders-table">
+            <thead>
+              <tr>
+                <th>{{ t('orders.table.orderNumber') }}</th>
+                <th>{{ t('orders.table.orderDate') }}</th>
+                <th>{{ t('orders.table.expectedDelivery') }}</th>
+                <th>{{ t('orders.table.items') }}</th>
+                <th>{{ t('restocking.totalCost') }}</th>
+                <th>{{ t('orders.table.status') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in restockingOrders" :key="order.id">
+                <td><strong>{{ order.order_number }}</strong></td>
+                <td>{{ formatDate(order.order_date) }}</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td>{{ order.items.length }} {{ t('common.items') }}</td>
+                <td><strong>${{ order.total_cost.toLocaleString() }}</strong></td>
+                <td><span class="badge info">{{ order.status }}</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="stats-grid">
         <div class="stat-card success">
           <div class="stat-label">{{ t('status.delivered') }}</div>
@@ -95,6 +127,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -121,6 +154,14 @@ export default {
         error.value = 'Failed to load orders: ' + err.message
       } finally {
         loading.value = false
+      }
+    }
+
+    const loadRestockingOrders = async () => {
+      try {
+        restockingOrders.value = await api.getRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load restocking orders:', err)
       }
     }
 
@@ -153,7 +194,7 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    onMounted(() => { loadOrders(); loadRestockingOrders() })
 
     return {
       t,
@@ -165,7 +206,8 @@ export default {
       formatDate,
       currencySymbol,
       translateProductName,
-      translateCustomerName
+      translateCustomerName,
+      restockingOrders
     }
   }
 }
@@ -275,5 +317,21 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+.restocking-section {
+  border-left: 4px solid #3b82f6;
+  margin-bottom: 1.25rem;
+}
+
+.restocking-lead-time {
+  font-size: 0.813rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.restocking-orders-table {
+  table-layout: fixed;
+  width: 100%;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,372 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+
+    <!-- Success state -->
+    <div v-else-if="orderSuccess" class="card success-card">
+      <div class="success-icon">✓</div>
+      <h3>{{ t('restocking.orderPlaced') }}</h3>
+      <p>{{ t('restocking.orderSuccess').replace('{orderNumber}', submittedOrder.order_number) }}</p>
+      <p>{{ t('restocking.expectedDelivery').replace('{date}', formatDate(submittedOrder.expected_delivery)) }}</p>
+      <button @click="resetForm" class="btn-primary">{{ t('restocking.placeAnother') }}</button>
+    </div>
+
+    <!-- Main form -->
+    <div v-else>
+      <!-- Budget card -->
+      <div class="card budget-card">
+        <div class="budget-header">
+          <span class="budget-label">{{ t('restocking.budgetLabel') }}</span>
+          <span class="budget-value">{{ formatCurrency(budget) }}</span>
+        </div>
+        <input type="range" v-model.number="budget" min="0" max="500000" step="1000" class="budget-slider" />
+        <div class="progress-track">
+          <div class="progress-fill" :style="{ width: budgetUsedPercent + '%', background: progressColor }"></div>
+        </div>
+        <div class="budget-meta">
+          <span>{{ t('restocking.budgetUsed') }}: {{ formatCurrency(totalCost) }}</span>
+          <span>{{ t('restocking.remaining') }}: {{ formatCurrency(remainingBudget) }}</span>
+        </div>
+      </div>
+
+      <!-- Selected items card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.selectedItems') }} ({{ selectedItems.length }})</h3>
+          <span class="total-cost">{{ formatCurrency(totalCost) }}</span>
+        </div>
+
+        <div v-if="selectedItems.length === 0" class="no-items">{{ t('restocking.noItems') }}</div>
+        <div v-else class="table-container">
+          <table class="restock-table">
+            <thead>
+              <tr>
+                <th>{{ t('restocking.sku') }}</th>
+                <th>{{ t('restocking.itemName') }}</th>
+                <th>{{ t('restocking.trend') }}</th>
+                <th>{{ t('restocking.restockQty') }}</th>
+                <th>{{ t('restocking.unitCost') }}</th>
+                <th>{{ t('restocking.lineTotal') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in selectedItems" :key="item.sku">
+                <td><strong>{{ item.sku }}</strong></td>
+                <td>{{ item.name }}</td>
+                <td><span :class="['badge', item.trend]">{{ item.trend }}</span></td>
+                <td>{{ item.quantity.toLocaleString() }}</td>
+                <td>{{ formatCurrency(item.unit_cost) }}</td>
+                <td><strong>{{ formatCurrency(item.line_total) }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="order-actions">
+        <button
+          @click="placeOrder"
+          :disabled="selectedItems.length === 0 || submitting"
+          class="btn-primary btn-place-order"
+        >
+          {{ submitting ? t('common.loading') : t('restocking.placeOrder') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t } = useI18n()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const budget = ref(100000)
+    const submitting = ref(false)
+    const orderSuccess = ref(false)
+    const submittedOrder = ref(null)
+    const allForecasts = ref([])
+    const inventoryMap = ref({})
+
+    const loadData = async () => {
+      try {
+        loading.value = true
+        error.value = null
+        const [forecasts, inventory] = await Promise.all([
+          api.getDemandForecasts(),
+          api.getInventory({})
+        ])
+        allForecasts.value = forecasts
+        const map = {}
+        inventory.forEach(item => {
+          map[item.sku] = item
+        })
+        inventoryMap.value = map
+      } catch (err) {
+        error.value = 'Failed to load data: ' + err.message
+        console.error(err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const selectedItems = computed(() => {
+      // Filter out decreasing trend
+      const candidates = allForecasts.value
+        .filter(f => f.trend !== 'decreasing')
+        .reduce((acc, f) => {
+          const inv = inventoryMap.value[f.item_sku]
+          if (!inv) return acc
+          const gap = f.forecasted_demand - inv.quantity_on_hand
+          if (gap <= 0) return acc
+          acc.push({
+            sku: f.item_sku,
+            name: f.item_name,
+            trend: f.trend,
+            quantity: gap,
+            unit_cost: inv.unit_cost,
+            line_total: gap * inv.unit_cost
+          })
+          return acc
+        }, [])
+
+      // Sort: increasing first, then stable; within each tier by line_total descending
+      candidates.sort((a, b) => {
+        const tierOrder = { increasing: 0, stable: 1 }
+        const tierA = tierOrder[a.trend] ?? 2
+        const tierB = tierOrder[b.trend] ?? 2
+        if (tierA !== tierB) return tierA - tierB
+        return b.line_total - a.line_total
+      })
+
+      // Greedy fill
+      let remaining = budget.value
+      const result = []
+      for (const item of candidates) {
+        if (item.line_total <= remaining) {
+          result.push(item)
+          remaining -= item.line_total
+        }
+        // Don't break — a cheaper item later may still fit
+      }
+      return result
+    })
+
+    const totalCost = computed(() => selectedItems.value.reduce((sum, i) => sum + i.line_total, 0))
+
+    const budgetUsedPercent = computed(() => {
+      return budget.value > 0 ? Math.min((totalCost.value / budget.value) * 100, 100) : 0
+    })
+
+    const remainingBudget = computed(() => budget.value - totalCost.value)
+
+    const progressColor = computed(() => {
+      const pct = budgetUsedPercent.value
+      if (pct > 95) return '#ef4444'
+      if (pct > 80) return '#f59e0b'
+      return '#10b981'
+    })
+
+    const placeOrder = async () => {
+      if (selectedItems.value.length === 0) return
+      try {
+        submitting.value = true
+        const result = await api.createRestockingOrder({
+          budget: budget.value,
+          items: selectedItems.value.map(item => ({
+            sku: item.sku,
+            name: item.name,
+            quantity: item.quantity,
+            unit_cost: item.unit_cost,
+            line_total: item.line_total
+          }))
+        })
+        submittedOrder.value = result
+        orderSuccess.value = true
+      } catch (err) {
+        error.value = 'Failed to place order: ' + err.message
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    const resetForm = () => {
+      orderSuccess.value = false
+      submittedOrder.value = null
+      budget.value = 100000
+    }
+
+    const formatCurrency = (v) => v.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
+
+    const formatDate = (dateString) => {
+      const { currentLocale } = useI18n()
+      const locale = currentLocale.value === 'ja' ? 'ja-JP' : 'en-US'
+      return new Date(dateString).toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' })
+    }
+
+    onMounted(() => loadData())
+
+    return {
+      t,
+      loading,
+      error,
+      budget,
+      submitting,
+      orderSuccess,
+      submittedOrder,
+      selectedItems,
+      totalCost,
+      budgetUsedPercent,
+      remainingBudget,
+      progressColor,
+      placeOrder,
+      resetForm,
+      formatCurrency,
+      formatDate
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.budget-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.budget-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.budget-slider {
+  width: 100%;
+  height: 6px;
+  margin: 0.75rem 0;
+  cursor: pointer;
+  accent-color: #3b82f6;
+}
+
+.progress-track {
+  width: 100%;
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 0.5rem 0;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.budget-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.813rem;
+  color: #64748b;
+  margin-top: 0.5rem;
+}
+
+.no-items {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+.total-cost {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.order-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-primary:hover {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.btn-place-order {
+  min-width: 160px;
+}
+
+.success-card {
+  text-align: center;
+  padding: 3rem;
+  border-left: 4px solid #10b981;
+}
+
+.success-icon {
+  font-size: 3rem;
+  color: #10b981;
+  margin-bottom: 1rem;
+}
+
+.success-card h3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+}
+
+.success-card p {
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.success-card button {
+  margin-top: 1.5rem;
+}
+
+.restock-table {
+  table-layout: fixed;
+  width: 100%;
+}
+</style>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -79,5 +79,59 @@
     "forecasted_demand": 96,
     "trend": "stable",
     "period": "Next 30 days"
+  },
+  {
+    "id": "10",
+    "item_sku": "TMP-201",
+    "item_name": "Temperature Sensor Module",
+    "current_demand": 125,
+    "forecasted_demand": 400,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "11",
+    "item_sku": "PSU-508",
+    "item_name": "Battery Backup Power Supply",
+    "current_demand": 75,
+    "forecasted_demand": 300,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "12",
+    "item_sku": "HMD-202",
+    "item_name": "Humidity Sensor Module",
+    "current_demand": 95,
+    "forecasted_demand": 250,
+    "trend": "stable",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "13",
+    "item_sku": "ACC-206",
+    "item_name": "3-Axis Accelerometer",
+    "current_demand": 180,
+    "forecasted_demand": 350,
+    "trend": "stable",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "14",
+    "item_sku": "SRV-301",
+    "item_name": "Micro Servo Motor",
+    "current_demand": 45,
+    "forecasted_demand": 200,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "15",
+    "item_sku": "SRV-302",
+    "item_name": "Standard Servo Motor",
+    "current_demand": 28,
+    "forecasted_demand": 100,
+    "trend": "increasing",
+    "period": "Next 30 days"
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,10 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+
+restocking_orders = []  # runtime only; resets on server restart
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -119,6 +122,27 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+    line_total: float
+
+class CreateRestockingOrderRequest(BaseModel):
+    budget: float
+    items: List[RestockingOrderItem]
+
+class RestockingOrder(BaseModel):
+    id: str
+    order_number: str
+    order_date: str
+    expected_delivery: str
+    budget: float
+    total_cost: float
+    items: List[RestockingOrderItem]
+    status: str
 
 # API endpoints
 @app.get("/")
@@ -303,6 +327,29 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking-orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all submitted restocking orders"""
+    return restocking_orders
+
+@app.post("/api/restocking-orders", response_model=RestockingOrder, status_code=201)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Create a new restocking order"""
+    now = datetime.utcnow()
+    order_number = f"RES-{now.strftime('%Y')}-{len(restocking_orders) + 1:04d}"
+    order = {
+        "id": str(len(restocking_orders) + 1),
+        "order_number": order_number,
+        "order_date": now.strftime("%Y-%m-%dT%H:%M:%S"),
+        "expected_delivery": (now + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S"),
+        "budget": request.budget,
+        "total_cost": sum(item.line_total for item in request.items),
+        "items": [item.model_dump() for item in request.items],
+        "status": "Submitted"
+    }
+    restocking_orders.append(order)
+    return order
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary

- **New Restocking tab**: Budget slider (up to $500K) auto-fills restock recommendations from demand forecasts using a greedy allocation algorithm — increasing-trend items prioritized first, quantities set to close the forecast gap (`forecasted_demand − on_hand`)
- **Orders tab update**: New "Submitted Restocking Orders" section at the top displays placed orders with order number, dates, item count, total cost, and delivery lead time (+7 days)
- **Backend**: New `/api/restocking-orders` GET + POST endpoints with in-memory store, `RES-YYYY-NNNN` order numbering, and Pydantic v2 validation
- **Supporting data**: Added 6 demand forecast entries with matching inventory SKUs to make the demo functional
- **i18n**: Full English and Japanese translation keys for all restocking UI strings
- **architecture.html**: Static architecture reference page documenting tech stack, data flow, and API endpoints

## Test plan

- [ ] Navigate to Restocking tab — budget slider renders at $100K default, 2 items auto-selected (SRV-301 + TMP-201, ~$93.6K total)
- [ ] Adjust slider up to ~$250K — verify more items are added as budget allows
- [ ] Click "Place Order" — success card shows order number `RES-2026-XXXX` and expected delivery date
- [ ] Navigate to Orders tab — "Submitted Restocking Orders" section appears at top with the placed order
- [ ] Click "Place Another Order" — form resets to default state
- [ ] Verify Japanese locale renders restocking UI correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)