### PR TITLE
Add budget-based restocking tab and SaaS-style sidebar redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,207 @@
 # Factory Inventory Management System
 
-A full-stack demo application for a Claude Code workshop — inventory management, order tracking, demand forecasting, and analytics for factory operations.
+A full-stack Vue 3 + FastAPI demo that simulates factory inventory operations — stock tracking across warehouses, order management, demand forecasting, budget-based restocking, spending analytics, and performance reports. Built for a Claude Code workshop; a real working reference for agent-driven development.
 
 ![Dashboard](docs/dashboard-screenshot.png)
 
 ## Tech Stack
 
-- **Frontend**: Vue 3 + Vite (port 3000)
-- **Backend**: Python FastAPI (port 8001)
-- **Data**: In-memory mock data (no database)
+| Layer    | Stack                                                                   |
+|----------|-------------------------------------------------------------------------|
+| Frontend | Vue 3 (Composition API) · Vite · vue-router · axios · custom i18n       |
+| Backend  | Python 3.12 · FastAPI · Pydantic · uvicorn                              |
+| Storage  | In-memory from JSON files in `server/data/` (no database)               |
+| Tooling  | mise (toolchain) · uv (Python deps) · npm · vitest · ruff               |
 
-## Features
+## Architecture
 
-- Dashboard with interactive filtering and key metrics
-- Inventory tracking across multiple warehouses
-- Order management with status tracking
-- Demand forecasting with trend analysis
-- Backlog monitoring
-- Spending analytics
+```mermaid
+flowchart LR
+    subgraph Browser
+      UI[Vue 3 App]
+      Filters[useFilters composable]
+      I18n[useI18n composable]
+    end
 
-## Quick Start
+    subgraph Server
+      API[FastAPI app]
+      Filter[filter helpers]
+      Models[Pydantic models]
+      Data[(JSON fixtures)]
+    end
 
-**One-command startup:**
-```bash
-./scripts/start.sh
-# Starts both backend and frontend
-# Backend: http://localhost:8001
-# Frontend: http://localhost:3000
-# API Docs: http://localhost:8001/docs
+    UI -->|axios| API
+    Filters -.shared refs.-> UI
+    I18n -.shared refs.-> UI
+    API --> Filter
+    Filter --> Data
+    API --> Models
+    Models --> UI
 ```
 
-**Manual startup:**
+Four global filters live in `useFilters` — **Time Period**, **Warehouse**, **Category**, **Order Status** — and every view watches them to refetch. See `client/src/composables/useFilters.js`.
 
-Backend:
+## Getting started
+
+The project expects [mise](https://mise.jdx.dev/) to manage Python and Node versions. `mise.toml` pins them.
+
+```bash
+# Backend (http://localhost:8001)
+cd server
+mise exec -- uv sync
+mise exec -- uv run python main.py
+
+# Frontend (http://localhost:3000)
+cd client
+mise exec -- npm install
+mise exec -- npm run dev
+```
+
+Or use the convenience scripts (macOS/Linux):
+
+```bash
+./scripts/start.sh     # Starts both
+./scripts/stop.sh      # Kills both
+```
+
+API docs at <http://localhost:8001/docs> (FastAPI's generated Swagger UI).
+
+## Project structure
+
+```
+inventory/
+├── client/                      # Vue 3 frontend
+│   ├── src/
+│   │   ├── App.vue              # Shell: sidebar, layout, design tokens (:root)
+│   │   ├── main.js              # Router, app mount
+│   │   ├── api.js               # All backend calls, one place
+│   │   ├── views/               # Page components (routed)
+│   │   ├── components/          # Reusable UI (modals, filter bar, etc.)
+│   │   ├── composables/         # useFilters, useI18n, useAuth
+│   │   ├── locales/             # en.js, ja.js translations
+│   │   └── utils/               # currency formatting, etc.
+│   └── vitest.config.js         # Frontend test config
+├── server/                      # Python FastAPI backend
+│   ├── main.py                  # All routes + Pydantic models
+│   ├── mock_data.py             # JSON loader (module-level state)
+│   ├── data/                    # Fixture data (7 JSON files)
+│   └── pyproject.toml           # uv deps + ruff config
+├── tests/
+│   ├── backend/                 # pytest + FastAPI TestClient
+│   └── frontend/                # vitest + @vue/test-utils
+├── scripts/                     # start.sh, stop.sh, test.sh
+├── docs/
+└── mise.toml                    # Toolchain pins
+```
+
+## API reference
+
+All `GET` endpoints accept the filter params noted. Filters use `'all'` as a skip sentinel.
+
+### Inventory · Orders · Dashboard
+
+| Endpoint                          | Filters                                          | Description                                    |
+|-----------------------------------|--------------------------------------------------|------------------------------------------------|
+| `GET /api/inventory`              | `warehouse`, `category`                          | SKU catalog with lead times and reorder points |
+| `GET /api/inventory/{id}`         | —                                                | Single item                                    |
+| `GET /api/orders`                 | `warehouse`, `category`, `status`, `month`       | Customer orders                                |
+| `GET /api/orders/{id}`            | —                                                | Single order                                   |
+| `GET /api/dashboard/summary`      | all four                                         | KPIs, totals, counts                           |
+
+### Demand · Backlog · Reports
+
+| Endpoint                          | Filters | Description                               |
+|-----------------------------------|---------|-------------------------------------------|
+| `GET /api/demand`                 | —       | Demand forecasts                          |
+| `GET /api/backlog`                | —       | Unfulfilled order items                   |
+| `GET /api/reports/quarterly`      | —       | Per-quarter totals + fulfillment rate     |
+| `GET /api/reports/monthly-trends` | —       | Per-month revenue and order counts        |
+
+### Spending
+
+| Endpoint                             | Description                       |
+|--------------------------------------|-----------------------------------|
+| `GET /api/spending/summary`          | Totals + deltas                   |
+| `GET /api/spending/monthly`          | Monthly cost categories           |
+| `GET /api/spending/categories`       | Spend by category                 |
+| `GET /api/spending/transactions`     | Recent transactions               |
+
+### Restocking (new)
+
+| Endpoint                             | Body / filters                         | Description                               |
+|--------------------------------------|----------------------------------------|-------------------------------------------|
+| `GET /api/restocking/candidates`     | `warehouse`, `category`                | Shortfall items = forecast − on-hand      |
+| `POST /api/restocking/orders`        | `CreateRestockingOrderRequest`         | Submits; generates `RO-YYYY-NNNN` id      |
+| `GET /api/restocking/orders`         | —                                      | All submitted restocking orders           |
+
+## Design system
+
+CSS design tokens live in `client/src/App.vue` `:root`. Views consume them through scoped styles:
+
+- **Color:** `--color-bg`, `--color-surface`, `--color-border`, `--color-text`, `--color-text-muted`, `--color-accent`, plus semantic `--color-success`, `--color-warning`, `--color-danger`, `--color-info` (each paired with a `-bg` variant).
+- **Layers:** `--radius-sm|md|lg`, `--shadow-sm|md|lg`.
+- **Spacing:** `--space-1` through `--space-8` on a 0.25rem grid.
+- **Shell:** `--sidebar-width` / `--sidebar-width-collapsed` drive the collapsible left nav.
+
+Global class helpers in `App.vue` — `.card`, `.stat-card`, `.stats-grid`, `.page-header`, `.badge.{success|warning|danger|info|high|medium|low|increasing|stable|decreasing}` — are shared across every view; don't redefine them in scoped styles.
+
+## Development workflow
+
+### Frontend
+
+```bash
+cd client
+mise exec -- npm run dev         # Dev server with HMR
+mise exec -- npm run build       # Production build to client/dist
+mise exec -- npm test            # Vitest unit tests
+mise exec -- npm run test:watch  # Watch mode
+mise exec -- npm run lint        # ESLint
+mise exec -- npm run format      # Prettier write
+```
+
+### Backend
+
 ```bash
 cd server
-uv venv && uv sync
-uv run python main.py
+mise exec -- uv run python main.py          # Dev server
+mise exec -- uv run pytest ../tests/backend # Full test suite
+mise exec -- uv run ruff check .            # Lint
+mise exec -- uv run ruff format .           # Format
 ```
 
-Frontend:
-```bash
-cd client
-npm install
-npm run dev
-```
+### i18n
 
-## API Endpoints
+Every user-visible string goes through `t()` from `useI18n`. Add keys to **both** `client/src/locales/en.js` and `client/src/locales/ja.js` in matching positions. The composable falls back to English if a Japanese key is missing, but missing keys are a bug — don't rely on it.
 
-All endpoints support optional filtering via query params: `warehouse`, `category`, `status`, `month`
+### Adding a feature
 
-- `GET /api/inventory` - Inventory items
-- `GET /api/orders` - Orders
-- `GET /api/demand` - Demand forecasts
-- `GET /api/backlog` - Backlog items
-- `GET /api/dashboard/summary` - Summary statistics
-- `GET /api/spending/*` - Spending data
+1. **Backend:** define Pydantic model → add route in `main.py` → add to `tests/backend/`.
+2. **API client:** add method to `client/src/api.js`.
+3. **View:** create/edit `.vue` file using Composition API, `useFilters`, `useI18n`, `api` client. Reuse global classes and tokens; don't invent parallel styles.
+4. **Nav:** add route to `main.js`, add sidebar entry to `App.vue`, add `nav.<name>` keys to both locales.
+5. **Test:** unit tests for pure logic, component tests for interaction.
 
-## Demo Data
+See `CLAUDE.md`, `client/CLAUDE.md`, and `server/CLAUDE.md` for the longer engineering conventions.
 
-Mock data includes:
-- Inventory items (Circuit Boards, Sensors, Actuators, Controllers)
-- Orders spanning 12 months (Delivered, Shipped, Processing, Backordered)
-- Demand forecasts with trends
-- Backlog items
-- Spending transactions
+## Data model (fixtures)
 
-Data files: `server/data/*.json`
+All data lives in `server/data/` and loads into memory at startup. Mutations (e.g., submitted restocking orders) persist only for the process lifetime.
 
-## Production Build
+| File                     | Shape                                                                         |
+|--------------------------|-------------------------------------------------------------------------------|
+| `inventory.json`         | SKU, name, category, warehouse, quantity_on_hand, reorder_point, unit_cost, lead_time_days |
+| `orders.json`            | Customer orders with items, status, dates, total_value                        |
+| `demand_forecasts.json`  | SKU, current_demand, forecasted_demand, trend, period                         |
+| `backlog_items.json`     | order_id, sku, needed vs. available, days_delayed, priority                   |
+| `purchase_orders.json`   | Backlog-driven purchase orders (empty by default)                             |
+| `spending.json`          | Aggregate summary, monthly breakdown, category breakdown                      |
+| `transactions.json`      | Individual transactions (date, vendor, category, amount)                      |
 
-```bash
-cd client
-npm run build  # Output: client/dist/
-```
+## Platform notes
 
-## Platform Notes
-
-**macOS/Linux:** The one-command startup script (`./scripts/start.sh`) and stop script (`./scripts/stop.sh`) work out of the box.
-
-**Windows:** The shell scripts in `scripts/` are macOS/Linux only. Use the manual startup commands instead — run each in a separate terminal:
-
-Backend:
-```bash
-cd server
-uv venv && uv sync
-uv run python main.py
-```
-
-Frontend:
-```bash
-cd client
-npm install
-npm run dev
-```
-
-To stop the servers, press Ctrl+C in each terminal window.
+- **macOS/Linux:** `scripts/start.sh` and `scripts/stop.sh` work out of the box.
+- **Windows:** run the manual commands above in two terminals. Ctrl+C to stop.
 
 ---
 
-**Note:** Demo application with in-memory data. Not production-ready without database, authentication, and security implementation.
+Demo application. No auth, no rate limiting, in-memory only — not production-ready without a database, authentication, and security hardening.

--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+coverage

--- a/client/.prettierrc.json
+++ b/client/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "vueIndentScriptAndStyle": false
+}

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,0 +1,16 @@
+import pluginVue from 'eslint-plugin-vue'
+import configPrettier from '@vue/eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...pluginVue.configs['flat/recommended'],
+  configPrettier,
+  {
+    rules: {
+      'vue/multi-word-component-names': 'off',
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    },
+  },
+]

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,15 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
-        "vite": "^5.2.0"
+        "@vitest/coverage-v8": "^4.1.5",
+        "@vue/eslint-config-prettier": "^10.2.0",
+        "@vue/test-utils": "^2.4.6",
+        "eslint": "^10.2.1",
+        "eslint-plugin-vue": "^10.8.0",
+        "happy-dom": "^20.9.0",
+        "prettier": "^3.8.3",
+        "vite": "^5.2.0",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -27,21 +35,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -51,16 +59,60 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -352,6 +404,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -369,6 +439,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -384,6 +472,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -454,10 +560,585 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -768,12 +1449,89 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -787,6 +1545,123 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -845,6 +1720,21 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
+    "node_modules/@vue/eslint-config-prettier": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-10.2.0.tgz",
+      "integrity": "sha512-GL3YBLwv/+b86yHcNNfPJxOTtVFJ4Mbc9UU3zR+KVoG7SwGTjPT+32fXamscNumElhcpXW3mT0DgzS9w32S7Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-prettier": "^5.2.2"
+      },
+      "peerDependencies": {
+        "eslint": ">= 8.21.0",
+        "prettier": ">= 3.0.0"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
@@ -895,6 +1785,125 @@
       "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -912,6 +1921,30 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -925,6 +1958,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -937,10 +2000,91 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -950,6 +2094,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -965,6 +2119,39 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -995,6 +2182,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1062,11 +2256,401 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.12"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vue": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.8.0.tgz",
+      "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^7.1.0",
+        "semver": "^7.6.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "vue-eslint-parser": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -1086,6 +2670,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -1165,6 +2766,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1175,6 +2811,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1216,13 +2893,538 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1255,6 +3457,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1273,16 +3508,177 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1307,11 +3703,115 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+      }
     },
     "node_modules/rollup": {
       "version": "4.52.4",
@@ -1355,6 +3855,62 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1363,6 +3919,242 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.20",
@@ -1424,6 +4216,669 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
@@ -1445,6 +4900,38 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
+      "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
@@ -1458,6 +4945,202 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -5,15 +5,30 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src --ext .vue,.js",
+    "lint:fix": "eslint src --ext .vue,.js --fix",
+    "format": "prettier --write \"src/**/*.{js,vue,css,json}\"",
+    "format:check": "prettier --check \"src/**/*.{js,vue,css,json}\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "axios": "^1.6.7",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0",
-    "axios": "^1.6.7"
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
-    "vite": "^5.2.0"
+    "@vitest/coverage-v8": "^4.1.5",
+    "@vue/eslint-config-prettier": "^10.2.0",
+    "@vue/test-utils": "^2.4.6",
+    "eslint": "^10.2.1",
+    "eslint-plugin-vue": "^10.8.0",
+    "happy-dom": "^20.9.0",
+    "prettier": "^3.8.3",
+    "vite": "^5.2.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -73,6 +73,15 @@
           <span class="nav-label">{{ t('nav.demandForecast') }}</span>
         </router-link>
 
+        <router-link to="/backlog" class="nav-item" :class="{ active: $route.path === '/backlog' }">
+          <!-- Backlog: hourglass (delayed queue) -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M5 3h10M5 17h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <path d="M6 3c0 4 3 5 4 7-1 2-4 3-4 7M14 3c0 4-3 5-4 7 1 2 4 3 4 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.backlog') }}</span>
+        </router-link>
+
         <router-link to="/reports" class="nav-item" :class="{ active: $route.path === '/reports' }">
           <!-- Reports: bar chart -->
           <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -80,7 +89,7 @@
             <rect x="8.25" y="7" width="3.5" height="10" rx="1" fill="currentColor"/>
             <rect x="13.5" y="3" width="3.5" height="14" rx="1" fill="currentColor"/>
           </svg>
-          <span class="nav-label">Reports</span>
+          <span class="nav-label">{{ t('nav.reports') }}</span>
         </router-link>
       </nav>
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -131,8 +131,7 @@
 </template>
 
 <script>
-import { ref, watch, onMounted, computed } from 'vue'
-import { api } from './api'
+import { ref, watch, computed } from 'vue'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
 import FilterBar from './components/FilterBar.vue'
@@ -155,7 +154,6 @@ export default {
     const { t } = useI18n()
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
-    const apiTasks = ref([])
 
     // Sidebar collapse state persisted to localStorage
     const sidebarCollapsed = ref(localStorage.getItem('sidebarCollapsed') === 'true')
@@ -168,63 +166,30 @@ export default {
       sidebarCollapsed.value = !sidebarCollapsed.value
     }
 
-    // Merge mock tasks from currentUser with API tasks
-    const tasks = computed(() => {
-      return [...currentUser.value.tasks, ...apiTasks.value]
-    })
+    const tasks = computed(() => currentUser.value.tasks)
 
-    const loadTasks = async () => {
-      try {
-        apiTasks.value = await api.getTasks()
-      } catch (err) {
-        console.error('Failed to load tasks:', err)
+    const addTask = (taskData) => {
+      const newTask = {
+        id: `task-${Date.now()}`,
+        status: 'pending',
+        ...taskData
+      }
+      currentUser.value.tasks.unshift(newTask)
+    }
+
+    const deleteTask = (taskId) => {
+      const index = currentUser.value.tasks.findIndex(t => t.id === taskId)
+      if (index !== -1) {
+        currentUser.value.tasks.splice(index, 1)
       }
     }
 
-    const addTask = async (taskData) => {
-      try {
-        const newTask = await api.createTask(taskData)
-        apiTasks.value.unshift(newTask)
-      } catch (err) {
-        console.error('Failed to add task:', err)
+    const toggleTask = (taskId) => {
+      const task = currentUser.value.tasks.find(t => t.id === taskId)
+      if (task) {
+        task.status = task.status === 'pending' ? 'completed' : 'pending'
       }
     }
-
-    const deleteTask = async (taskId) => {
-      try {
-        const isMockTask = currentUser.value.tasks.some(t => t.id === taskId)
-        if (isMockTask) {
-          const index = currentUser.value.tasks.findIndex(t => t.id === taskId)
-          if (index !== -1) {
-            currentUser.value.tasks.splice(index, 1)
-          }
-        } else {
-          await api.deleteTask(taskId)
-          apiTasks.value = apiTasks.value.filter(t => t.id !== taskId)
-        }
-      } catch (err) {
-        console.error('Failed to delete task:', err)
-      }
-    }
-
-    const toggleTask = async (taskId) => {
-      try {
-        const mockTask = currentUser.value.tasks.find(t => t.id === taskId)
-        if (mockTask) {
-          mockTask.status = mockTask.status === 'pending' ? 'completed' : 'pending'
-        } else {
-          const updatedTask = await api.toggleTask(taskId)
-          const index = apiTasks.value.findIndex(t => t.id === taskId)
-          if (index !== -1) {
-            apiTasks.value[index] = updatedTask
-          }
-        }
-      } catch (err) {
-        console.error('Failed to toggle task:', err)
-      }
-    }
-
-    onMounted(loadTasks)
 
     return {
       t,

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,118 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
+    <!-- Sidebar -->
+    <aside class="sidebar" :class="{ collapsed: sidebarCollapsed }">
+      <!-- Brand -->
+      <div class="sidebar-brand">
+        <div class="brand-monogram">CC</div>
+        <div class="brand-text">
+          <span class="brand-name">{{ t('nav.companyName') }}</span>
+          <span class="brand-subtitle">{{ t('nav.subtitle') }}</span>
         </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
+      </div>
+
+      <!-- Nav -->
+      <nav class="sidebar-nav">
+        <router-link to="/" class="nav-item" :class="{ active: $route.path === '/' }">
+          <!-- Overview: grid of 4 dots -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="3" width="6" height="6" rx="1.5" fill="currentColor"/>
+            <rect x="11" y="3" width="6" height="6" rx="1.5" fill="currentColor"/>
+            <rect x="3" y="11" width="6" height="6" rx="1.5" fill="currentColor"/>
+            <rect x="11" y="11" width="6" height="6" rx="1.5" fill="currentColor"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.overview') }}</span>
+        </router-link>
+
+        <router-link to="/inventory" class="nav-item" :class="{ active: $route.path === '/inventory' }">
+          <!-- Inventory: stacked boxes -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="10" width="14" height="7" rx="1.5" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="5" y="6" width="10" height="5" rx="1" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="7" y="3" width="6" height="4" rx="1" stroke="currentColor" stroke-width="1.5"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.inventory') }}</span>
+        </router-link>
+
+        <router-link to="/orders" class="nav-item" :class="{ active: $route.path === '/orders' }">
+          <!-- Orders: clipboard with lines -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="4" y="3" width="12" height="14" rx="1.5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M7 8h6M7 11h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <rect x="8" y="2" width="4" height="2.5" rx="1" fill="currentColor"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.orders') }}</span>
+        </router-link>
+
+        <router-link to="/restocking" class="nav-item" :class="{ active: $route.path === '/restocking' }">
+          <!-- Restocking: refresh arrow circle -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 10a6 6 0 016-6 6 6 0 014.24 1.76L16 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <path d="M16 10a6 6 0 01-6 6 6 6 0 01-4.24-1.76L4 12.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <polyline points="14,5 16,7.5 13.5,8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <polyline points="6,15 4,12.5 6.5,12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.restocking') }}</span>
+        </router-link>
+
+        <router-link to="/spending" class="nav-item" :class="{ active: $route.path === '/spending' }">
+          <!-- Spending: dollar sign in circle -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="10" cy="10" r="7.5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M10 6v8M8 8.5c0-.83.67-1.5 1.5-1.5h1c.83 0 1.5.67 1.5 1.5S11.33 10 10.5 10h-1C8.67 10 8 10.67 8 11.5S8.67 13 9.5 13h1c.83 0 1.5-.67 1.5-1.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.finance') }}</span>
+        </router-link>
+
+        <router-link to="/demand" class="nav-item" :class="{ active: $route.path === '/demand' }">
+          <!-- Demand: trending up arrow -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <polyline points="3,14 8,9 11,12 17,6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <polyline points="13,6 17,6 17,10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.demandForecast') }}</span>
+        </router-link>
+
+        <router-link to="/reports" class="nav-item" :class="{ active: $route.path === '/reports' }">
+          <!-- Reports: bar chart -->
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="11" width="3.5" height="6" rx="1" fill="currentColor"/>
+            <rect x="8.25" y="7" width="3.5" height="10" rx="1" fill="currentColor"/>
+            <rect x="13.5" y="3" width="3.5" height="14" rx="1" fill="currentColor"/>
+          </svg>
+          <span class="nav-label">Reports</span>
+        </router-link>
+      </nav>
+
+      <!-- Footer -->
+      <div class="sidebar-footer">
         <LanguageSwitcher />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
+        <button class="collapse-toggle" @click="toggleSidebar" :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+          <svg
+            class="chevron-icon"
+            :class="{ rotated: sidebarCollapsed }"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M13 15l-5-5 5-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="nav-label">Collapse</span>
+        </button>
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    </aside>
+
+    <!-- Main column -->
+    <div class="main-column">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -55,7 +131,7 @@
 </template>
 
 <script>
-import { ref, onMounted, computed } from 'vue'
+import { ref, watch, onMounted, computed } from 'vue'
 import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
@@ -81,6 +157,17 @@ export default {
     const showTasks = ref(false)
     const apiTasks = ref([])
 
+    // Sidebar collapse state persisted to localStorage
+    const sidebarCollapsed = ref(localStorage.getItem('sidebarCollapsed') === 'true')
+
+    watch(sidebarCollapsed, (v) => {
+      localStorage.setItem('sidebarCollapsed', String(v))
+    })
+
+    const toggleSidebar = () => {
+      sidebarCollapsed.value = !sidebarCollapsed.value
+    }
+
     // Merge mock tasks from currentUser with API tasks
     const tasks = computed(() => {
       return [...currentUser.value.tasks, ...apiTasks.value]
@@ -97,7 +184,6 @@ export default {
     const addTask = async (taskData) => {
       try {
         const newTask = await api.createTask(taskData)
-        // Add new task to the beginning of the array
         apiTasks.value.unshift(newTask)
       } catch (err) {
         console.error('Failed to add task:', err)
@@ -106,17 +192,13 @@ export default {
 
     const deleteTask = async (taskId) => {
       try {
-        // Check if it's a mock task (from currentUser)
         const isMockTask = currentUser.value.tasks.some(t => t.id === taskId)
-
         if (isMockTask) {
-          // Remove from mock tasks
           const index = currentUser.value.tasks.findIndex(t => t.id === taskId)
           if (index !== -1) {
             currentUser.value.tasks.splice(index, 1)
           }
         } else {
-          // Remove from API tasks
           await api.deleteTask(taskId)
           apiTasks.value = apiTasks.value.filter(t => t.id !== taskId)
         }
@@ -127,14 +209,10 @@ export default {
 
     const toggleTask = async (taskId) => {
       try {
-        // Check if it's a mock task (from currentUser)
         const mockTask = currentUser.value.tasks.find(t => t.id === taskId)
-
         if (mockTask) {
-          // Toggle mock task status
           mockTask.status = mockTask.status === 'pending' ? 'completed' : 'pending'
         } else {
-          // Toggle API task
           const updatedTask = await api.toggleTask(taskId)
           const index = apiTasks.value.findIndex(t => t.id === taskId)
           if (index !== -1) {
@@ -155,13 +233,57 @@ export default {
       tasks,
       addTask,
       deleteTask,
-      toggleTask
+      toggleTask,
+      sidebarCollapsed,
+      toggleSidebar
     }
   }
 }
 </script>
 
 <style>
+/* ============================================================
+   Design tokens
+   ============================================================ */
+:root {
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f1f5f9;
+  --color-border: #e2e8f0;
+  --color-border-strong: #cbd5e1;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-text-subtle: #94a3b8;
+  --color-accent: #2563eb;
+  --color-accent-bg: #eff6ff;
+  --color-success: #059669;
+  --color-success-bg: #d1fae5;
+  --color-warning: #ea580c;
+  --color-warning-bg: #fed7aa;
+  --color-danger: #dc2626;
+  --color-danger-bg: #fecaca;
+  --color-info: #2563eb;
+  --color-info-bg: #dbeafe;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 10px 24px rgba(15, 23, 42, 0.08);
+  --sidebar-width: 260px;
+  --sidebar-width-collapsed: 64px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+}
+
+/* ============================================================
+   Reset & base
+   ============================================================ */
 * {
   margin: 0;
   padding: 0;
@@ -170,149 +292,284 @@ export default {
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
+  background: var(--color-bg);
+  color: var(--color-text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ============================================================
+   App shell
+   ============================================================ */
 .app {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+/* ============================================================
+   Sidebar
+   ============================================================ */
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
   position: sticky;
   top: 0;
+  height: 100vh;
   z-index: 100;
+  transition: width 0.2s ease, min-width 0.2s ease;
+  overflow: hidden;
 }
 
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
+.sidebar.collapsed {
+  width: var(--sidebar-width-collapsed);
+  min-width: var(--sidebar-width-collapsed);
+}
+
+/* Brand */
+.sidebar-brand {
   display: flex;
   align-items: center;
-  padding: 0 2rem;
-  height: 70px;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  min-height: 70px;
+  overflow: hidden;
 }
 
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
+.brand-monogram {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(135deg, var(--color-accent) 0%, #1e40af 100%);
+  color: white;
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
+  align-items: center;
+  justify-content: center;
   font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
+  font-size: 0.75rem;
+  letter-spacing: 0.025em;
 }
 
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
+.brand-text {
   display: flex;
-  gap: 0.25rem;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
+.brand-name {
+  font-size: 0.938rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+}
+
+.brand-subtitle {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-weight: 400;
+  line-height: 1.2;
+}
+
+.sidebar.collapsed .brand-text {
+  display: none;
+}
+
+/* Nav */
+.sidebar-nav {
+  flex: 1;
+  padding: var(--space-4) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-muted);
   text-decoration: none;
   font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
+  font-size: 0.875rem;
+  border-radius: var(--radius-sm);
+  transition: all 0.15s ease;
   position: relative;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
+.nav-item:hover {
+  color: var(--color-text);
+  background: var(--color-surface-alt);
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
+.nav-item.active {
+  color: var(--color-accent);
+  background: var(--color-accent-bg);
 }
 
-.nav-tabs a.active::after {
+.nav-item.active::before {
   content: '';
   position: absolute;
-  bottom: -1px;
   left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+  top: 6px;
+  bottom: 6px;
+  width: 4px;
+  border-radius: 0 2px 2px 0;
+  background: var(--color-accent);
+}
+
+.nav-icon {
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  color: currentColor;
+}
+
+.nav-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar.collapsed .nav-label {
+  display: none;
+}
+
+.sidebar.collapsed .nav-item {
+  justify-content: center;
+  padding: var(--space-2);
+}
+
+/* Footer */
+.sidebar-footer {
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* Collapse toggle */
+.collapse-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  width: 100%;
+  text-align: left;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.collapse-toggle:hover {
+  color: var(--color-text);
+  background: var(--color-surface-alt);
+}
+
+.chevron-icon {
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  transition: transform 0.2s ease;
+}
+
+.chevron-icon.rotated {
+  transform: rotate(180deg);
+}
+
+.sidebar.collapsed .collapse-toggle {
+  justify-content: center;
+  padding: var(--space-2);
+}
+
+/* ============================================================
+   Main column
+   ============================================================ */
+.main-column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .main-content {
   flex: 1;
-  max-width: 1600px;
   width: 100%;
-  margin: 0 auto;
-  padding: 1.5rem 2rem;
+  padding: var(--space-6) var(--space-8);
 }
 
+/* ============================================================
+   Page header
+   ============================================================ */
 .page-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .page-header h2 {
   font-size: 1.875rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
   margin-bottom: 0.375rem;
   letter-spacing: -0.025em;
 }
 
 .page-header p {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.938rem;
 }
 
+/* ============================================================
+   Stats grid
+   ============================================================ */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: var(--space-5);
+  margin-bottom: var(--space-6);
 }
 
+/* ============================================================
+   Stat card
+   ============================================================ */
 .stat-card {
-  background: white;
-  padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  transition: all 0.2s ease;
+  background: var(--color-surface);
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .stat-card:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-md);
 }
 
 .stat-label {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.875rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -323,50 +580,62 @@ body {
 .stat-value {
   font-size: 2.25rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
   letter-spacing: -0.025em;
 }
 
 .stat-card.warning .stat-value {
-  color: #ea580c;
+  color: var(--color-warning);
 }
 
 .stat-card.success .stat-value {
-  color: #059669;
+  color: var(--color-success);
 }
 
 .stat-card.danger .stat-value {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .stat-card.info .stat-value {
-  color: #2563eb;
+  color: var(--color-info);
 }
 
+/* ============================================================
+   Card
+   ============================================================ */
 .card {
-  background: white;
-  border-radius: 10px;
-  padding: 1.25rem;
-  border: 1px solid #e2e8f0;
-  margin-bottom: 1.25rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-5);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
   padding-bottom: 0.875rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .card-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
   letter-spacing: -0.025em;
 }
 
+/* ============================================================
+   Tables
+   ============================================================ */
 .table-container {
   overflow-x: auto;
 }
@@ -377,14 +646,14 @@ table {
 }
 
 thead {
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 th {
   text-align: left;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   font-weight: 600;
   color: #475569;
   font-size: 0.75rem;
@@ -393,8 +662,8 @@ th {
 }
 
 td {
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid #f1f5f9;
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--color-surface-alt);
   color: #334155;
   font-size: 0.875rem;
 }
@@ -404,13 +673,16 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background: #f8fafc;
+  background: var(--color-bg);
 }
 
+/* ============================================================
+   Badges
+   ============================================================ */
 .badge {
   display: inline-block;
-  padding: 0.313rem 0.75rem;
-  border-radius: 6px;
+  padding: 0.313rem var(--space-3);
+  border-radius: var(--radius-sm);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -418,32 +690,32 @@ tbody tr:hover {
 }
 
 .badge.success {
-  background: #d1fae5;
+  background: var(--color-success-bg);
   color: #065f46;
 }
 
 .badge.warning {
-  background: #fed7aa;
+  background: var(--color-warning-bg);
   color: #92400e;
 }
 
 .badge.danger {
-  background: #fecaca;
+  background: var(--color-danger-bg);
   color: #991b1b;
 }
 
 .badge.info {
-  background: #dbeafe;
+  background: var(--color-info-bg);
   color: #1e40af;
 }
 
 .badge.increasing {
-  background: #d1fae5;
+  background: var(--color-success-bg);
   color: #065f46;
 }
 
 .badge.decreasing {
-  background: #fecaca;
+  background: var(--color-danger-bg);
   color: #991b1b;
 }
 
@@ -453,34 +725,37 @@ tbody tr:hover {
 }
 
 .badge.high {
-  background: #fecaca;
+  background: var(--color-danger-bg);
   color: #991b1b;
 }
 
 .badge.medium {
-  background: #fed7aa;
+  background: var(--color-warning-bg);
   color: #92400e;
 }
 
 .badge.low {
-  background: #dbeafe;
+  background: var(--color-info-bg);
   color: #1e40af;
 }
 
+/* ============================================================
+   Loading / Error states
+   ============================================================ */
 .loading {
   text-align: center;
   padding: 3rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.938rem;
 }
 
 .error {
   background: #fef2f2;
-  border: 1px solid #fecaca;
+  border: 1px solid var(--color-danger-bg);
   color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
+  margin: var(--space-4) 0;
   font-size: 0.938rem;
 }
 </style>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -74,36 +74,6 @@ export const api = {
     return response.data
   },
 
-  async getTasks() {
-    const response = await axios.get(`${API_BASE_URL}/tasks`)
-    return response.data
-  },
-
-  async createTask(taskData) {
-    const response = await axios.post(`${API_BASE_URL}/tasks`, taskData)
-    return response.data
-  },
-
-  async deleteTask(taskId) {
-    const response = await axios.delete(`${API_BASE_URL}/tasks/${taskId}`)
-    return response.data
-  },
-
-  async toggleTask(taskId) {
-    const response = await axios.patch(`${API_BASE_URL}/tasks/${taskId}`)
-    return response.data
-  },
-
-  async createPurchaseOrder(purchaseOrderData) {
-    const response = await axios.post(`${API_BASE_URL}/purchase-orders`, purchaseOrderData)
-    return response.data
-  },
-
-  async getPurchaseOrderByBacklogItem(backlogItemId) {
-    const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
-    return response.data
-  },
-
   async getRestockingCandidates(filters = {}) {
     const params = new URLSearchParams()
     if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -74,6 +74,16 @@ export const api = {
     return response.data
   },
 
+  async getQuarterlyReports() {
+    const response = await axios.get(`${API_BASE_URL}/reports/quarterly`)
+    return response.data
+  },
+
+  async getMonthlyTrends() {
+    const response = await axios.get(`${API_BASE_URL}/reports/monthly-trends`)
+    return response.data
+  },
+
   async getRestockingCandidates(filters = {}) {
     const params = new URLSearchParams()
     if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,23 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingCandidates(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    const response = await axios.get(`${API_BASE_URL}/restocking/candidates?${params.toString()}`)
+    return response.data
+  },
+
+  async submitRestockingOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/orders`, orderData)
+    return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/orders`)
+    return response.data
   }
 }

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -102,18 +102,17 @@ export default {
 
 <style scoped>
 .filters-bar {
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--color-bg, #f8fafc);
+  border-bottom: 1px solid var(--color-border, #e2e8f0);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(15, 23, 42, 0.04));
   padding: 0.75rem 0;
   position: sticky;
-  top: 70px;
-  z-index: 90;
+  top: 0;
+  z-index: 50;
 }
 
 .filters-container {
-  max-width: 1600px;
-  margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 var(--space-8, 2rem);
   display: flex;
   align-items: center;
   gap: 1rem;

--- a/client/src/components/dashboard/InventoryByCategoryCard.vue
+++ b/client/src/components/dashboard/InventoryByCategoryCard.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="card chart-card">
+    <div class="card-header">
+      <h3 class="card-title">{{ t('dashboard.inventoryValue.title') }}</h3>
+    </div>
+    <div class="chart-content">
+      <div class="horizontal-bar-chart" v-if="categoryData.length > 0">
+        <div v-for="cat in categoryData" :key="cat.name" class="h-bar-item">
+          <div class="h-bar-label">{{ translateCategory(cat.name) }}</div>
+          <div class="h-bar-container">
+            <div class="h-bar" :style="{ width: (cat.value / maxCategoryValue * 100) + '%', background: cat.color }">
+              <span class="h-bar-value">{{ selectedCurrency === 'JPY' ? formatCurrency(cat.value, selectedCurrency) : `$${(cat.value / 1000).toFixed(1)}K` }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-else class="no-data">{{ t('dashboard.inventoryShortages.noData') }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useI18n } from '../../composables/useI18n'
+import { formatCurrency } from '../../utils/currency'
+
+export default {
+  name: 'InventoryByCategoryCard',
+  props: {
+    categoryData: {
+      type: Array,
+      required: true
+    },
+    maxCategoryValue: {
+      type: Number,
+      required: true
+    },
+    selectedCurrency: {
+      type: String,
+      required: true
+    }
+  },
+  setup() {
+    const { t } = useI18n()
+
+    const translateCategory = (category) => {
+      const categoryMap = {
+        'Circuit Boards': t('categories.circuitBoards'),
+        'Sensors': t('categories.sensors'),
+        'Actuators': t('categories.actuators'),
+        'Controllers': t('categories.controllers'),
+        'Power Supplies': t('categories.powerSupplies')
+      }
+      return categoryMap[category] || category
+    }
+
+    return {
+      t,
+      formatCurrency,
+      translateCategory
+    }
+  }
+}
+</script>
+
+<style scoped>
+.chart-content {
+  padding: 1rem;
+}
+
+.horizontal-bar-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 1rem;
+}
+
+.h-bar-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.h-bar-label {
+  width: 120px;
+  min-width: 120px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.h-bar-container {
+  flex: 1;
+  height: 32px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.h-bar {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 0.75rem;
+  transition: width 0.6s ease;
+}
+
+.h-bar-value {
+  font-size: 0.813rem;
+  font-weight: 700;
+  color: white;
+}
+
+.no-data {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-subtle);
+  font-size: 0.875rem;
+}
+</style>

--- a/client/src/components/dashboard/InventoryShortagesCard.vue
+++ b/client/src/components/dashboard/InventoryShortagesCard.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="card chart-card full-width">
+    <div class="card-header">
+      <h3 class="card-title">{{ t('dashboard.inventoryShortages.title') }} ({{ backlogItems.length }})</h3>
+    </div>
+    <div v-if="backlogItems.length === 0" class="no-backlog">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="success-icon">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+      </svg>
+      <p class="no-backlog-text">{{ t('dashboard.inventoryShortages.noShortages') }}</p>
+    </div>
+    <div v-else class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>{{ t('dashboard.inventoryShortages.orderId') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.sku') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.itemName') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.quantityNeeded') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.quantityAvailable') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.shortage') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.daysDelayed') }}</th>
+            <th>{{ t('dashboard.inventoryShortages.priority') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="item in backlogItems"
+            :key="item.id"
+          >
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;"><strong>{{ item.order_id }}</strong></td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;"><strong>{{ item.item_sku }}</strong></td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;">{{ translateProductName(item.item_name) }}</td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;">{{ item.quantity_needed }}</td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;">{{ item.quantity_available }}</td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;">
+              <span class="badge danger">
+                {{ Math.abs(item.quantity_needed - item.quantity_available) }} {{ t('dashboard.inventoryShortages.unitsShort') }}
+              </span>
+            </td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;">
+              <span :style="{ color: item.days_delayed > 7 ? '#ef4444' : '#f59e0b', fontWeight: 600 }">
+                {{ item.days_delayed }} {{ t('dashboard.inventoryShortages.days') }}
+              </span>
+            </td>
+            <td @click="$emit('show-detail', item)" style="cursor: pointer;">
+              <span :class="['badge', item.priority]">
+                {{ translatePriority(item.priority) }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useI18n } from '../../composables/useI18n'
+
+export default {
+  name: 'InventoryShortagesCard',
+  props: {
+    backlogItems: {
+      type: Array,
+      required: true
+    }
+  },
+  emits: ['show-detail'],
+  setup() {
+    const { t, translateProductName } = useI18n()
+
+    const translatePriority = (priority) => {
+      const priorityMap = {
+        'high': t('priority.high'),
+        'medium': t('priority.medium'),
+        'low': t('priority.low'),
+        'High': t('priority.high'),
+        'Medium': t('priority.medium'),
+        'Low': t('priority.low')
+      }
+      return priorityMap[priority] || priority
+    }
+
+    return {
+      t,
+      translateProductName,
+      translatePriority,
+      Math
+    }
+  }
+}
+</script>
+
+<style scoped>
+.no-backlog {
+  padding: 3rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.success-icon {
+  width: 48px;
+  height: 48px;
+  color: var(--color-success);
+}
+
+.no-backlog-text {
+  font-size: 1.125rem;
+  color: var(--color-success);
+  font-weight: 600;
+  margin: 0;
+}
+</style>

--- a/client/src/components/dashboard/KpiSection.vue
+++ b/client/src/components/dashboard/KpiSection.vue
@@ -1,0 +1,183 @@
+<template>
+  <div class="kpi-section">
+    <h3 class="section-title">{{ t('dashboard.kpi.title') }}</h3>
+    <div class="kpi-grid">
+      <div class="kpi-card">
+        <div class="kpi-header">
+          <span class="kpi-label">{{ t('dashboard.kpi.inventoryTurnover') }}</span>
+        </div>
+        <div class="kpi-value">4.2</div>
+        <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 4.5 (-6.67%)</div>
+        <div class="kpi-progress-bar">
+          <div class="kpi-progress" style="width: 93.33%"></div>
+        </div>
+      </div>
+
+      <div class="kpi-card">
+        <div class="kpi-header">
+          <span class="kpi-label">{{ t('dashboard.kpi.ordersFulfilled') }}</span>
+        </div>
+        <div class="kpi-value">{{ ordersData.fulfilled }}</div>
+        <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ ordersData.goal }} ({{ calculatePercentage(ordersData.fulfilled, ordersData.goal) }}%)</div>
+        <div class="kpi-progress-bar">
+          <div class="kpi-progress" :style="{ width: calculatePercentage(ordersData.fulfilled, ordersData.goal) + '%' }"></div>
+        </div>
+      </div>
+
+      <div class="kpi-card">
+        <div class="kpi-header">
+          <span class="kpi-label">{{ t('dashboard.kpi.orderFillRate') }}</span>
+        </div>
+        <div class="kpi-value">{{ fillRate }}%</div>
+        <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 95% ({{ fillRate - 95 > 0 ? '+' : '' }}{{ (fillRate - 95).toFixed(2) }}%)</div>
+        <div class="kpi-progress-bar">
+          <div class="kpi-progress success" :style="{ width: (fillRate / 95 * 100) + '%' }"></div>
+        </div>
+      </div>
+
+      <div class="kpi-card">
+        <div class="kpi-header">
+          <span class="kpi-label">{{ t(selectedPeriod === 'all' ? 'dashboard.kpi.revenueYTD' : 'dashboard.kpi.revenueMTD') }}</span>
+        </div>
+        <div class="kpi-value">{{ formatCurrency(Math.round(summary.total_orders_value), selectedCurrency) }}</div>
+        <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ formatCurrency(revenueGoal, selectedCurrency) }} ({{ summary.total_orders_value > revenueGoal ? '+' : '' }}{{ ((summary.total_orders_value / revenueGoal - 1) * 100).toFixed(1) }}%)</div>
+        <div class="kpi-progress-bar">
+          <div class="kpi-progress" :style="{ width: Math.min((summary.total_orders_value / revenueGoal * 100), 100) + '%' }"></div>
+        </div>
+      </div>
+
+      <div class="kpi-card">
+        <div class="kpi-header">
+          <span class="kpi-label">{{ t('dashboard.kpi.avgProcessingTime') }}</span>
+        </div>
+        <div class="kpi-value">2.8</div>
+        <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 3.0 (-6.67%)</div>
+        <div class="kpi-progress-bar">
+          <div class="kpi-progress success" style="width: 93.33%"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useI18n } from '../../composables/useI18n'
+import { formatCurrency } from '../../utils/currency'
+
+export default {
+  name: 'KpiSection',
+  props: {
+    summary: {
+      type: Object,
+      required: true
+    },
+    ordersData: {
+      type: Object,
+      required: true
+    },
+    fillRate: {
+      type: Number,
+      required: true
+    },
+    revenueGoal: {
+      type: Number,
+      required: true
+    },
+    selectedPeriod: {
+      type: String,
+      required: true
+    },
+    selectedCurrency: {
+      type: String,
+      required: true
+    }
+  },
+  setup() {
+    const { t } = useI18n()
+
+    const calculatePercentage = (value, goal) => {
+      return ((value / goal) * 100).toFixed(2)
+    }
+
+    return {
+      t,
+      formatCurrency,
+      calculatePercentage,
+      Math
+    }
+  }
+}
+</script>
+
+<style scoped>
+.kpi-section {
+  margin-bottom: 1.5rem;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.kpi-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.kpi-header {
+  margin-bottom: 0.75rem;
+}
+
+.kpi-label {
+  font-size: 0.813rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.kpi-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.025em;
+}
+
+.kpi-goal {
+  font-size: 0.813rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.kpi-progress-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--color-surface-alt);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.kpi-progress {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  transition: width 0.6s ease;
+}
+
+.kpi-progress.success {
+  background: var(--color-success);
+}
+</style>

--- a/client/src/components/dashboard/OrderHealthCard.vue
+++ b/client/src/components/dashboard/OrderHealthCard.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="card chart-card">
+    <div class="card-header">
+      <h3 class="card-title">{{ t('dashboard.orderHealth.title') }}</h3>
+    </div>
+    <div class="chart-content">
+      <div class="order-health-container">
+        <!-- Left: Donut Chart -->
+        <div class="order-health-chart">
+          <svg viewBox="0 0 200 200" class="donut-svg-compact">
+            <circle cx="100" cy="100" r="65" fill="none" stroke="#e2e8f0" stroke-width="25"/>
+            <circle cx="100" cy="100" r="65" fill="none" stroke="#10b981" stroke-width="25"
+              :stroke-dasharray="`${getCircleSegment(statusData.delivered)} 408`"
+              stroke-dashoffset="0" transform="rotate(-90 100 100)"/>
+            <circle cx="100" cy="100" r="65" fill="none" stroke="#3b82f6" stroke-width="25"
+              :stroke-dasharray="`${getCircleSegment(statusData.shipped)} 408`"
+              :stroke-dashoffset="`-${getCircleSegment(statusData.delivered)}`"
+              transform="rotate(-90 100 100)"/>
+            <circle cx="100" cy="100" r="65" fill="none" stroke="#f59e0b" stroke-width="25"
+              :stroke-dasharray="`${getCircleSegment(statusData.processing)} 408`"
+              :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped)}`"
+              transform="rotate(-90 100 100)"/>
+            <circle cx="100" cy="100" r="65" fill="none" stroke="#ef4444" stroke-width="25"
+              :stroke-dasharray="`${getCircleSegment(statusData.backordered)} 408`"
+              :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped) + getCircleSegment(statusData.processing)}`"
+              transform="rotate(-90 100 100)"/>
+            <text x="100" y="90" text-anchor="middle" class="donut-center-label">{{ t('dashboard.orderHealth.total') }}</text>
+            <text x="100" y="120" text-anchor="middle" class="donut-center-value">{{ orderHealthMetrics.totalOrders }}</text>
+          </svg>
+          <div class="donut-legend-compact">
+            <div class="legend-item-compact"><span class="legend-dot" style="background: #10b981"></span>{{ t('status.delivered') }}</div>
+            <div class="legend-item-compact"><span class="legend-dot" style="background: #3b82f6"></span>{{ t('status.shipped') }}</div>
+            <div class="legend-item-compact"><span class="legend-dot" style="background: #f59e0b"></span>{{ t('status.processing') }}</div>
+            <div class="legend-item-compact"><span class="legend-dot" style="background: #ef4444"></span>{{ t('status.backordered') }}</div>
+          </div>
+        </div>
+
+        <!-- Right: Health Metrics -->
+        <div class="order-health-metrics">
+          <div class="health-metric">
+            <div class="health-metric-label">{{ t('dashboard.orderHealth.revenue') }}</div>
+            <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.totalValue, selectedCurrency) }}</div>
+          </div>
+          <div class="health-metric">
+            <div class="health-metric-label">{{ t('dashboard.orderHealth.avgOrderValue') }}</div>
+            <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.avgOrderValue, selectedCurrency) }}</div>
+          </div>
+          <div class="health-metric">
+            <div class="health-metric-label">{{ t('dashboard.orderHealth.onTimeRate') }}</div>
+            <div class="health-metric-value" :class="{ 'metric-good': orderHealthMetrics.onTimeRate >= 90, 'metric-warning': orderHealthMetrics.onTimeRate < 90 && orderHealthMetrics.onTimeRate >= 75, 'metric-bad': orderHealthMetrics.onTimeRate < 75 }">
+              {{ orderHealthMetrics.onTimeRate.toFixed(1) }}%
+            </div>
+          </div>
+          <div class="health-metric">
+            <div class="health-metric-label">{{ t('dashboard.orderHealth.avgFulfillmentDays') }}</div>
+            <div class="health-metric-value">{{ orderHealthMetrics.avgFulfillmentDays.toFixed(1) }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed } from 'vue'
+import { useI18n } from '../../composables/useI18n'
+import { formatCurrency } from '../../utils/currency'
+
+export default {
+  name: 'OrderHealthCard',
+  props: {
+    statusData: {
+      type: Object,
+      required: true
+    },
+    orderHealthMetrics: {
+      type: Object,
+      required: true
+    },
+    selectedCurrency: {
+      type: String,
+      required: true
+    }
+  },
+  setup(props) {
+    const { t } = useI18n()
+
+    const totalOrders = computed(() => {
+      return props.statusData.delivered + props.statusData.shipped +
+             props.statusData.processing + props.statusData.backordered
+    })
+
+    const getCircleSegment = (value) => {
+      return totalOrders.value > 0 ? (value / totalOrders.value) * 440 : 0
+    }
+
+    return {
+      t,
+      formatCurrency,
+      getCircleSegment
+    }
+  }
+}
+</script>
+
+<style scoped>
+.chart-content {
+  padding: 1rem;
+}
+
+.order-health-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1rem;
+  min-height: 240px;
+}
+
+.order-health-chart {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0 1rem;
+}
+
+.donut-svg-compact {
+  width: 200px;
+  height: 200px;
+}
+
+.donut-center-label {
+  font-size: 12px;
+  fill: var(--color-text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.donut-center-value {
+  font-size: 36px;
+  fill: var(--color-text);
+  font-weight: 700;
+}
+
+.donut-legend-compact {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.625rem 1.25rem;
+}
+
+.legend-item-compact {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+.order-health-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.health-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  text-align: center;
+  width: 100%;
+}
+
+.health-metric-label {
+  font-size: 0.688rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.health-metric-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.025em;
+}
+
+.metric-good {
+  color: var(--color-success);
+}
+
+.metric-warning {
+  color: var(--color-warning);
+}
+
+.metric-bad {
+  color: var(--color-danger);
+}
+</style>

--- a/client/src/components/dashboard/TopProductsCard.vue
+++ b/client/src/components/dashboard/TopProductsCard.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="card chart-card full-width">
+    <div class="card-header">
+      <h3 class="card-title">{{ t('dashboard.topProducts.title') }}</h3>
+    </div>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>{{ t('dashboard.topProducts.product') }}</th>
+            <th>{{ t('dashboard.topProducts.sku') }}</th>
+            <th>{{ t('dashboard.topProducts.category') }}</th>
+            <th>{{ t('dashboard.topProducts.unitsOrdered') }}</th>
+            <th>{{ t('dashboard.topProducts.revenue') }}</th>
+            <th>{{ t('dashboard.topProducts.firstOrder') }}</th>
+            <th>{{ t('dashboard.topProducts.stockStatus') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="item in topProducts"
+            :key="item.sku"
+            class="clickable-row"
+            @click="$emit('show-product', item)"
+          >
+            <td><strong>{{ translateProductName(item.name) }}</strong></td>
+            <td>{{ item.sku }}</td>
+            <td>{{ translateCategory(item.category) }}</td>
+            <td>{{ item.unitsOrdered }}</td>
+            <td><strong>{{ formatCurrency(item.revenue, selectedCurrency) }}</strong></td>
+            <td>{{ formatDate(item.firstOrderDate) }}</td>
+            <td>
+              <span :class="['badge', getStockBadge(item.stockLevel)]">
+                {{ translateStockLevel(item.stockLevel) }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useI18n } from '../../composables/useI18n'
+import { formatCurrency } from '../../utils/currency'
+
+export default {
+  name: 'TopProductsCard',
+  props: {
+    topProducts: {
+      type: Array,
+      required: true
+    },
+    selectedCurrency: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ['show-product'],
+  setup() {
+    const { t, currentLocale, translateProductName } = useI18n()
+
+    const translateCategory = (category) => {
+      const categoryMap = {
+        'Circuit Boards': t('categories.circuitBoards'),
+        'Sensors': t('categories.sensors'),
+        'Actuators': t('categories.actuators'),
+        'Controllers': t('categories.controllers'),
+        'Power Supplies': t('categories.powerSupplies')
+      }
+      return categoryMap[category] || category
+    }
+
+    const translateStockLevel = (stockLevel) => {
+      const stockMap = {
+        'In Stock': t('status.inStock'),
+        'Low Stock': t('status.lowStock')
+      }
+      return stockMap[stockLevel] || stockLevel
+    }
+
+    const getStockBadge = (level) => {
+      if (level === 'In Stock') return 'success'
+      if (level === 'Low Stock') return 'warning'
+      return 'danger'
+    }
+
+    const formatDate = (dateString) => {
+      if (!dateString) return '-'
+      const locale = currentLocale.value === 'ja' ? 'ja-JP' : 'en-US'
+      const date = new Date(dateString)
+      if (isNaN(date.getTime())) return '-'
+      return date.toLocaleDateString(locale, { month: 'short', day: 'numeric', year: 'numeric' })
+    }
+
+    return {
+      t,
+      formatCurrency,
+      translateProductName,
+      translateCategory,
+      translateStockLevel,
+      getStockBadge,
+      formatDate
+    }
+  }
+}
+</script>
+
+<style scoped>
+.clickable-row {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.clickable-row:hover {
+  background: var(--color-accent-bg) !important;
+}
+</style>

--- a/client/src/composables/useAuth.js
+++ b/client/src/composables/useAuth.js
@@ -93,7 +93,6 @@ export function useAuth() {
 
   const logout = () => {
     // In a real app, this would clear tokens, etc.
-    console.log('Logout clicked - would redirect to login')
     alert('Logout functionality - in a real app, this would clear session and redirect to login')
   }
 

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -4,6 +4,7 @@ export default {
     overview: 'Overview',
     inventory: 'Inventory',
     orders: 'Orders',
+    restocking: 'Restocking',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
     companyName: 'Catalyst Components',

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -58,7 +58,9 @@ export default {
       daysDelayed: 'Days Delayed',
       priority: 'Priority',
       unitsShort: 'units short',
-      days: 'days'
+      days: 'days',
+      createPO: 'Create PO',
+      viewPO: 'View PO'
     },
     topProducts: {
       title: 'Top Products by Revenue',
@@ -115,6 +117,18 @@ export default {
     onTimeDelivery: 'On-Time Delivery',
     itemsCount: '{count} items',
     quantity: 'Qty',
+    restockingOrders: {
+      title: 'Submitted Restocking Orders',
+      orderId: 'Order ID',
+      items: 'Items',
+      totalCost: 'Total Cost',
+      maxLeadTime: 'Max Lead Time',
+      expectedDelivery: 'Expected Delivery',
+      status: 'Status',
+      submitted: 'Submitted',
+      itemsCount: '{count} items',
+      days: 'days'
+    },
     table: {
       orderNumber: 'Order Number',
       orderId: 'Order ID',
@@ -340,6 +354,38 @@ export default {
     }
   },
 
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Recommend items to restock based on demand forecasts and your available budget.',
+    loadingCandidates: 'Loading restocking candidates...',
+    candidates: 'Candidates',
+    maxPossibleSpend: 'Max Possible Spend',
+    selectedTotal: 'Selected Total',
+    budget: 'Budget',
+    overBudget: 'Over budget by {amount}',
+    restockingCandidates: 'Restocking Candidates',
+    resetAutoSelect: 'Reset to auto-select',
+    noItems: 'No items need restocking with current filters.',
+    cancel: 'Cancel',
+    placeOrder: 'Place Order',
+    placingOrder: 'Placing Order...',
+    days: 'days',
+    selectedOf: 'Selected {selected} of {budget} budget',
+    table: {
+      item: 'Item',
+      warehouse: 'Warehouse',
+      trend: 'Trend',
+      current: 'Current',
+      forecast: 'Forecast',
+      shortfall: 'Shortfall',
+      qtyToOrder: 'Qty to Order',
+      unitCost: 'Unit Cost',
+      subtotal: 'Subtotal',
+      leadTime: 'Lead Time'
+    }
+  },
+
   // Backlog
   backlog: {
     title: 'Backlog Management',
@@ -375,6 +421,7 @@ export default {
     search: 'Search',
     filter: 'Filter',
     export: 'Export',
-    items: 'items'
+    items: 'items',
+    actions: 'Actions'
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -58,9 +58,7 @@ export default {
       daysDelayed: 'Days Delayed',
       priority: 'Priority',
       unitsShort: 'units short',
-      days: 'days',
-      createPO: 'Create PO',
-      viewPO: 'View PO'
+      days: 'days'
     },
     topProducts: {
       title: 'Top Products by Revenue',
@@ -421,7 +419,6 @@ export default {
     search: 'Search',
     filter: 'Filter',
     export: 'Export',
-    items: 'items',
-    actions: 'Actions'
+    items: 'items'
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -7,6 +7,8 @@ export default {
     restocking: 'Restocking',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    backlog: 'Backlog',
+    reports: 'Reports',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -310,6 +312,55 @@ export default {
     english: 'English',
     japanese: 'Japanese',
     selectLanguage: 'Select Language'
+  },
+
+  // Reports
+  reports: {
+    title: 'Performance Reports',
+    description: 'View quarterly performance metrics and monthly trends',
+    quarterlyPerformance: 'Quarterly Performance',
+    monthlyRevenueTrend: 'Monthly Revenue Trend',
+    monthOverMonth: 'Month-over-Month Analysis',
+    totalRevenueYTD: 'Total Revenue (YTD)',
+    avgMonthlyRevenue: 'Avg Monthly Revenue',
+    totalOrdersYTD: 'Total Orders (YTD)',
+    bestPerformingQuarter: 'Best Performing Quarter',
+    loadError: 'Failed to load reports',
+    table: {
+      quarter: 'Quarter',
+      totalOrders: 'Total Orders',
+      totalRevenue: 'Total Revenue',
+      avgOrderValue: 'Avg Order Value',
+      fulfillmentRate: 'Fulfillment Rate',
+      month: 'Month',
+      orders: 'Orders',
+      revenue: 'Revenue',
+      change: 'Change',
+      growthRate: 'Growth Rate'
+    }
+  },
+
+  // Backlog
+  backlog: {
+    title: 'Backlog Management',
+    description: 'Track and resolve inventory shortages',
+    highPriority: 'High Priority',
+    mediumPriority: 'Medium Priority',
+    lowPriority: 'Low Priority',
+    totalBacklogItems: 'Total Backlog Items',
+    backlogItems: 'Backlog Items',
+    noBacklog: 'No backlog items - all orders can be fulfilled!',
+    loadError: 'Failed to load backlog',
+    table: {
+      orderId: 'Order ID',
+      sku: 'SKU',
+      itemName: 'Item Name',
+      quantityNeeded: 'Quantity Needed',
+      quantityAvailable: 'Quantity Available',
+      shortage: 'Shortage',
+      daysDelayed: 'Days Delayed',
+      priority: 'Priority'
+    }
   },
 
   // Common

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -58,7 +58,9 @@ export default {
       daysDelayed: '遅延日数',
       priority: '優先度',
       unitsShort: '単位不足',
-      days: '日'
+      days: '日',
+      createPO: '発注作成',
+      viewPO: '発注を表示'
     },
     topProducts: {
       title: '収益別トップ製品',
@@ -115,6 +117,18 @@ export default {
     onTimeDelivery: '定時配達',
     itemsCount: '{count}件',
     quantity: '数量',
+    restockingOrders: {
+      title: '補充発注履歴',
+      orderId: '注文ID',
+      items: '品目',
+      totalCost: '合計費用',
+      maxLeadTime: '最大リードタイム',
+      expectedDelivery: '予定配達日',
+      status: 'ステータス',
+      submitted: '提出済み',
+      itemsCount: '{count}件',
+      days: '日'
+    },
     table: {
       orderNumber: '注文番号',
       orderId: '注文ID',
@@ -340,6 +354,38 @@ export default {
     }
   },
 
+  // Restocking
+  restocking: {
+    title: '補充発注',
+    description: '需要予測と予算に基づいて補充品目を推薦します。',
+    loadingCandidates: '補充候補を読み込み中...',
+    candidates: '候補',
+    maxPossibleSpend: '最大可能支出',
+    selectedTotal: '選択合計',
+    budget: '予算',
+    overBudget: '予算超過：{amount}',
+    restockingCandidates: '補充候補',
+    resetAutoSelect: '自動選択にリセット',
+    noItems: '現在のフィルターで補充が必要な品目はありません。',
+    cancel: 'キャンセル',
+    placeOrder: '発注する',
+    placingOrder: '発注中...',
+    days: '日',
+    selectedOf: '{selected}（予算{budget}中）を選択',
+    table: {
+      item: '品目',
+      warehouse: '倉庫',
+      trend: 'トレンド',
+      current: '現在庫',
+      forecast: '予測',
+      shortfall: '不足',
+      qtyToOrder: '発注数量',
+      unitCost: '単価',
+      subtotal: '小計',
+      leadTime: 'リードタイム'
+    }
+  },
+
   // Backlog
   backlog: {
     title: 'バックログ管理',
@@ -375,7 +421,8 @@ export default {
     search: '検索',
     filter: 'フィルター',
     export: 'エクスポート',
-    items: '件'
+    items: '件',
+    actions: 'アクション'
   },
 
   // Product Names

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -58,9 +58,7 @@ export default {
       daysDelayed: '遅延日数',
       priority: '優先度',
       unitsShort: '単位不足',
-      days: '日',
-      createPO: '発注作成',
-      viewPO: '発注を表示'
+      days: '日'
     },
     topProducts: {
       title: '収益別トップ製品',
@@ -421,8 +419,7 @@ export default {
     search: '検索',
     filter: 'フィルター',
     export: 'エクスポート',
-    items: '件',
-    actions: 'アクション'
+    items: '件'
   },
 
   // Product Names

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -7,6 +7,8 @@ export default {
     restocking: '補充発注',
     finance: '財務',
     demandForecast: '需要予測',
+    backlog: 'バックログ',
+    reports: 'レポート',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -310,6 +312,55 @@ export default {
     english: 'English',
     japanese: '日本語',
     selectLanguage: '言語を選択'
+  },
+
+  // Reports
+  reports: {
+    title: 'パフォーマンスレポート',
+    description: '四半期業績指標と月次傾向を表示',
+    quarterlyPerformance: '四半期業績',
+    monthlyRevenueTrend: '月次収益推移',
+    monthOverMonth: '前月比分析',
+    totalRevenueYTD: '総収益（年初来）',
+    avgMonthlyRevenue: '平均月次収益',
+    totalOrdersYTD: '総注文数（年初来）',
+    bestPerformingQuarter: '最高業績四半期',
+    loadError: 'レポートの読み込みに失敗しました',
+    table: {
+      quarter: '四半期',
+      totalOrders: '総注文数',
+      totalRevenue: '総収益',
+      avgOrderValue: '平均注文額',
+      fulfillmentRate: '履行率',
+      month: '月',
+      orders: '注文',
+      revenue: '収益',
+      change: '変化',
+      growthRate: '成長率'
+    }
+  },
+
+  // Backlog
+  backlog: {
+    title: 'バックログ管理',
+    description: '在庫不足の追跡と解決',
+    highPriority: '高優先度',
+    mediumPriority: '中優先度',
+    lowPriority: '低優先度',
+    totalBacklogItems: 'バックログ品目総数',
+    backlogItems: 'バックログ品目',
+    noBacklog: 'バックログなし - すべての注文を履行できます！',
+    loadError: 'バックログの読み込みに失敗しました',
+    table: {
+      orderId: '注文ID',
+      sku: 'SKU',
+      itemName: '品目名',
+      quantityNeeded: '必要数量',
+      quantityAvailable: '在庫数量',
+      shortage: '不足',
+      daysDelayed: '遅延日数',
+      priority: '優先度'
+    }
   },
 
   // Common

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -4,6 +4,7 @@ export default {
     overview: '概要',
     inventory: '在庫',
     orders: '注文',
+    restocking: '補充発注',
     finance: '財務',
     demandForecast: '需要予測',
     companyName: '触媒コンポーネンツ',

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -14,8 +14,9 @@ const router = createRouter({
     { path: '/', component: Dashboard },
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
-    { path: '/demand', component: Demand },
+    { path: '/restocking', component: () => import('./views/Restocking.vue'), name: 'restocking' },
     { path: '/spending', component: Spending },
+    { path: '/demand', component: Demand },
     { path: '/reports', component: Reports }
   ]
 })

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -17,6 +17,7 @@ const router = createRouter({
     { path: '/restocking', component: () => import('./views/Restocking.vue'), name: 'restocking' },
     { path: '/spending', component: Spending },
     { path: '/demand', component: Demand },
+    { path: '/backlog', component: () => import('./views/Backlog.vue'), name: 'backlog' },
     { path: '/reports', component: Reports }
   ]
 })

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -1,75 +1,76 @@
 <template>
   <div class="backlog">
     <div class="page-header">
-      <h2>Backlog Management</h2>
-      <p>Track and resolve inventory shortages</p>
+      <h2>{{ t('backlog.title') }}</h2>
+      <p>{{ t('backlog.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading backlog...</div>
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <div class="stats-grid">
         <div class="stat-card danger">
-          <div class="stat-label">High Priority</div>
-          <div class="stat-value">{{ getBacklogByPriority('high').length }}</div>
+          <div class="stat-label">{{ t('backlog.highPriority') }}</div>
+          <div class="stat-value">{{ highPriorityCount }}</div>
         </div>
         <div class="stat-card warning">
-          <div class="stat-label">Medium Priority</div>
-          <div class="stat-value">{{ getBacklogByPriority('medium').length }}</div>
+          <div class="stat-label">{{ t('backlog.mediumPriority') }}</div>
+          <div class="stat-value">{{ mediumPriorityCount }}</div>
         </div>
         <div class="stat-card info">
-          <div class="stat-label">Low Priority</div>
-          <div class="stat-value">{{ getBacklogByPriority('low').length }}</div>
+          <div class="stat-label">{{ t('backlog.lowPriority') }}</div>
+          <div class="stat-value">{{ lowPriorityCount }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Backlog Items</div>
+          <div class="stat-label">{{ t('backlog.totalBacklogItems') }}</div>
           <div class="stat-value">{{ backlogItems.length }}</div>
         </div>
       </div>
 
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Backlog Items</h3>
+          <h3 class="card-title">{{ t('backlog.backlogItems') }}</h3>
         </div>
-        <div v-if="backlogItems.length === 0" style="padding: 3rem; text-align: center;">
-          <p style="font-size: 1.125rem; color: #10b981; font-weight: 600;">
-            ✓ No backlog items - all orders can be fulfilled!
-          </p>
+        <div v-if="backlogItems.length === 0" class="no-backlog">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="success-icon">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+          </svg>
+          <p class="no-backlog-text">{{ t('backlog.noBacklog') }}</p>
         </div>
         <div v-else class="table-container">
           <table>
             <thead>
               <tr>
-                <th>Order ID</th>
-                <th>SKU</th>
-                <th>Item Name</th>
-                <th>Quantity Needed</th>
-                <th>Quantity Available</th>
-                <th>Shortage</th>
-                <th>Days Delayed</th>
-                <th>Priority</th>
+                <th>{{ t('backlog.table.orderId') }}</th>
+                <th>{{ t('backlog.table.sku') }}</th>
+                <th>{{ t('backlog.table.itemName') }}</th>
+                <th>{{ t('backlog.table.quantityNeeded') }}</th>
+                <th>{{ t('backlog.table.quantityAvailable') }}</th>
+                <th>{{ t('backlog.table.shortage') }}</th>
+                <th>{{ t('backlog.table.daysDelayed') }}</th>
+                <th>{{ t('backlog.table.priority') }}</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="item in backlogItems" :key="item.id">
                 <td><strong>{{ item.order_id }}</strong></td>
                 <td><strong>{{ item.item_sku }}</strong></td>
-                <td>{{ item.item_name }}</td>
+                <td>{{ translateProductName(item.item_name) }}</td>
                 <td>{{ item.quantity_needed }}</td>
                 <td>{{ item.quantity_available }}</td>
                 <td>
                   <span class="badge danger">
-                    {{ item.quantity_needed - item.quantity_available }} units short
+                    {{ Math.abs(item.quantity_needed - item.quantity_available) }} {{ t('dashboard.inventoryShortages.unitsShort') }}
                   </span>
                 </td>
                 <td>
-                  <span :style="{ color: item.days_delayed > 7 ? '#ef4444' : '#f59e0b' }">
-                    {{ item.days_delayed }} days
+                  <span :style="{ color: item.days_delayed > 7 ? 'var(--color-danger)' : 'var(--color-warning)', fontWeight: 600 }">
+                    {{ item.days_delayed }} {{ t('dashboard.inventoryShortages.days') }}
                   </span>
                 </td>
                 <td>
                   <span :class="['badge', item.priority]">
-                    {{ item.priority }}
+                    {{ translatePriority(item.priority) }}
                   </span>
                 </td>
               </tr>
@@ -82,37 +83,58 @@
 </template>
 
 <script>
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { api } from '../api'
 import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
 
 export default {
   name: 'Backlog',
   setup() {
+    const { t, translateProductName } = useI18n()
+    const { selectedLocation, selectedCategory, selectedPeriod, selectedStatus, getCurrentFilters } = useFilters()
+
     const loading = ref(true)
     const error = ref(null)
     const allBacklogItems = ref([])
     const inventoryItems = ref([])
-
-    // Use shared filters
-    const { selectedLocation, selectedCategory, getCurrentFilters } = useFilters()
 
     // Filter backlog based on inventory filters
     const backlogItems = computed(() => {
       if (selectedLocation.value === 'all' && selectedCategory.value === 'all') {
         return allBacklogItems.value
       }
-
-      // Get SKUs of items that match the filters
       const validSkus = new Set(inventoryItems.value.map(item => item.sku))
       return allBacklogItems.value.filter(b => validSkus.has(b.item_sku))
     })
 
-    const loadBacklog = async () => {
-      try {
-        loading.value = true
-        const filters = getCurrentFilters()
+    const highPriorityCount = computed(() =>
+      backlogItems.value.filter(item => item.priority === 'high').length
+    )
+    const mediumPriorityCount = computed(() =>
+      backlogItems.value.filter(item => item.priority === 'medium').length
+    )
+    const lowPriorityCount = computed(() =>
+      backlogItems.value.filter(item => item.priority === 'low').length
+    )
 
+    const translatePriority = (priority) => {
+      const map = {
+        high: t('priority.high'),
+        medium: t('priority.medium'),
+        low: t('priority.low'),
+        High: t('priority.high'),
+        Medium: t('priority.medium'),
+        Low: t('priority.low')
+      }
+      return map[priority] || priority
+    }
+
+    const loadBacklog = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        const filters = getCurrentFilters()
         const [backlogData, inventoryData] = await Promise.all([
           api.getBacklog(),
           api.getInventory({
@@ -120,33 +142,61 @@ export default {
             category: filters.category
           })
         ])
-
         allBacklogItems.value = backlogData
         inventoryItems.value = inventoryData
       } catch (err) {
-        error.value = 'Failed to load backlog: ' + err.message
+        error.value = t('backlog.loadError')
+        console.error('Failed to load backlog:', err)
       } finally {
         loading.value = false
       }
     }
 
-    const getBacklogByPriority = (priority) => {
-      return backlogItems.value.filter(item => item.priority === priority)
-    }
-
-    // Watch for filter changes and reload data
-    watch([selectedLocation, selectedCategory], () => {
+    watch([selectedLocation, selectedCategory, selectedPeriod, selectedStatus], () => {
       loadBacklog()
     })
 
     onMounted(loadBacklog)
 
     return {
+      t,
       loading,
       error,
       backlogItems,
-      getBacklogByPriority
+      highPriorityCount,
+      mediumPriorityCount,
+      lowPriorityCount,
+      translateProductName,
+      translatePriority
     }
   }
 }
 </script>
+
+<style scoped>
+.backlog {
+  padding: 0;
+}
+
+.no-backlog {
+  padding: 3rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.success-icon {
+  width: 48px;
+  height: 48px;
+  color: var(--color-success);
+}
+
+.no-backlog-text {
+  font-size: 1.125rem;
+  color: var(--color-success);
+  font-weight: 600;
+  margin: 0;
+}
+</style>

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -7,66 +7,14 @@
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
-      <!-- Key Performance Indicators -->
-      <div class="kpi-section">
-        <h3 class="section-title">{{ t('dashboard.kpi.title') }}</h3>
-        <div class="kpi-grid">
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.inventoryTurnover') }}</span>
-            </div>
-            <div class="kpi-value">4.2</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 4.5 (-6.67%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress" style="width: 93.33%"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.ordersFulfilled') }}</span>
-            </div>
-            <div class="kpi-value">{{ ordersData.fulfilled }}</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ ordersData.goal }} ({{ calculatePercentage(ordersData.fulfilled, ordersData.goal) }}%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress" :style="{ width: calculatePercentage(ordersData.fulfilled, ordersData.goal) + '%' }"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.orderFillRate') }}</span>
-            </div>
-            <div class="kpi-value">{{ fillRate }}%</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 95% ({{ fillRate - 95 > 0 ? '+' : '' }}{{ (fillRate - 95).toFixed(2) }}%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress success" :style="{ width: (fillRate / 95 * 100) + '%' }"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t(selectedPeriod === 'all' ? 'dashboard.kpi.revenueYTD' : 'dashboard.kpi.revenueMTD') }}</span>
-            </div>
-            <div class="kpi-value">{{ formatCurrency(Math.round(summary.total_orders_value), selectedCurrency) }}</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ formatCurrency(revenueGoal, selectedCurrency) }} ({{ summary.total_orders_value > revenueGoal ? '+' : '' }}{{ ((summary.total_orders_value / revenueGoal - 1) * 100).toFixed(1) }}%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress" :style="{ width: Math.min((summary.total_orders_value / revenueGoal * 100), 100) + '%' }"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.avgProcessingTime') }}</span>
-            </div>
-            <div class="kpi-value">2.8</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 3.0 (-6.67%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress success" style="width: 93.33%"></div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <KpiSection
+        :summary="summary"
+        :orders-data="ordersData"
+        :fill-rate="fillRate"
+        :revenue-goal="revenueGoal"
+        :selected-period="selectedPeriod"
+        :selected-currency="selectedCurrency"
+      />
 
       <!-- Summary Section -->
       <div class="summary-section">
@@ -75,202 +23,28 @@
 
       <!-- Charts Grid -->
       <div class="charts-grid">
-        <!-- Order Health Dashboard -->
-        <div class="card chart-card">
-          <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.orderHealth.title') }}</h3>
-          </div>
-          <div class="chart-content">
-            <div class="order-health-container">
-              <!-- Left: Donut Chart -->
-              <div class="order-health-chart">
-                <svg viewBox="0 0 200 200" class="donut-svg-compact">
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#e2e8f0" stroke-width="25"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#10b981" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.delivered)} 408`"
-                    stroke-dashoffset="0" transform="rotate(-90 100 100)"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#3b82f6" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.shipped)} 408`"
-                    :stroke-dashoffset="`-${getCircleSegment(statusData.delivered)}`"
-                    transform="rotate(-90 100 100)"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#f59e0b" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.processing)} 408`"
-                    :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped)}`"
-                    transform="rotate(-90 100 100)"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#ef4444" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.backordered)} 408`"
-                    :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped) + getCircleSegment(statusData.processing)}`"
-                    transform="rotate(-90 100 100)"/>
-                  <text x="100" y="90" text-anchor="middle" class="donut-center-label">{{ t('dashboard.orderHealth.total') }}</text>
-                  <text x="100" y="120" text-anchor="middle" class="donut-center-value">{{ orderHealthMetrics.totalOrders }}</text>
-                </svg>
-                <div class="donut-legend-compact">
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #10b981"></span>{{ t('status.delivered') }}</div>
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #3b82f6"></span>{{ t('status.shipped') }}</div>
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #f59e0b"></span>{{ t('status.processing') }}</div>
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #ef4444"></span>{{ t('status.backordered') }}</div>
-                </div>
-              </div>
+        <OrderHealthCard
+          :status-data="statusData"
+          :order-health-metrics="orderHealthMetrics"
+          :selected-currency="selectedCurrency"
+        />
 
-              <!-- Right: Health Metrics -->
-              <div class="order-health-metrics">
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.revenue') }}</div>
-                  <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.totalValue, selectedCurrency) }}</div>
-                </div>
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.avgOrderValue') }}</div>
-                  <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.avgOrderValue, selectedCurrency) }}</div>
-                </div>
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.onTimeRate') }}</div>
-                  <div class="health-metric-value" :class="{ 'metric-good': orderHealthMetrics.onTimeRate >= 90, 'metric-warning': orderHealthMetrics.onTimeRate < 90 && orderHealthMetrics.onTimeRate >= 75, 'metric-bad': orderHealthMetrics.onTimeRate < 75 }">
-                    {{ orderHealthMetrics.onTimeRate.toFixed(1) }}%
-                  </div>
-                </div>
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.avgFulfillmentDays') }}</div>
-                  <div class="health-metric-value">{{ orderHealthMetrics.avgFulfillmentDays.toFixed(1) }}</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <InventoryByCategoryCard
+          :category-data="categoryData"
+          :max-category-value="maxCategoryValue"
+          :selected-currency="selectedCurrency"
+        />
 
-        <!-- Inventory by Category -->
-        <div class="card chart-card">
-          <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.inventoryValue.title') }}</h3>
-          </div>
-          <div class="chart-content">
-            <div class="horizontal-bar-chart" v-if="categoryData.length > 0">
-              <div v-for="cat in categoryData" :key="cat.name" class="h-bar-item">
-                <div class="h-bar-label">{{ translateCategory(cat.name) }}</div>
-                <div class="h-bar-container">
-                  <div class="h-bar" :style="{ width: (cat.value / maxCategoryValue * 100) + '%', background: cat.color }">
-                    <span class="h-bar-value">{{ selectedCurrency === 'JPY' ? formatCurrency(cat.value, selectedCurrency) : `$${(cat.value / 1000).toFixed(1)}K` }}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div v-else class="no-data">{{ t('dashboard.inventoryShortages.noData') }}</div>
-          </div>
-        </div>
+        <InventoryShortagesCard
+          :backlog-items="backlogItems"
+          @show-detail="showBacklogDetail"
+        />
 
-        <!-- Inventory Shortages -->
-        <div class="card chart-card full-width">
-          <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.inventoryShortages.title') }} ({{ backlogItems.length }})</h3>
-          </div>
-          <div v-if="backlogItems.length === 0" class="no-backlog">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="success-icon">
-              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-            </svg>
-            <p class="no-backlog-text">{{ t('dashboard.inventoryShortages.noShortages') }}</p>
-          </div>
-          <div v-else class="table-container">
-            <table>
-              <thead>
-                <tr>
-                  <th>{{ t('dashboard.inventoryShortages.orderId') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.sku') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.itemName') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.quantityNeeded') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.quantityAvailable') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.shortage') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.daysDelayed') }}</th>
-                  <th>{{ t('dashboard.inventoryShortages.priority') }}</th>
-                  <th>{{ t('common.actions') }}</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  v-for="item in backlogItems"
-                  :key="item.id"
-                >
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;"><strong>{{ item.order_id }}</strong></td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;"><strong>{{ item.item_sku }}</strong></td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;">{{ translateProductName(item.item_name) }}</td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;">{{ item.quantity_needed }}</td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;">{{ item.quantity_available }}</td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;">
-                    <span class="badge danger">
-                      {{ Math.abs(item.quantity_needed - item.quantity_available) }} {{ t('dashboard.inventoryShortages.unitsShort') }}
-                    </span>
-                  </td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;">
-                    <span :style="{ color: item.days_delayed > 7 ? '#ef4444' : '#f59e0b', fontWeight: 600 }">
-                      {{ item.days_delayed }} {{ t('dashboard.inventoryShortages.days') }}
-                    </span>
-                  </td>
-                  <td @click="showBacklogDetail(item)" style="cursor: pointer;">
-                    <span :class="['badge', item.priority]">
-                      {{ translatePriority(item.priority) }}
-                    </span>
-                  </td>
-                  <td>
-                    <button
-                      v-if="!item.purchase_order_id"
-                      @click.stop="openPOModal(item)"
-                      class="po-button create"
-                    >
-                      {{ t('dashboard.inventoryShortages.createPO') }}
-                    </button>
-                    <button
-                      v-else
-                      @click.stop="viewPO(item)"
-                      class="po-button view"
-                    >
-                      {{ t('dashboard.inventoryShortages.viewPO') }}
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <!-- Top Products Table -->
-        <div class="card chart-card full-width">
-          <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.topProducts.title') }}</h3>
-          </div>
-          <div class="table-container">
-            <table>
-              <thead>
-                <tr>
-                  <th>{{ t('dashboard.topProducts.product') }}</th>
-                  <th>{{ t('dashboard.topProducts.sku') }}</th>
-                  <th>{{ t('dashboard.topProducts.category') }}</th>
-                  <th>{{ t('dashboard.topProducts.unitsOrdered') }}</th>
-                  <th>{{ t('dashboard.topProducts.revenue') }}</th>
-                  <th>{{ t('dashboard.topProducts.firstOrder') }}</th>
-                  <th>{{ t('dashboard.topProducts.stockStatus') }}</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  v-for="item in topProducts"
-                  :key="item.sku"
-                  class="clickable-row"
-                  @click="showProductDetail(item)"
-                >
-                  <td><strong>{{ translateProductName(item.name) }}</strong></td>
-                  <td>{{ item.sku }}</td>
-                  <td>{{ translateCategory(item.category) }}</td>
-                  <td>{{ item.unitsOrdered }}</td>
-                  <td><strong>{{ formatCurrency(item.revenue, selectedCurrency) }}</strong></td>
-                  <td>{{ formatDate(item.firstOrderDate) }}</td>
-                  <td>
-                    <span :class="['badge', getStockBadge(item.stockLevel)]">
-                      {{ translateStockLevel(item.stockLevel) }}
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <TopProductsCard
+          :top-products="topProducts"
+          :selected-currency="selectedCurrency"
+          @show-product="showProductDetail"
+        />
       </div>
     </div>
 
@@ -285,14 +59,6 @@
       :backlog-item="selectedBacklogItem"
       @close="showBacklogModal = false"
     />
-
-    <PurchaseOrderModal
-      :is-open="showPOModal"
-      :backlog-item="selectedBacklogForPO"
-      :mode="poModalMode"
-      @close="showPOModal = false"
-      @po-created="handlePOCreated"
-    />
   </div>
 </template>
 
@@ -301,18 +67,27 @@ import { ref, onMounted, computed, watch } from 'vue'
 import { api } from '../api'
 import { useFilters } from '../composables/useFilters'
 import { useI18n } from '../composables/useI18n'
-import { formatCurrency } from '../utils/currency'
 import ProductDetailModal from '../components/ProductDetailModal.vue'
 import BacklogDetailModal from '../components/BacklogDetailModal.vue'
+import KpiSection from '../components/dashboard/KpiSection.vue'
+import OrderHealthCard from '../components/dashboard/OrderHealthCard.vue'
+import InventoryByCategoryCard from '../components/dashboard/InventoryByCategoryCard.vue'
+import InventoryShortagesCard from '../components/dashboard/InventoryShortagesCard.vue'
+import TopProductsCard from '../components/dashboard/TopProductsCard.vue'
 
 export default {
   name: 'Dashboard',
   components: {
     ProductDetailModal,
     BacklogDetailModal,
+    KpiSection,
+    OrderHealthCard,
+    InventoryByCategoryCard,
+    InventoryShortagesCard,
+    TopProductsCard
   },
   setup() {
-    const { t, currentCurrency, translateProductName, translateWarehouse } = useI18n()
+    const { t, currentCurrency } = useI18n()
     const loading = ref(true)
     const error = ref(null)
     const summary = ref({})
@@ -324,11 +99,7 @@ export default {
     const selectedProduct = ref(null)
     const showBacklogModal = ref(false)
     const selectedBacklogItem = ref(null)
-    const showPOModal = ref(false)
-    const selectedBacklogForPO = ref(null)
-    const poModalMode = ref('create')
 
-    // Use shared filters
     const {
       selectedPeriod,
       selectedLocation,
@@ -341,19 +112,11 @@ export default {
     const fillRate = ref(96.8)
 
     const revenueGoal = computed(() => {
-      // $800K per month, so if looking at all months (12 months), goal is 12 * 800K = 9.6M
       const monthlyGoal = 800000
       if (selectedPeriod.value === 'all') {
-        return monthlyGoal * 12 // $9,600,000 for the full year
+        return monthlyGoal * 12
       }
-      return monthlyGoal // $800,000 for a single month
-    })
-
-    const revenueGoalDisplay = computed(() => {
-      if (revenueGoal.value >= 1000000) {
-        return `$${(revenueGoal.value / 1000000).toFixed(1)}M`
-      }
-      return `$${(revenueGoal.value / 1000).toFixed(0)}K`
+      return monthlyGoal
     })
 
     const statusData = computed(() => {
@@ -370,7 +133,6 @@ export default {
       const totalValue = allOrders.value.reduce((sum, order) => sum + (order.total_value || 0), 0)
       const avgOrderValue = totalOrders > 0 ? totalValue / totalOrders : 0
 
-      // Calculate on-time delivery rate (delivered orders that arrived on or before expected date)
       const deliveredOrders = allOrders.value.filter(o => o.status.toLowerCase() === 'delivered')
       const onTimeDeliveries = deliveredOrders.filter(o => {
         if (o.actual_delivery && o.expected_delivery) {
@@ -380,7 +142,6 @@ export default {
       }).length
       const onTimeRate = deliveredOrders.length > 0 ? (onTimeDeliveries / deliveredOrders.length) * 100 : 0
 
-      // Calculate average fulfillment speed (days from order to delivery for delivered orders)
       let totalDays = 0
       let countWithDates = 0
       deliveredOrders.forEach(o => {
@@ -404,14 +165,9 @@ export default {
     })
 
     const categoryData = computed(() => {
-      // Group inventory by category and calculate values
-      // Filter inventory items to only include those with orders in the selected period
       const categoryMap = {}
+      const singleColor = '#64748b'
 
-      // Use a single neutral slate/gray color for all categories
-      const singleColor = '#64748b' // Neutral slate gray color
-
-      // Get SKUs from orders in the filtered time period
       const orderedSkus = new Set()
       allOrders.value.forEach(order => {
         if (order.items) {
@@ -421,8 +177,6 @@ export default {
         }
       })
 
-      // Only include inventory items that have orders in the selected period
-      // If no period is selected (all), include all inventory items
       const itemsToInclude = selectedPeriod.value === 'all'
         ? inventoryItems.value
         : inventoryItems.value.filter(item => orderedSkus.has(item.sku))
@@ -450,60 +204,17 @@ export default {
       return Math.max(...categoryData.value.map(c => c.value))
     })
 
-    const orderTrendData = computed(() => {
-      // Group orders by month from the actual data
-      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-
-      // Initialize all months with 0 orders
-      const monthMap = {}
-      monthNames.forEach(month => {
-        monthMap[month] = { month, orders: 0 }
-      })
-
-      // Count orders for each month
-      if (Array.isArray(allOrders.value)) {
-        allOrders.value.forEach(order => {
-          if (order && order.order_date) {
-            const date = new Date(order.order_date)
-            const monthIndex = date.getMonth()
-            // Check if monthIndex is valid (0-11)
-            if (!isNaN(monthIndex) && monthIndex >= 0 && monthIndex <= 11) {
-              const monthName = monthNames[monthIndex]
-              monthMap[monthName].orders++
-            }
-          }
-        })
-      }
-
-      // Return all months in order
-      return monthNames.map(month => monthMap[month])
-    })
-
-    const maxOrderCount = computed(() => {
-      if (orderTrendData.value.length === 0) return 10
-      const max = Math.max(...orderTrendData.value.map(d => d.orders))
-      // Round up to nearest 10 for cleaner axis, minimum 10
-      return Math.max(10, Math.ceil(max / 10) * 10)
-    })
-
     const topProducts = computed(() => {
-      // Calculate top products from filtered order data
       const productMap = {}
 
-      // allOrders is already filtered by API based on: month, warehouse, category, status
       allOrders.value.forEach(order => {
         if (order.items) {
           order.items.forEach(item => {
             const sku = item.sku
-
-            // Find matching inventory item to get full product details
-            // Note: inventoryItems is also filtered by API based on: warehouse, category
             const invItem = inventoryItems.value.find(i => i.sku === sku)
 
-            // Skip products that don't match current inventory filters
-            // (e.g., if filtering by warehouse A, don't show products from warehouse B)
             if (!invItem && (selectedLocation.value !== 'all' || selectedCategory.value !== 'all')) {
-              return // Skip this product as it doesn't match inventory filters
+              return
             }
 
             if (!productMap[sku]) {
@@ -518,7 +229,6 @@ export default {
                 firstOrderDate: order.order_date
               }
             } else {
-              // Update to EARLIEST order date (to show January at top when selecting All Months)
               if (order.order_date && (!productMap[sku].firstOrderDate || order.order_date < productMap[sku].firstOrderDate)) {
                 productMap[sku].firstOrderDate = order.order_date
               }
@@ -529,17 +239,13 @@ export default {
         }
       })
 
-      // Convert to array, sort by first order date (earliest first = January at top), then by revenue, and take top 12
       return Object.values(productMap)
         .sort((a, b) => {
-          // Sort by first order date (earliest first)
-          // This ensures products first ordered in January appear before those first ordered in December
           const dateA = new Date(a.firstOrderDate || '9999-12-31')
           const dateB = new Date(b.firstOrderDate || '9999-12-31')
           if (dateA.getTime() !== dateB.getTime()) {
-            return dateA.getTime() - dateB.getTime() // Earlier dates come first
+            return dateA.getTime() - dateB.getTime()
           }
-          // If dates are equal, sort by revenue (highest first)
           return b.revenue - a.revenue
         })
         .slice(0, 12)
@@ -547,13 +253,10 @@ export default {
 
     const allBacklogItems = ref([])
 
-    // Filter backlog based on inventory filters
     const backlogItems = computed(() => {
       if (selectedLocation.value === 'all' && selectedCategory.value === 'all') {
         return allBacklogItems.value
       }
-
-      // Get SKUs of items that match the filters
       const validSkus = new Set(inventoryItems.value.map(item => item.sku))
       return allBacklogItems.value.filter(b => validSkus.has(b.item_sku))
     })
@@ -563,7 +266,7 @@ export default {
         loading.value = true
         const filters = getCurrentFilters()
 
-        const [summaryData, ordersData, inventoryData, backlogData] = await Promise.all([
+        const [summaryData, ordersResponse, inventoryData, backlogData] = await Promise.all([
           api.getDashboardSummary(filters),
           api.getOrders(filters),
           api.getInventory(filters),
@@ -571,7 +274,7 @@ export default {
         ])
 
         summary.value = summaryData
-        allOrders.value = ordersData
+        allOrders.value = ordersResponse
         inventoryItems.value = inventoryData
         allBacklogItems.value = backlogData
       } catch (err) {
@@ -579,65 +282,6 @@ export default {
       } finally {
         loading.value = false
       }
-    }
-
-    const calculatePercentage = (value, goal) => {
-      return ((value / goal) * 100).toFixed(2)
-    }
-
-    // Compute total orders once for efficiency
-    const totalOrders = computed(() => {
-      return statusData.value.delivered + statusData.value.shipped +
-             statusData.value.processing + statusData.value.backordered
-    })
-
-    const getCircleSegment = (value) => {
-      return totalOrders.value > 0 ? (value / totalOrders.value) * 440 : 0
-    }
-
-    const getStockBadge = (level) => {
-      if (level === 'In Stock') return 'success'
-      if (level === 'Low Stock') return 'warning'
-      return 'danger'
-    }
-
-    const translateCategory = (category) => {
-      const categoryMap = {
-        'Circuit Boards': t('categories.circuitBoards'),
-        'Sensors': t('categories.sensors'),
-        'Actuators': t('categories.actuators'),
-        'Controllers': t('categories.controllers'),
-        'Power Supplies': t('categories.powerSupplies')
-      }
-      return categoryMap[category] || category
-    }
-
-    const translateStockLevel = (stockLevel) => {
-      const stockMap = {
-        'In Stock': t('status.inStock'),
-        'Low Stock': t('status.lowStock')
-      }
-      return stockMap[stockLevel] || stockLevel
-    }
-
-    const translatePriority = (priority) => {
-      const priorityMap = {
-        'high': t('priority.high'),
-        'medium': t('priority.medium'),
-        'low': t('priority.low'),
-        'High': t('priority.high'),
-        'Medium': t('priority.medium'),
-        'Low': t('priority.low')
-      }
-      return priorityMap[priority] || priority
-    }
-
-    const formatDate = (dateString) => {
-      if (!dateString) return '-'
-      const { currentLocale } = useI18n()
-      const locale = currentLocale.value === 'ja' ? 'ja-JP' : 'en-US'
-      const date = new Date(dateString)
-      return date.toLocaleDateString(locale, { month: 'short', day: 'numeric', year: 'numeric' })
     }
 
     const showProductDetail = (product) => {
@@ -650,29 +294,6 @@ export default {
       showBacklogModal.value = true
     }
 
-    const openPOModal = (item) => {
-      selectedBacklogForPO.value = item
-      poModalMode.value = 'create'
-      showPOModal.value = true
-    }
-
-    const viewPO = (item) => {
-      selectedBacklogForPO.value = item
-      poModalMode.value = 'view'
-      showPOModal.value = true
-    }
-
-    const handlePOCreated = (poData) => {
-      // Update the backlog item with the new PO ID
-      const item = allBacklogItems.value.find(b => b.id === poData.backlog_item_id)
-      if (item) {
-        item.purchase_order_id = poData.id
-        item.purchase_order = poData
-      }
-      showPOModal.value = false
-    }
-
-    // Watch for filter changes and reload data
     watch([selectedPeriod, selectedLocation, selectedCategory, selectedStatus], () => {
       loadData()
     })
@@ -690,19 +311,9 @@ export default {
       orderHealthMetrics,
       categoryData,
       maxCategoryValue,
-      orderTrendData,
-      maxOrderCount,
       topProducts,
       backlogItems,
-      calculatePercentage,
-      getCircleSegment,
-      getStockBadge,
-      translateCategory,
-      translateStockLevel,
-      translatePriority,
-      formatDate,
       revenueGoal,
-      revenueGoalDisplay,
       showProductModal,
       selectedProduct,
       showProductDetail,
@@ -710,17 +321,7 @@ export default {
       selectedBacklogItem,
       showBacklogDetail,
       selectedPeriod,
-      selectedCurrency: currentCurrency,
-      formatCurrency,
-      Math,
-      translateProductName,
-      translateWarehouse,
-      showPOModal,
-      selectedBacklogForPO,
-      poModalMode,
-      openPOModal,
-      viewPO,
-      handlePOCreated
+      selectedCurrency: currentCurrency
     }
   }
 }
@@ -739,8 +340,8 @@ export default {
   color: var(--color-text-muted);
 }
 
-.kpi-section {
-  margin-bottom: 1.5rem;
+.summary-section {
+  margin-bottom: 1rem;
 }
 
 .section-title {
@@ -752,64 +353,6 @@ export default {
   margin-bottom: 1rem;
 }
 
-.kpi-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.kpi-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 1rem;
-}
-
-.kpi-header {
-  margin-bottom: 0.75rem;
-}
-
-.kpi-label {
-  font-size: 0.813rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-}
-
-.kpi-value {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--color-text);
-  margin-bottom: 0.5rem;
-  letter-spacing: -0.025em;
-}
-
-.kpi-goal {
-  font-size: 0.813rem;
-  color: var(--color-text-muted);
-  margin-bottom: 0.75rem;
-}
-
-.kpi-progress-bar {
-  width: 100%;
-  height: 6px;
-  background: var(--color-surface-alt);
-  border-radius: 3px;
-  overflow: hidden;
-}
-
-.kpi-progress {
-  height: 100%;
-  background: var(--color-accent);
-  border-radius: 3px;
-  transition: width 0.6s ease;
-}
-
-.kpi-progress.success {
-  background: var(--color-success);
-}
-
 .charts-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -817,456 +360,7 @@ export default {
   margin-bottom: 1.5rem;
 }
 
-.chart-card.full-width {
+.charts-grid :deep(.chart-card.full-width) {
   grid-column: 1 / -1;
-}
-
-.chart-content {
-  padding: 1rem;
-}
-
-.donut-chart {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 3rem;
-}
-
-.donut-svg {
-  width: 200px;
-  height: 200px;
-}
-
-.donut-legend {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.legend-item {
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
-}
-
-.legend-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-}
-
-/* Order Health Dashboard Styles */
-.order-health-container {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
-  align-items: center;
-  padding: 1rem;
-  min-height: 240px;
-}
-
-.order-health-chart {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  padding: 0 1rem;
-}
-
-.donut-svg-compact {
-  width: 200px;
-  height: 200px;
-}
-
-.donut-center-label {
-  font-size: 12px;
-  fill: var(--color-text-muted);
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.donut-center-value {
-  font-size: 36px;
-  fill: var(--color-text);
-  font-weight: 700;
-}
-
-.donut-legend-compact {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.625rem 1.25rem;
-}
-
-.legend-item-compact {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
-  font-weight: 500;
-}
-
-.order-health-metrics {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  justify-content: center;
-  align-items: center;
-}
-
-.health-metric {
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-  text-align: center;
-  width: 100%;
-}
-
-.health-metric-label {
-  font-size: 0.688rem;
-  color: var(--color-text-muted);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.health-metric-value {
-  font-size: 1.75rem;
-  font-weight: 700;
-  color: var(--color-text);
-  letter-spacing: -0.025em;
-}
-
-.metric-good {
-  color: var(--color-success);
-}
-
-.metric-warning {
-  color: var(--color-warning);
-}
-
-.metric-bad {
-  color: var(--color-danger);
-}
-
-.horizontal-bar-chart {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  padding: 0 1rem;
-}
-
-.h-bar-item {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.h-bar-label {
-  width: 120px;
-  min-width: 120px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  flex-shrink: 0;
-}
-
-.h-bar-container {
-  flex: 1;
-  height: 32px;
-  background: var(--color-bg);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-}
-
-.h-bar {
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding-right: 0.75rem;
-  transition: width 0.6s ease;
-}
-
-.h-bar-value {
-  font-size: 0.813rem;
-  font-weight: 700;
-  color: white;
-}
-
-.line-chart {
-  display: flex;
-  gap: 1.5rem;
-  height: 280px;
-}
-
-.line-y-axis {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding-right: 1rem;
-  font-size: 0.75rem;
-  color: var(--color-text-subtle);
-  border-right: 1px solid var(--color-border);
-}
-
-.line-chart-area {
-  flex: 1;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-around;
-  gap: 0.5rem;
-}
-
-.line-bar-group {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
-  max-width: 80px;
-  gap: 0.5rem;
-}
-
-.line-bar-wrapper {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-.line-bar {
-  width: 100%;
-  max-width: 60px;
-  min-height: 8px;
-  background: var(--color-accent);
-  border-radius: 6px 6px 0 0;
-  transition: all 0.3s ease;
-  cursor: pointer;
-  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
-}
-
-.line-bar.empty-bar {
-  background: var(--color-border);
-  box-shadow: none;
-  min-height: 4px;
-}
-
-.line-bar:hover {
-  background: var(--color-accent);
-  transform: scaleY(1.05);
-}
-
-.line-bar.empty-bar:hover {
-  background: var(--color-border-strong);
-  transform: none;
-}
-
-.line-bar-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-}
-
-.no-data {
-  padding: 2rem;
-  text-align: center;
-  color: var(--color-text-subtle);
-  font-size: 0.875rem;
-}
-
-.no-backlog {
-  padding: 3rem;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-}
-
-.success-icon {
-  width: 48px;
-  height: 48px;
-  color: var(--color-success);
-}
-
-.no-backlog-text {
-  font-size: 1.125rem;
-  color: var(--color-success);
-  font-weight: 600;
-  margin: 0;
-}
-
-.clickable-row {
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-
-.clickable-row:hover {
-  background: var(--color-accent-bg) !important;
-}
-
-/* Tasks Card Styles */
-.tasks-card {
-  margin-bottom: 2rem;
-}
-
-.tasks-content {
-  padding: 1.5rem;
-}
-
-.task-input-container {
-  display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.task-input {
-  flex: 1;
-  padding: 0.75rem;
-  border: 2px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  font-size: 0.95rem;
-  transition: border-color 0.2s ease;
-}
-
-.task-input:focus {
-  outline: none;
-  border-color: #667eea;
-}
-
-.task-add-btn {
-  padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.task-add-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-}
-
-.task-add-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.no-tasks {
-  text-align: center;
-  padding: 2rem;
-  color: var(--color-text-muted);
-  font-style: italic;
-}
-
-.tasks-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.task-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  background: var(--color-bg);
-  border-radius: var(--radius-sm);
-  border: 2px solid transparent;
-  transition: all 0.2s ease;
-}
-
-.task-item:hover {
-  border-color: var(--color-border);
-  background: var(--color-surface);
-}
-
-.task-item.completed {
-  opacity: 0.6;
-}
-
-.task-item.completed .task-text {
-  text-decoration: line-through;
-  color: var(--color-text-subtle);
-}
-
-.task-checkbox {
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  accent-color: #667eea;
-}
-
-.task-text {
-  flex: 1;
-  cursor: pointer;
-  user-select: none;
-  color: var(--color-text);
-  font-size: 0.95rem;
-}
-
-.task-delete-btn {
-  width: 28px;
-  height: 28px;
-  background: var(--color-danger);
-  color: white;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 1.25rem;
-  line-height: 1;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-}
-
-.task-delete-btn:hover {
-  background: #b91c1c;
-  transform: scale(1.1);
-}
-
-.po-button {
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 0.813rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-}
-
-.po-button.create {
-  background: var(--color-accent);
-  color: white;
-}
-
-.po-button.create:hover {
-  background: var(--color-accent);
-  opacity: 0.9;
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-sm);
-}
-
-.po-button.view {
-  background: var(--color-text-muted);
-  color: white;
-}
-
-.po-button.view:hover {
-  opacity: 0.9;
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-sm);
 }
 </style>

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -180,7 +180,7 @@
                   <th>{{ t('dashboard.inventoryShortages.shortage') }}</th>
                   <th>{{ t('dashboard.inventoryShortages.daysDelayed') }}</th>
                   <th>{{ t('dashboard.inventoryShortages.priority') }}</th>
-                  <th>Actions</th>
+                  <th>{{ t('common.actions') }}</th>
                 </tr>
               </thead>
               <tbody>
@@ -214,14 +214,14 @@
                       @click.stop="openPOModal(item)"
                       class="po-button create"
                     >
-                      Create PO
+                      {{ t('dashboard.inventoryShortages.createPO') }}
                     </button>
                     <button
                       v-else
                       @click.stop="viewPO(item)"
                       class="po-button view"
                     >
-                      View PO
+                      {{ t('dashboard.inventoryShortages.viewPO') }}
                     </button>
                   </td>
                 </tr>
@@ -736,7 +736,7 @@ export default {
 
 .header-meta {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .kpi-section {
@@ -746,7 +746,7 @@ export default {
 .section-title {
   font-size: 1rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 1rem;
@@ -759,9 +759,9 @@ export default {
 }
 
 .kpi-card {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   padding: 1rem;
 }
 
@@ -772,7 +772,7 @@ export default {
 .kpi-label {
   font-size: 0.813rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.025em;
 }
@@ -780,34 +780,34 @@ export default {
 .kpi-value {
   font-size: 2rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
   margin-bottom: 0.5rem;
   letter-spacing: -0.025em;
 }
 
 .kpi-goal {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   margin-bottom: 0.75rem;
 }
 
 .kpi-progress-bar {
   width: 100%;
   height: 6px;
-  background: #f1f5f9;
+  background: var(--color-surface-alt);
   border-radius: 3px;
   overflow: hidden;
 }
 
 .kpi-progress {
   height: 100%;
-  background: #3b82f6;
+  background: var(--color-accent);
   border-radius: 3px;
   transition: width 0.6s ease;
 }
 
 .kpi-progress.success {
-  background: #10b981;
+  background: var(--color-success);
 }
 
 .charts-grid {
@@ -848,7 +848,7 @@ export default {
   align-items: center;
   gap: 0.625rem;
   font-size: 0.875rem;
-  color: #475569;
+  color: var(--color-text-muted);
 }
 
 .legend-dot {
@@ -883,7 +883,7 @@ export default {
 
 .donut-center-label {
   font-size: 12px;
-  fill: #64748b;
+  fill: var(--color-text-muted);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -891,7 +891,7 @@ export default {
 
 .donut-center-value {
   font-size: 36px;
-  fill: #0f172a;
+  fill: var(--color-text);
   font-weight: 700;
 }
 
@@ -906,7 +906,7 @@ export default {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: #475569;
+  color: var(--color-text-muted);
   font-weight: 500;
 }
 
@@ -928,7 +928,7 @@ export default {
 
 .health-metric-label {
   font-size: 0.688rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -937,20 +937,20 @@ export default {
 .health-metric-value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
   letter-spacing: -0.025em;
 }
 
 .metric-good {
-  color: #10b981;
+  color: var(--color-success);
 }
 
 .metric-warning {
-  color: #f59e0b;
+  color: var(--color-warning);
 }
 
 .metric-bad {
-  color: #ef4444;
+  color: var(--color-danger);
 }
 
 .horizontal-bar-chart {
@@ -971,15 +971,15 @@ export default {
   min-width: 120px;
   font-size: 0.875rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-muted);
   flex-shrink: 0;
 }
 
 .h-bar-container {
   flex: 1;
   height: 32px;
-  background: #f8fafc;
-  border-radius: 6px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
@@ -1010,8 +1010,8 @@ export default {
   justify-content: space-between;
   padding-right: 1rem;
   font-size: 0.75rem;
-  color: #94a3b8;
-  border-right: 1px solid #e2e8f0;
+  color: var(--color-text-subtle);
+  border-right: 1px solid var(--color-border);
 }
 
 .line-chart-area {
@@ -1044,7 +1044,7 @@ export default {
   width: 100%;
   max-width: 60px;
   min-height: 8px;
-  background: #3b82f6;
+  background: var(--color-accent);
   border-radius: 6px 6px 0 0;
   transition: all 0.3s ease;
   cursor: pointer;
@@ -1052,32 +1052,32 @@ export default {
 }
 
 .line-bar.empty-bar {
-  background: #e2e8f0;
+  background: var(--color-border);
   box-shadow: none;
   min-height: 4px;
 }
 
 .line-bar:hover {
-  background: #2563eb;
+  background: var(--color-accent);
   transform: scaleY(1.05);
 }
 
 .line-bar.empty-bar:hover {
-  background: #cbd5e1;
+  background: var(--color-border-strong);
   transform: none;
 }
 
 .line-bar-label {
   font-size: 0.75rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .no-data {
   padding: 2rem;
   text-align: center;
-  color: #94a3b8;
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
 }
 
@@ -1093,12 +1093,12 @@ export default {
 .success-icon {
   width: 48px;
   height: 48px;
-  color: #10b981;
+  color: var(--color-success);
 }
 
 .no-backlog-text {
   font-size: 1.125rem;
-  color: #10b981;
+  color: var(--color-success);
   font-weight: 600;
   margin: 0;
 }
@@ -1109,7 +1109,7 @@ export default {
 }
 
 .clickable-row:hover {
-  background: #eff6ff !important;
+  background: var(--color-accent-bg) !important;
 }
 
 /* Tasks Card Styles */
@@ -1130,8 +1130,8 @@ export default {
 .task-input {
   flex: 1;
   padding: 0.75rem;
-  border: 2px solid #e2e8f0;
-  border-radius: 8px;
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-sm);
   font-size: 0.95rem;
   transition: border-color 0.2s ease;
 }
@@ -1146,7 +1146,7 @@ export default {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, opacity 0.2s ease;
@@ -1164,7 +1164,7 @@ export default {
 .no-tasks {
   text-align: center;
   padding: 2rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-style: italic;
 }
 
@@ -1179,15 +1179,15 @@ export default {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem;
-  background: #f8fafc;
-  border-radius: 8px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
   border: 2px solid transparent;
   transition: all 0.2s ease;
 }
 
 .task-item:hover {
-  border-color: #e2e8f0;
-  background: white;
+  border-color: var(--color-border);
+  background: var(--color-surface);
 }
 
 .task-item.completed {
@@ -1196,7 +1196,7 @@ export default {
 
 .task-item.completed .task-text {
   text-decoration: line-through;
-  color: #94a3b8;
+  color: var(--color-text-subtle);
 }
 
 .task-checkbox {
@@ -1210,17 +1210,17 @@ export default {
   flex: 1;
   cursor: pointer;
   user-select: none;
-  color: #0f172a;
+  color: var(--color-text);
   font-size: 0.95rem;
 }
 
 .task-delete-btn {
   width: 28px;
   height: 28px;
-  background: #ef4444;
+  background: var(--color-danger);
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
@@ -1232,14 +1232,14 @@ export default {
 }
 
 .task-delete-btn:hover {
-  background: #dc2626;
+  background: #b91c1c;
   transform: scale(1.1);
 }
 
 .po-button {
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 0.813rem;
   font-weight: 600;
   cursor: pointer;
@@ -1248,24 +1248,25 @@ export default {
 }
 
 .po-button.create {
-  background: #3b82f6;
+  background: var(--color-accent);
   color: white;
 }
 
 .po-button.create:hover {
-  background: #2563eb;
+  background: var(--color-accent);
+  opacity: 0.9;
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
+  box-shadow: var(--shadow-sm);
 }
 
 .po-button.view {
-  background: #64748b;
+  background: var(--color-text-muted);
   color: white;
 }
 
 .po-button.view:hover {
-  background: #475569;
+  opacity: 0.9;
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(100, 116, 139, 0.3);
+  box-shadow: var(--shadow-sm);
 }
 </style>

--- a/client/src/views/Demand.vue
+++ b/client/src/views/Demand.vue
@@ -232,27 +232,27 @@ export default {
 }
 
 .trend-card {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   transition: all 0.2s ease;
 }
 
 .trend-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-md);
 }
 
 .increasing-card {
-  border-left: 4px solid #10b981;
+  border-left: 4px solid var(--color-success);
 }
 
 .stable-card {
-  border-left: 4px solid #3b82f6;
+  border-left: 4px solid var(--color-accent);
 }
 
 .decreasing-card {
-  border-left: 4px solid #ef4444;
+  border-left: 4px solid var(--color-danger);
 }
 
 .trend-header {
@@ -261,7 +261,7 @@ export default {
   gap: 1rem;
   margin-bottom: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--color-surface-alt);
 }
 
 .trend-icon {
@@ -270,31 +270,31 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   font-size: 1.75rem;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .increasing-card .trend-icon {
-  background: #d1fae5;
-  color: #059669;
+  background: var(--color-success-bg);
+  color: var(--color-success);
 }
 
 .stable-card .trend-icon {
-  background: #dbeafe;
-  color: #2563eb;
+  background: var(--color-info-bg);
+  color: var(--color-accent);
 }
 
 .decreasing-card .trend-icon {
-  background: #fee2e2;
-  color: #dc2626;
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
 }
 
 .trend-label {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -302,7 +302,7 @@ export default {
 .trend-count {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
   margin-top: 0.25rem;
 }
 
@@ -317,18 +317,18 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 0.75rem;
-  background: #f8fafc;
-  border-radius: 6px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
   transition: background 0.2s;
 }
 
 .trend-item:hover {
-  background: #f1f5f9;
+  background: var(--color-surface-alt);
 }
 
 .item-name {
   font-size: 0.875rem;
-  color: #0f172a;
+  color: var(--color-text);
   font-weight: 500;
   flex: 1;
   overflow: hidden;
@@ -344,24 +344,24 @@ export default {
 }
 
 .increasing-card .item-change {
-  color: #059669;
+  color: var(--color-success);
 }
 
 .stable-card .item-change {
-  color: #3b82f6;
+  color: var(--color-accent);
 }
 
 .decreasing-card .item-change {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .item-change.neutral {
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .more-items {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-style: italic;
   text-align: center;
   padding: 0.5rem;

--- a/client/src/views/Inventory.vue
+++ b/client/src/views/Inventory.vue
@@ -234,7 +234,7 @@ export default {
 }
 
 .page-header p {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.875rem;
 }
 
@@ -244,13 +244,13 @@ export default {
   align-items: center;
   gap: 1.5rem;
   padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .card-title {
   font-size: 1rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text);
   margin: 0;
 }
 
@@ -266,30 +266,30 @@ export default {
   left: 0.75rem;
   width: 18px;
   height: 18px;
-  color: #94a3b8;
+  color: var(--color-text-subtle);
   pointer-events: none;
 }
 
 .search-input {
   width: 100%;
   padding: 0.5rem 2.5rem 0.5rem 2.5rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
   font-size: 0.875rem;
-  color: #0f172a;
-  background: #f8fafc;
+  color: var(--color-text);
+  background: var(--color-bg);
   transition: all 0.2s;
 }
 
 .search-input:focus {
   outline: none;
-  border-color: #3b82f6;
-  background: white;
+  border-color: var(--color-accent);
+  background: var(--color-surface);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
 .search-input::placeholder {
-  color: #94a3b8;
+  color: var(--color-text-subtle);
 }
 
 .clear-search {
@@ -302,14 +302,14 @@ export default {
   background: transparent;
   border: none;
   border-radius: 4px;
-  color: #94a3b8;
+  color: var(--color-text-subtle);
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .clear-search:hover {
-  background: #e2e8f0;
-  color: #64748b;
+  background: var(--color-border);
+  color: var(--color-text-muted);
 }
 
 .clear-search svg {
@@ -321,11 +321,11 @@ export default {
 .error {
   padding: 2rem;
   text-align: center;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .error {
-  color: #ef4444;
+  color: var(--color-danger);
 }
 
 .clickable-row {
@@ -334,6 +334,6 @@ export default {
 }
 
 .clickable-row:hover {
-  background: #eff6ff !important;
+  background: var(--color-accent-bg) !important;
 }
 </style>

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -8,6 +8,49 @@
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
+      <!-- Submitted Restocking Orders -->
+      <div v-if="restockingOrders.length > 0" class="card restocking-card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders</h3>
+          <span class="badge info">{{ restockingOrders.length }} {{ restockingOrders.length === 1 ? 'order' : 'orders' }}</span>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Order ID</th>
+                <th>Items</th>
+                <th>Total Cost</th>
+                <th>Max Lead Time</th>
+                <th>Expected Delivery</th>
+                <th>Status</th>
+                <th>Submitted</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="ro in restockingOrders" :key="ro.id">
+                <td><strong>{{ ro.id }}</strong></td>
+                <td>
+                  <details>
+                    <summary class="items-summary">{{ ro.items.length }} items</summary>
+                    <div class="restock-items-list">
+                      <div v-for="item in ro.items" :key="item.sku" class="restock-item-row">
+                        {{ item.sku }} &times; {{ item.quantity }}
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td>{{ formatCurrency(ro.total_cost) }}</td>
+                <td>{{ ro.max_lead_time_days }} days</td>
+                <td>{{ formatDateStr(ro.expected_delivery_date) }}</td>
+                <td><span class="badge info">Submitted</span></td>
+                <td>{{ formatDateStr(ro.submitted_date) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="stats-grid">
         <div class="stat-card success">
           <div class="stat-label">{{ t('status.delivered') }}</div>
@@ -95,6 +138,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -122,6 +166,28 @@ export default {
       } finally {
         loading.value = false
       }
+    }
+
+    const loadRestockingOrders = async () => {
+      try {
+        restockingOrders.value = await api.getRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load restocking orders:', err)
+      }
+    }
+
+    const formatCurrency = (value) => {
+      return Number(value).toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0
+      })
+    }
+
+    const formatDateStr = (dateString) => {
+      const d = new Date(dateString)
+      if (isNaN(d.getTime())) return dateString
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
     }
 
     // Watch for filter changes and reload data
@@ -153,7 +219,10 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    onMounted(() => {
+      loadOrders()
+      loadRestockingOrders()
+    })
 
     return {
       t,
@@ -165,13 +234,37 @@ export default {
       formatDate,
       currencySymbol,
       translateProductName,
-      translateCustomerName
+      translateCustomerName,
+      restockingOrders,
+      formatCurrency,
+      formatDateStr
     }
   }
 }
 </script>
 
 <style scoped>
+/* Restocking card accent */
+.restocking-card {
+  background: var(--color-accent-bg);
+  border-color: #bfdbfe;
+}
+
+.restock-items-list {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  min-width: 180px;
+}
+
+.restock-item-row {
+  font-size: 0.813rem;
+  color: var(--color-text-muted);
+  padding: 2px 0;
+}
+
 /* Fixed table layout to prevent column shifting */
 .orders-table {
   table-layout: fixed;

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -247,7 +247,7 @@ export default {
 /* Restocking card accent */
 .restocking-card {
   background: var(--color-accent-bg);
-  border-color: #bfdbfe;
+  border-color: var(--color-info-bg);
 }
 
 .restock-items-list {
@@ -303,7 +303,7 @@ export default {
 
 .items-summary {
   cursor: pointer;
-  color: #3b82f6;
+  color: var(--color-accent);
   font-weight: 500;
   list-style: none;
   user-select: none;
@@ -327,7 +327,8 @@ export default {
 }
 
 .items-summary:hover {
-  color: #2563eb;
+  color: var(--color-accent);
+  opacity: 0.8;
   text-decoration: underline;
 }
 
@@ -337,10 +338,10 @@ export default {
   top: 100%;
   left: 0;
   margin-top: 0.5rem;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
   padding: 0.75rem;
   z-index: 10;
   min-width: 300px;
@@ -352,7 +353,7 @@ export default {
   flex-direction: column;
   gap: 0.25rem;
   padding: 0.5rem;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--color-surface-alt);
 }
 
 .item-entry:last-child {
@@ -362,11 +363,11 @@ export default {
 .item-name {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #0f172a;
+  color: var(--color-text);
 }
 
 .item-meta {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 </style>

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -11,20 +11,20 @@
       <!-- Submitted Restocking Orders -->
       <div v-if="restockingOrders.length > 0" class="card restocking-card">
         <div class="card-header">
-          <h3 class="card-title">Submitted Restocking Orders</h3>
-          <span class="badge info">{{ restockingOrders.length }} {{ restockingOrders.length === 1 ? 'order' : 'orders' }}</span>
+          <h3 class="card-title">{{ t('orders.restockingOrders.title') }}</h3>
+          <span class="badge info">{{ t('orders.restockingOrders.itemsCount', { count: restockingOrders.length }) }}</span>
         </div>
         <div class="table-container">
           <table>
             <thead>
               <tr>
-                <th>Order ID</th>
-                <th>Items</th>
-                <th>Total Cost</th>
-                <th>Max Lead Time</th>
-                <th>Expected Delivery</th>
-                <th>Status</th>
-                <th>Submitted</th>
+                <th>{{ t('orders.restockingOrders.orderId') }}</th>
+                <th>{{ t('orders.restockingOrders.items') }}</th>
+                <th>{{ t('orders.restockingOrders.totalCost') }}</th>
+                <th>{{ t('orders.restockingOrders.maxLeadTime') }}</th>
+                <th>{{ t('orders.restockingOrders.expectedDelivery') }}</th>
+                <th>{{ t('orders.restockingOrders.status') }}</th>
+                <th>{{ t('orders.restockingOrders.submitted') }}</th>
               </tr>
             </thead>
             <tbody>
@@ -32,7 +32,7 @@
                 <td><strong>{{ ro.id }}</strong></td>
                 <td>
                   <details>
-                    <summary class="items-summary">{{ ro.items.length }} items</summary>
+                    <summary class="items-summary">{{ t('orders.restockingOrders.itemsCount', { count: ro.items.length }) }}</summary>
                     <div class="restock-items-list">
                       <div v-for="item in ro.items" :key="item.sku" class="restock-item-row">
                         {{ item.sku }} &times; {{ item.quantity }}
@@ -41,9 +41,9 @@
                   </details>
                 </td>
                 <td>{{ formatCurrency(ro.total_cost) }}</td>
-                <td>{{ ro.max_lead_time_days }} days</td>
+                <td>{{ ro.max_lead_time_days }} {{ t('orders.restockingOrders.days') }}</td>
                 <td>{{ formatDateStr(ro.expected_delivery_date) }}</td>
-                <td><span class="badge info">Submitted</span></td>
+                <td><span class="badge info">{{ t('orders.restockingOrders.submitted') }}</span></td>
                 <td>{{ formatDateStr(ro.submitted_date) }}</td>
               </tr>
             </tbody>

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -1,35 +1,35 @@
 <template>
   <div class="reports">
     <div class="page-header">
-      <h2>Performance Reports</h2>
-      <p>View quarterly performance metrics and monthly trends</p>
+      <h2>{{ t('reports.title') }}</h2>
+      <p>{{ t('reports.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading reports...</div>
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <!-- Quarterly Performance -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Quarterly Performance</h3>
+          <h3 class="card-title">{{ t('reports.quarterlyPerformance') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Quarter</th>
-                <th>Total Orders</th>
-                <th>Total Revenue</th>
-                <th>Avg Order Value</th>
-                <th>Fulfillment Rate</th>
+                <th>{{ t('reports.table.quarter') }}</th>
+                <th>{{ t('reports.table.totalOrders') }}</th>
+                <th>{{ t('reports.table.totalRevenue') }}</th>
+                <th>{{ t('reports.table.avgOrderValue') }}</th>
+                <th>{{ t('reports.table.fulfillmentRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="q in quarterlyData" :key="q.quarter">
+              <tr v-for="q in filteredQuarterlyData" :key="q.quarter">
                 <td><strong>{{ q.quarter }}</strong></td>
                 <td>{{ q.total_orders }}</td>
-                <td>${{ formatNumber(q.total_revenue) }}</td>
-                <td>${{ formatNumber(q.avg_order_value) }}</td>
+                <td>{{ formatCurrency(q.total_revenue, currentCurrency) }}</td>
+                <td>{{ formatCurrency(q.avg_order_value, currentCurrency) }}</td>
                 <td>
                   <span :class="getFulfillmentClass(q.fulfillment_rate)">
                     {{ q.fulfillment_rate }}%
@@ -41,19 +41,19 @@
         </div>
       </div>
 
-      <!-- Monthly Trends Chart -->
+      <!-- Monthly Revenue Trend Chart -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Monthly Revenue Trend</h3>
+          <h3 class="card-title">{{ t('reports.monthlyRevenueTrend') }}</h3>
         </div>
         <div class="chart-container">
           <div class="bar-chart">
-            <div v-for="month in monthlyData" :key="month.month" class="bar-wrapper">
+            <div v-for="month in filteredMonthlyData" :key="month.month" class="bar-wrapper">
               <div class="bar-container">
                 <div
                   class="bar"
                   :style="{ height: getBarHeight(month.revenue) + 'px' }"
-                  :title="'$' + formatNumber(month.revenue)"
+                  :title="formatCurrency(month.revenue, currentCurrency)"
                 ></div>
               </div>
               <div class="bar-label">{{ formatMonth(month.month) }}</div>
@@ -65,33 +65,33 @@
       <!-- Month-over-Month Comparison -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Month-over-Month Analysis</h3>
+          <h3 class="card-title">{{ t('reports.monthOverMonth') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Month</th>
-                <th>Orders</th>
-                <th>Revenue</th>
-                <th>Change</th>
-                <th>Growth Rate</th>
+                <th>{{ t('reports.table.month') }}</th>
+                <th>{{ t('reports.table.orders') }}</th>
+                <th>{{ t('reports.table.revenue') }}</th>
+                <th>{{ t('reports.table.change') }}</th>
+                <th>{{ t('reports.table.growthRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(month, index) in monthlyData" :key="month.month">
+              <tr v-for="(month, index) in filteredMonthlyData" :key="month.month">
                 <td><strong>{{ formatMonth(month.month) }}</strong></td>
                 <td>{{ month.order_count }}</td>
-                <td>${{ formatNumber(month.revenue) }}</td>
+                <td>{{ formatCurrency(month.revenue, currentCurrency) }}</td>
                 <td>
-                  <span v-if="index > 0" :class="getChangeClass(month.revenue, monthlyData[index - 1].revenue)">
-                    {{ getChangeValue(month.revenue, monthlyData[index - 1].revenue) }}
+                  <span v-if="index > 0" :class="getChangeClass(month.revenue, filteredMonthlyData[index - 1].revenue)">
+                    {{ getChangeValue(month.revenue, filteredMonthlyData[index - 1].revenue) }}
                   </span>
                   <span v-else>-</span>
                 </td>
                 <td>
-                  <span v-if="index > 0" :class="getChangeClass(month.revenue, monthlyData[index - 1].revenue)">
-                    {{ getGrowthRate(month.revenue, monthlyData[index - 1].revenue) }}
+                  <span v-if="index > 0" :class="getChangeClass(month.revenue, filteredMonthlyData[index - 1].revenue)">
+                    {{ getGrowthRate(month.revenue, filteredMonthlyData[index - 1].revenue) }}
                   </span>
                   <span v-else>-</span>
                 </td>
@@ -104,19 +104,19 @@
       <!-- Summary Stats -->
       <div class="stats-grid">
         <div class="stat-card">
-          <div class="stat-label">Total Revenue (YTD)</div>
-          <div class="stat-value">${{ formatNumber(totalRevenue) }}</div>
+          <div class="stat-label">{{ t('reports.totalRevenueYTD') }}</div>
+          <div class="stat-value">{{ formatCurrency(totalRevenue, currentCurrency) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Avg Monthly Revenue</div>
-          <div class="stat-value">${{ formatNumber(avgMonthlyRevenue) }}</div>
+          <div class="stat-label">{{ t('reports.avgMonthlyRevenue') }}</div>
+          <div class="stat-value">{{ formatCurrency(avgMonthlyRevenue, currentCurrency) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Orders (YTD)</div>
+          <div class="stat-label">{{ t('reports.totalOrdersYTD') }}</div>
           <div class="stat-value">{{ totalOrders }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Best Performing Quarter</div>
+          <div class="stat-label">{{ t('reports.bestPerformingQuarter') }}</div>
           <div class="stat-value">{{ bestQuarter }}</div>
         </div>
       </div>
@@ -125,192 +125,186 @@
 </template>
 
 <script>
-import axios from 'axios'
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
+import { formatCurrency } from '../utils/currency'
 
 export default {
   name: 'Reports',
-  data() {
-    return {
-      loading: true,
-      error: null,
-      quarterlyData: [],
-      monthlyData: [],
-      totalRevenue: 0,
-      avgMonthlyRevenue: 0,
-      totalOrders: 0,
-      bestQuarter: ''
+  setup() {
+    const { t, currentCurrency } = useI18n()
+    const {
+      selectedPeriod,
+      selectedLocation,
+      selectedCategory,
+      selectedStatus
+    } = useFilters()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const allQuarterlyData = ref([])
+    const allMonthlyData = ref([])
+
+    // Map period string to quarter identifier: 'Q1-2025', 'Q2-2025', etc.
+    const periodToQuarter = (period) => {
+      if (!period || period === 'all') return null
+      // If it's already a quarter string like 'Q1-2025'
+      if (/^Q[1-4]-\d{4}$/.test(period)) return period
+      // If it's a YYYY-MM string, find the quarter
+      const match = period.match(/^(\d{4})-(\d{2})$/)
+      if (match) {
+        const month = parseInt(match[2], 10)
+        const year = match[1]
+        const quarter = Math.ceil(month / 3)
+        return `Q${quarter}-${year}`
+      }
+      return null
     }
-  },
-  mounted() {
-    console.log('Reports component mounted')
-    this.loadData()
-  },
-  methods: {
-    async loadData() {
-      console.log('Loading reports data...')
+
+    // Filter quarterly data based on selected period
+    const filteredQuarterlyData = computed(() => {
+      if (selectedPeriod.value === 'all') return allQuarterlyData.value
+      const quarter = periodToQuarter(selectedPeriod.value)
+      if (!quarter) return allQuarterlyData.value
+      return allQuarterlyData.value.filter(q => q.quarter === quarter)
+    })
+
+    // Filter monthly data based on selected period
+    const filteredMonthlyData = computed(() => {
+      if (selectedPeriod.value === 'all') return allMonthlyData.value
+      // If period is a quarter like 'Q1-2025', show months Jan/Feb/Mar 2025
+      if (/^Q[1-4]-\d{4}$/.test(selectedPeriod.value)) {
+        const qMatch = selectedPeriod.value.match(/^Q([1-4])-(\d{4})$/)
+        if (qMatch) {
+          const quarter = parseInt(qMatch[1], 10)
+          const year = qMatch[2]
+          const startMonth = (quarter - 1) * 3 + 1
+          const months = [startMonth, startMonth + 1, startMonth + 2].map(
+            m => `${year}-${String(m).padStart(2, '0')}`
+          )
+          return allMonthlyData.value.filter(m => months.includes(m.month))
+        }
+      }
+      // If period is a single YYYY-MM month
+      if (/^\d{4}-\d{2}$/.test(selectedPeriod.value)) {
+        return allMonthlyData.value.filter(m => m.month === selectedPeriod.value)
+      }
+      return allMonthlyData.value
+    })
+
+    const totalRevenue = computed(() =>
+      filteredMonthlyData.value.reduce((sum, m) => sum + (m.revenue || 0), 0)
+    )
+
+    const avgMonthlyRevenue = computed(() =>
+      filteredMonthlyData.value.length > 0
+        ? totalRevenue.value / filteredMonthlyData.value.length
+        : 0
+    )
+
+    const totalOrders = computed(() =>
+      filteredMonthlyData.value.reduce((sum, m) => sum + (m.order_count || 0), 0)
+    )
+
+    const bestQuarter = computed(() => {
+      if (filteredQuarterlyData.value.length === 0) return '-'
+      return filteredQuarterlyData.value.reduce(
+        (best, q) => (q.total_revenue > best.total_revenue ? q : best),
+        filteredQuarterlyData.value[0]
+      ).quarter
+    })
+
+    const maxRevenue = computed(() => {
+      if (filteredMonthlyData.value.length === 0) return 1
+      return Math.max(...filteredMonthlyData.value.map(m => m.revenue || 0))
+    })
+
+    const loadData = async () => {
+      loading.value = true
+      error.value = null
       try {
-        this.loading = true
-
-        // Fetch quarterly data
-        console.log('Fetching quarterly data...')
-        const quarterlyResponse = await axios.get('http://localhost:8001/api/reports/quarterly')
-        this.quarterlyData = quarterlyResponse.data
-        console.log('Quarterly data:', this.quarterlyData)
-
-        // Fetch monthly data
-        console.log('Fetching monthly data...')
-        const monthlyResponse = await axios.get('http://localhost:8001/api/reports/monthly-trends')
-        this.monthlyData = monthlyResponse.data
-        console.log('Monthly data:', this.monthlyData)
-
-        // Calculate summary stats
-        console.log('Calculating summary stats...')
-        this.calculateSummaryStats()
-        console.log('Summary stats calculated')
-
+        const [quarterly, monthly] = await Promise.all([
+          api.getQuarterlyReports(),
+          api.getMonthlyTrends()
+        ])
+        allQuarterlyData.value = quarterly
+        allMonthlyData.value = monthly
       } catch (err) {
-        console.log('Error loading reports:', err)
-        this.error = 'Failed to load reports: ' + err.message
+        error.value = t('reports.loadError')
+        console.error('Failed to load reports:', err)
       } finally {
-        this.loading = false
-        console.log('Loading complete')
+        loading.value = false
       }
-    },
+    }
 
-    calculateSummaryStats() {
-      // Calculate total revenue
-      var total = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        total = total + this.monthlyData[i].revenue
-      }
-      this.totalRevenue = total
+    const monthKeyMap = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
 
-      // Calculate average monthly revenue
-      if (this.monthlyData.length > 0) {
-        this.avgMonthlyRevenue = total / this.monthlyData.length
-      } else {
-        this.avgMonthlyRevenue = 0
-      }
+    const formatMonth = (monthStr) => {
+      if (!monthStr) return ''
+      const parts = monthStr.split('-')
+      if (parts.length !== 2) return monthStr
+      const monthIndex = parseInt(parts[1], 10) - 1
+      if (monthIndex < 0 || monthIndex > 11) return monthStr
+      return t(`months.${monthKeyMap[monthIndex]}`) + ' ' + parts[0]
+    }
 
-      // Calculate total orders
-      var orders = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        orders = orders + this.monthlyData[i].order_count
-      }
-      this.totalOrders = orders
+    const getBarHeight = (revenue) => {
+      if (maxRevenue.value === 0) return 0
+      return (revenue / maxRevenue.value) * 200
+    }
 
-      // Find best quarter
-      var bestQ = ''
-      var bestRevenue = 0
-      for (var i = 0; i < this.quarterlyData.length; i++) {
-        if (this.quarterlyData[i].total_revenue > bestRevenue) {
-          bestRevenue = this.quarterlyData[i].total_revenue
-          bestQ = this.quarterlyData[i].quarter
-        }
-      }
-      this.bestQuarter = bestQ
-    },
+    const getFulfillmentClass = (rate) => {
+      if (rate >= 90) return 'badge success'
+      if (rate >= 75) return 'badge warning'
+      return 'badge danger'
+    }
 
-    formatNumber(num) {
-      console.log('Formatting number:', num)
-      // Format number with commas
-      var str = num.toString()
-      var parts = str.split('.')
-      var intPart = parts[0]
-      var decPart = parts.length > 1 ? parts[1] : '00'
+    const getChangeValue = (current, previous) => {
+      const change = current - previous
+      if (change > 0) return '+' + formatCurrency(change, currentCurrency.value)
+      if (change < 0) return '-' + formatCurrency(Math.abs(change), currentCurrency.value)
+      return formatCurrency(0, currentCurrency.value)
+    }
 
-      var formatted = ''
-      var count = 0
-      for (var i = intPart.length - 1; i >= 0; i--) {
-        if (count > 0 && count % 3 === 0) {
-          formatted = ',' + formatted
-        }
-        formatted = intPart[i] + formatted
-        count++
-      }
+    const getChangeClass = (current, previous) => {
+      const change = current - previous
+      if (change > 0) return 'positive-change'
+      if (change < 0) return 'negative-change'
+      return ''
+    }
 
-      if (decPart.length === 1) {
-        decPart = decPart + '0'
-      }
-      if (decPart.length > 2) {
-        decPart = decPart.substring(0, 2)
-      }
+    const getGrowthRate = (current, previous) => {
+      if (previous === 0) return 'N/A'
+      const rate = ((current - previous) / previous) * 100
+      return (rate > 0 ? '+' : '') + rate.toFixed(1) + '%'
+    }
 
-      return formatted + '.' + decPart
-    },
+    watch([selectedPeriod, selectedLocation, selectedCategory, selectedStatus], () => {
+      loadData()
+    })
 
-    formatMonth(monthStr) {
-      console.log('Formatting month:', monthStr)
-      // Convert YYYY-MM to readable format
-      var parts = monthStr.split('-')
-      var year = parts[0]
-      var month = parts[1]
+    onMounted(loadData)
 
-      var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-      var monthIndex = parseInt(month) - 1
-
-      return monthNames[monthIndex] + ' ' + year
-    },
-
-    getBarHeight(revenue) {
-      console.log('Calculating bar height for revenue:', revenue)
-      // Calculate bar height (max height 200px)
-      var maxRevenue = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        if (this.monthlyData[i].revenue > maxRevenue) {
-          maxRevenue = this.monthlyData[i].revenue
-        }
-      }
-
-      if (maxRevenue === 0) {
-        return 0
-      }
-
-      var height = (revenue / maxRevenue) * 200
-      return height
-    },
-
-    getFulfillmentClass(rate) {
-      if (rate >= 90) {
-        return 'badge success'
-      } else if (rate >= 75) {
-        return 'badge warning'
-      } else {
-        return 'badge danger'
-      }
-    },
-
-    getChangeValue(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return '+$' + this.formatNumber(change)
-      } else if (change < 0) {
-        return '-$' + this.formatNumber(Math.abs(change))
-      } else {
-        return '$0.00'
-      }
-    },
-
-    getChangeClass(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return 'positive-change'
-      } else if (change < 0) {
-        return 'negative-change'
-      } else {
-        return ''
-      }
-    },
-
-    getGrowthRate(current, previous) {
-      if (previous === 0) {
-        return 'N/A'
-      }
-
-      var rate = ((current - previous) / previous) * 100
-      var sign = rate > 0 ? '+' : ''
-
-      return sign + rate.toFixed(1) + '%'
+    return {
+      t,
+      loading,
+      error,
+      filteredQuarterlyData,
+      filteredMonthlyData,
+      totalRevenue,
+      avgMonthlyRevenue,
+      totalOrders,
+      bestQuarter,
+      currentCurrency,
+      formatCurrency,
+      formatMonth,
+      getBarHeight,
+      getFulfillmentClass,
+      getChangeValue,
+      getChangeClass,
+      getGrowthRate
     }
   }
 }
@@ -321,50 +315,13 @@ export default {
   padding: 0;
 }
 
-.card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.card-header {
-  margin-bottom: 1.5rem;
-}
-
-.card-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #0f172a;
-  margin: 0;
-}
-
 .reports-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.reports-table th {
-  background: #f8fafc;
-  padding: 0.75rem;
-  text-align: left;
-  font-weight: 600;
-  color: #64748b;
-  border-bottom: 2px solid #e2e8f0;
-}
-
-.reports-table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.reports-table tr:hover {
-  background: #f8fafc;
-}
-
 .chart-container {
-  padding: 2rem 1rem;
+  padding: var(--space-8) var(--space-4);
   min-height: 300px;
 }
 
@@ -373,7 +330,7 @@ export default {
   align-items: flex-end;
   justify-content: space-around;
   height: 250px;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .bar-wrapper {
@@ -393,96 +350,33 @@ export default {
 
 .bar {
   width: 100%;
-  background: linear-gradient(to top, #3b82f6, #60a5fa);
-  border-radius: 4px 4px 0 0;
-  transition: all 0.3s;
+  background: var(--color-accent);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  transition: all 0.3s ease;
   cursor: pointer;
+  opacity: 0.85;
 }
 
 .bar:hover {
-  background: linear-gradient(to top, #2563eb, #3b82f6);
+  opacity: 1;
 }
 
 .bar-label {
-  margin-top: 0.5rem;
+  margin-top: 1.5rem;
   font-size: 0.75rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   text-align: center;
   transform: rotate(-45deg);
   white-space: nowrap;
-  margin-top: 1.5rem;
-}
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
-
-.stat-card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border-left: 4px solid #3b82f6;
-}
-
-.stat-label {
-  font-size: 0.875rem;
-  color: #64748b;
-  margin-bottom: 0.5rem;
-}
-
-.stat-value {
-  font-size: 1.875rem;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.badge {
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.badge.success {
-  background: #dcfce7;
-  color: #166534;
-}
-
-.badge.warning {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.badge.danger {
-  background: #fee2e2;
-  color: #991b1b;
 }
 
 .positive-change {
-  color: #16a34a;
+  color: var(--color-success);
   font-weight: 600;
 }
 
 .negative-change {
-  color: #dc2626;
+  color: var(--color-danger);
   font-weight: 600;
-}
-
-.loading {
-  text-align: center;
-  padding: 3rem;
-  color: #64748b;
-}
-
-.error {
-  background: #fee2e2;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
 }
 </style>

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -25,7 +25,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(q, index) in quarterlyData" :key="index">
+              <tr v-for="q in quarterlyData" :key="q.quarter">
                 <td><strong>{{ q.quarter }}</strong></td>
                 <td>{{ q.total_orders }}</td>
                 <td>${{ formatNumber(q.total_revenue) }}</td>
@@ -48,7 +48,7 @@
         </div>
         <div class="chart-container">
           <div class="bar-chart">
-            <div v-for="(month, index) in monthlyData" :key="index" class="bar-wrapper">
+            <div v-for="month in monthlyData" :key="month.month" class="bar-wrapper">
               <div class="bar-container">
                 <div
                   class="bar"
@@ -79,7 +79,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(month, index) in monthlyData" :key="index">
+              <tr v-for="(month, index) in monthlyData" :key="month.month">
                 <td><strong>{{ formatMonth(month.month) }}</strong></td>
                 <td>{{ month.order_count }}</td>
                 <td>${{ formatNumber(month.revenue) }}</td>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,479 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>Recommend items to restock based on demand forecasts and your available budget.</p>
+    </div>
+
+    <div v-if="loading" class="loading">Loading restocking candidates...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Summary stats -->
+      <div class="stats-grid">
+        <div class="stat-card">
+          <div class="stat-label">Candidates</div>
+          <div class="stat-value">{{ candidates.length }}</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Max Possible Spend</div>
+          <div class="stat-value stat-value--currency">{{ formatCurrency(sliderMax) }}</div>
+        </div>
+        <div class="stat-card" :class="{ danger: overBudget }">
+          <div class="stat-label">Selected Total</div>
+          <div class="stat-value stat-value--currency" :class="{ 'over-budget-text': overBudget }">
+            {{ formatCurrency(selectedTotal) }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Budget card -->
+      <div class="card">
+        <div class="budget-header">
+          <span class="budget-label">Budget</span>
+          <span class="budget-value">{{ formatCurrency(budget) }}</span>
+        </div>
+        <div class="range-wrapper">
+          <input
+            type="range"
+            :min="0"
+            :max="sliderMax"
+            :step="sliderStep"
+            v-model.number="budget"
+            class="budget-range"
+          />
+        </div>
+        <div class="budget-bar">
+          <div
+            class="budget-fill"
+            :class="{ 'over-budget': overBudget }"
+            :style="{ width: Math.min((selectedTotal / (budget || 1)) * 100, 100) + '%' }"
+          ></div>
+        </div>
+        <div class="budget-info">
+          <span>
+            Selected {{ formatCurrency(selectedTotal) }} of {{ formatCurrency(budget) }} budget
+            &middot; {{ selectedCandidates.length }} items
+          </span>
+          <span v-if="overBudget" class="over-budget-warning">
+            &#9888; Over budget by {{ formatCurrency(selectedTotal - budget) }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Success message -->
+      <div v-if="successMessage" class="inline-success">{{ successMessage }}</div>
+
+      <!-- Candidates card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Restocking Candidates</h3>
+          <button class="btn-secondary btn-sm" @click="resetAutoSelect">Reset to auto-select</button>
+        </div>
+
+        <div v-if="candidates.length === 0" class="empty-state">
+          No items need restocking with current filters.
+        </div>
+        <div v-else class="table-container">
+          <table class="candidates-table">
+            <thead>
+              <tr>
+                <th class="col-check"></th>
+                <th class="col-sku">SKU</th>
+                <th class="col-name">Item</th>
+                <th class="col-warehouse">Warehouse</th>
+                <th class="col-trend">Trend</th>
+                <th class="col-num">Current</th>
+                <th class="col-num">Forecast</th>
+                <th class="col-num">Shortfall</th>
+                <th class="col-num">Qty to Order</th>
+                <th class="col-cost">Unit Cost</th>
+                <th class="col-cost">Subtotal</th>
+                <th class="col-lead">Lead Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="c in candidates"
+                :key="candidateKey(c)"
+                :class="['candidate-row', { selected: isSelected(c) }]"
+                @click="toggle(c)"
+              >
+                <td class="col-check">
+                  <input
+                    type="checkbox"
+                    :checked="isSelected(c)"
+                    @click.stop="toggle(c)"
+                  />
+                </td>
+                <td class="col-sku"><code>{{ c.sku }}</code></td>
+                <td class="col-name">{{ c.name }}</td>
+                <td class="col-warehouse">{{ c.warehouse }}</td>
+                <td class="col-trend">
+                  <span :class="['badge', c.trend]">{{ c.trend }}</span>
+                </td>
+                <td class="col-num">{{ c.quantity_on_hand }}</td>
+                <td class="col-num">{{ c.forecasted_demand }}</td>
+                <td class="col-num">{{ c.shortfall }}</td>
+                <td class="col-num">{{ c.recommended_qty }}</td>
+                <td class="col-cost">{{ formatCurrency(c.unit_cost) }}</td>
+                <td class="col-cost">{{ formatCurrency(c.recommended_qty * c.unit_cost) }}</td>
+                <td class="col-lead">{{ c.lead_time_days }} days</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Action row -->
+      <div class="action-row">
+        <button class="btn-secondary" @click="router.push('/')">Cancel</button>
+        <button
+          class="btn-primary"
+          :disabled="selectedCandidates.length === 0 || overBudget || submitting"
+          @click="submitOrder"
+        >
+          {{ submitting ? 'Placing Order...' : 'Place Order' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { api } from '../api'
+import { useFilters } from '../composables/useFilters'
+
+const router = useRouter()
+const { getCurrentFilters, selectedLocation, selectedCategory } = useFilters()
+
+// State
+const candidates = ref([])
+const selectedSkus = ref(new Set())
+const budget = ref(0)
+const userOverride = ref(false)
+const loading = ref(false)
+const error = ref(null)
+const submitting = ref(false)
+const successMessage = ref('')
+
+// Helpers
+const candidateKey = (c) => `${c.sku}__${c.warehouse}`
+
+const isSelected = (c) => selectedSkus.value.has(candidateKey(c))
+
+const toggle = (c) => {
+  const key = candidateKey(c)
+  const next = new Set(selectedSkus.value)
+  if (next.has(key)) {
+    next.delete(key)
+  } else {
+    next.add(key)
+  }
+  selectedSkus.value = next
+  userOverride.value = true
+}
+
+// Computed
+const sliderMax = computed(() => {
+  const total = candidates.value.reduce((sum, c) => sum + c.estimated_cost, 0)
+  return Math.max(1000, Math.ceil(total / 1000) * 1000)
+})
+
+const sliderStep = computed(() => {
+  return Math.max(100, Math.round(sliderMax.value / 200))
+})
+
+const selectedCandidates = computed(() => {
+  return candidates.value.filter(c => isSelected(c))
+})
+
+const selectedTotal = computed(() => {
+  return selectedCandidates.value.reduce((sum, c) => sum + c.recommended_qty * c.unit_cost, 0)
+})
+
+const overBudget = computed(() => selectedTotal.value > budget.value)
+
+// Auto-select via greedy fill
+const autoSelect = () => {
+  let remaining = budget.value
+  const next = new Set()
+  for (const c of candidates.value) {
+    if (remaining >= c.estimated_cost) {
+      next.add(candidateKey(c))
+      remaining -= c.estimated_cost
+    }
+  }
+  selectedSkus.value = next
+}
+
+const resetAutoSelect = () => {
+  userOverride.value = false
+  autoSelect()
+}
+
+// Load candidates
+const loadCandidates = async () => {
+  loading.value = true
+  error.value = null
+  try {
+    candidates.value = await api.getRestockingCandidates(getCurrentFilters())
+    userOverride.value = false
+    // Set budget to max of all candidates and then auto-select
+    budget.value = sliderMax.value
+    autoSelect()
+  } catch (err) {
+    error.value = 'Failed to load restocking candidates'
+    console.error(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+// Watchers
+watch(budget, () => {
+  if (!userOverride.value) autoSelect()
+})
+
+watch([selectedLocation, selectedCategory], () => {
+  loadCandidates()
+})
+
+// Submit order
+const submitOrder = async () => {
+  submitting.value = true
+  error.value = null
+  try {
+    const items = selectedCandidates.value.map(c => ({
+      sku: c.sku,
+      name: c.name,
+      quantity: c.recommended_qty,
+      unit_cost: c.unit_cost,
+      lead_time_days: c.lead_time_days,
+      subtotal: Math.round(c.recommended_qty * c.unit_cost)
+    }))
+    const response = await api.submitRestockingOrder({ items })
+    successMessage.value = `Order ${response.id} submitted. Redirecting to Orders...`
+    setTimeout(() => {
+      router.push('/orders')
+    }, 800)
+  } catch (err) {
+    error.value = 'Failed to submit restocking order: ' + (err.message || 'Unknown error')
+    console.error(err)
+  } finally {
+    submitting.value = false
+  }
+}
+
+// Currency format helper
+const formatCurrency = (value) => {
+  return Number(value).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  })
+}
+
+onMounted(loadCandidates)
+</script>
+
+<style scoped>
+.restocking {
+  /* inherits main-content padding */
+}
+
+/* Stat value override for currency (smaller font so it fits) */
+.stat-value--currency {
+  font-size: 1.5rem;
+}
+
+.over-budget-text {
+  color: var(--color-danger);
+}
+
+/* Budget card internals */
+.budget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-3);
+}
+
+.budget-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.budget-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.range-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.budget-range {
+  flex: 1;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+/* Budget progress bar */
+.budget-bar {
+  height: 12px;
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  margin-bottom: var(--space-3);
+}
+
+.budget-fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: var(--radius-sm);
+  transition: width 200ms ease, background 200ms ease;
+}
+
+.budget-fill.over-budget {
+  background: var(--color-danger);
+}
+
+.budget-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.over-budget-warning {
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: var(--space-8);
+  color: var(--color-text-muted);
+  font-size: 0.938rem;
+}
+
+/* Candidates table */
+.candidates-table {
+  table-layout: auto;
+  width: 100%;
+}
+
+.col-check { width: 36px; }
+.col-sku { width: 110px; }
+.col-name { min-width: 160px; }
+.col-warehouse { width: 130px; }
+.col-trend { width: 100px; }
+.col-num { width: 90px; text-align: right; }
+.col-cost { width: 100px; text-align: right; }
+.col-lead { width: 90px; text-align: right; }
+
+.candidate-row {
+  cursor: pointer;
+}
+
+.candidate-row.selected {
+  background: var(--color-accent-bg);
+}
+
+.candidate-row.selected:hover {
+  background: #dbeafe;
+}
+
+code {
+  font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  background: var(--color-surface-alt);
+  padding: 2px 5px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+}
+
+/* Buttons */
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  background: var(--color-accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease, box-shadow 0.15s ease;
+  font-family: inherit;
+}
+
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+  box-shadow: var(--shadow-md);
+}
+
+.btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  font-family: inherit;
+}
+
+.btn-secondary:hover {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
+.btn-sm {
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.813rem;
+}
+
+/* Action row */
+.action-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+/* Inline success */
+.inline-success {
+  background: var(--color-success-bg);
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+  border-radius: var(--radius-sm);
+  padding: var(--space-3) var(--space-4);
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+}
+</style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -394,7 +394,7 @@ onMounted(loadCandidates)
 }
 
 .candidate-row.selected:hover {
-  background: #dbeafe;
+  background: var(--color-info-bg);
 }
 
 code {
@@ -471,7 +471,7 @@ code {
 .inline-success {
   background: var(--color-success-bg);
   color: #065f46;
-  border: 1px solid #a7f3d0;
+  border: 1px solid var(--color-success-bg);
   border-radius: var(--radius-sm);
   padding: var(--space-3) var(--space-4);
   font-size: 0.875rem;

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,25 +1,25 @@
 <template>
   <div class="restocking">
     <div class="page-header">
-      <h2>Restocking</h2>
-      <p>Recommend items to restock based on demand forecasts and your available budget.</p>
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading restocking candidates...</div>
+    <div v-if="loading" class="loading">{{ t('restocking.loadingCandidates') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <!-- Summary stats -->
       <div class="stats-grid">
         <div class="stat-card">
-          <div class="stat-label">Candidates</div>
+          <div class="stat-label">{{ t('restocking.candidates') }}</div>
           <div class="stat-value">{{ candidates.length }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Max Possible Spend</div>
+          <div class="stat-label">{{ t('restocking.maxPossibleSpend') }}</div>
           <div class="stat-value stat-value--currency">{{ formatCurrency(sliderMax) }}</div>
         </div>
         <div class="stat-card" :class="{ danger: overBudget }">
-          <div class="stat-label">Selected Total</div>
+          <div class="stat-label">{{ t('restocking.selectedTotal') }}</div>
           <div class="stat-value stat-value--currency" :class="{ 'over-budget-text': overBudget }">
             {{ formatCurrency(selectedTotal) }}
           </div>
@@ -29,7 +29,7 @@
       <!-- Budget card -->
       <div class="card">
         <div class="budget-header">
-          <span class="budget-label">Budget</span>
+          <span class="budget-label">{{ t('restocking.budget') }}</span>
           <span class="budget-value">{{ formatCurrency(budget) }}</span>
         </div>
         <div class="range-wrapper">
@@ -51,11 +51,11 @@
         </div>
         <div class="budget-info">
           <span>
-            Selected {{ formatCurrency(selectedTotal) }} of {{ formatCurrency(budget) }} budget
-            &middot; {{ selectedCandidates.length }} items
+            {{ t('restocking.selectedOf', { selected: formatCurrency(selectedTotal), budget: formatCurrency(budget) }) }}
+            &middot; {{ selectedCandidates.length }} {{ t('common.items') }}
           </span>
           <span v-if="overBudget" class="over-budget-warning">
-            &#9888; Over budget by {{ formatCurrency(selectedTotal - budget) }}
+            &#9888; {{ t('restocking.overBudget', { amount: formatCurrency(selectedTotal - budget) }) }}
           </span>
         </div>
       </div>
@@ -66,12 +66,12 @@
       <!-- Candidates card -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Restocking Candidates</h3>
-          <button class="btn-secondary btn-sm" @click="resetAutoSelect">Reset to auto-select</button>
+          <h3 class="card-title">{{ t('restocking.restockingCandidates') }}</h3>
+          <button class="btn-secondary btn-sm" @click="resetAutoSelect">{{ t('restocking.resetAutoSelect') }}</button>
         </div>
 
         <div v-if="candidates.length === 0" class="empty-state">
-          No items need restocking with current filters.
+          {{ t('restocking.noItems') }}
         </div>
         <div v-else class="table-container">
           <table class="candidates-table">
@@ -79,16 +79,16 @@
               <tr>
                 <th class="col-check"></th>
                 <th class="col-sku">SKU</th>
-                <th class="col-name">Item</th>
-                <th class="col-warehouse">Warehouse</th>
-                <th class="col-trend">Trend</th>
-                <th class="col-num">Current</th>
-                <th class="col-num">Forecast</th>
-                <th class="col-num">Shortfall</th>
-                <th class="col-num">Qty to Order</th>
-                <th class="col-cost">Unit Cost</th>
-                <th class="col-cost">Subtotal</th>
-                <th class="col-lead">Lead Time</th>
+                <th class="col-name">{{ t('restocking.table.item') }}</th>
+                <th class="col-warehouse">{{ t('restocking.table.warehouse') }}</th>
+                <th class="col-trend">{{ t('restocking.table.trend') }}</th>
+                <th class="col-num">{{ t('restocking.table.current') }}</th>
+                <th class="col-num">{{ t('restocking.table.forecast') }}</th>
+                <th class="col-num">{{ t('restocking.table.shortfall') }}</th>
+                <th class="col-num">{{ t('restocking.table.qtyToOrder') }}</th>
+                <th class="col-cost">{{ t('restocking.table.unitCost') }}</th>
+                <th class="col-cost">{{ t('restocking.table.subtotal') }}</th>
+                <th class="col-lead">{{ t('restocking.table.leadTime') }}</th>
               </tr>
             </thead>
             <tbody>
@@ -117,7 +117,7 @@
                 <td class="col-num">{{ c.recommended_qty }}</td>
                 <td class="col-cost">{{ formatCurrency(c.unit_cost) }}</td>
                 <td class="col-cost">{{ formatCurrency(c.recommended_qty * c.unit_cost) }}</td>
-                <td class="col-lead">{{ c.lead_time_days }} days</td>
+                <td class="col-lead">{{ c.lead_time_days }} {{ t('restocking.days') }}</td>
               </tr>
             </tbody>
           </table>
@@ -126,13 +126,13 @@
 
       <!-- Action row -->
       <div class="action-row">
-        <button class="btn-secondary" @click="router.push('/')">Cancel</button>
+        <button class="btn-secondary" @click="router.push('/')">{{ t('restocking.cancel') }}</button>
         <button
           class="btn-primary"
           :disabled="selectedCandidates.length === 0 || overBudget || submitting"
           @click="submitOrder"
         >
-          {{ submitting ? 'Placing Order...' : 'Place Order' }}
+          {{ submitting ? t('restocking.placingOrder') : t('restocking.placeOrder') }}
         </button>
       </div>
     </div>
@@ -144,9 +144,11 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { api } from '../api'
 import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
 
 const router = useRouter()
 const { getCurrentFilters, selectedLocation, selectedCategory } = useFilters()
+const { t, currentCurrency } = useI18n()
 
 // State
 const candidates = ref([])

--- a/client/src/views/Spending.vue
+++ b/client/src/views/Spending.vue
@@ -624,8 +624,8 @@ export default {
   justify-content: space-between;
   padding-right: 1rem;
   font-size: 0.75rem;
-  color: #94a3b8;
-  border-right: 1px solid #e2e8f0;
+  color: var(--color-text-subtle);
+  border-right: 1px solid var(--color-border);
 }
 
 .chart-area {
@@ -675,10 +675,10 @@ export default {
   border-radius: 6px 6px 0 0;
 }
 
-.bar-segment.procurement { background: #3b82f6; }
+.bar-segment.procurement { background: var(--color-accent); }
 .bar-segment.operational { background: #8b5cf6; }
-.bar-segment.labor { background: #10b981; }
-.bar-segment.overhead { background: #f59e0b; }
+.bar-segment.labor { background: var(--color-success); }
+.bar-segment.overhead { background: var(--color-warning); }
 
 .bar-segment:hover {
   opacity: 0.8;
@@ -688,7 +688,7 @@ export default {
   margin-top: 0.5rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .two-column-grid {
@@ -717,26 +717,26 @@ export default {
 
 .category-name {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text);
 }
 
 .category-amount {
   font-weight: 700;
-  color: #2563eb;
+  color: var(--color-accent);
   font-size: 1.125rem;
 }
 
 .category-bar-container {
   width: 100%;
   height: 8px;
-  background: #f1f5f9;
+  background: var(--color-surface-alt);
   border-radius: 4px;
   overflow: hidden;
 }
 
 .category-bar {
   height: 100%;
-  background: linear-gradient(90deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent) 100%);
   border-radius: 4px;
   transition: width 0.6s ease;
 }
@@ -748,7 +748,7 @@ export default {
 }
 
 .percentage {
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .change {
@@ -756,11 +756,11 @@ export default {
 }
 
 .change.positive {
-  color: #059669;
+  color: var(--color-success);
 }
 
 .change.negative {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .transactions-card {
@@ -781,7 +781,7 @@ export default {
 .transactions-table thead {
   position: sticky;
   top: 0;
-  background: #f8fafc;
+  background: var(--color-bg);
   z-index: 1;
 }
 
@@ -789,11 +789,11 @@ export default {
   text-align: left;
   padding: 0.625rem 0.75rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-muted);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .transactions-table th.text-right {
@@ -802,7 +802,7 @@ export default {
 
 .transactions-table td {
   padding: 0.75rem 0.75rem;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--color-surface-alt);
   font-size: 0.875rem;
 }
 
@@ -812,37 +812,37 @@ export default {
 }
 
 .transactions-table tbody tr:hover {
-  background: #f8fafc;
+  background: var(--color-bg);
 }
 
 .transactions-table tbody tr.clickable-row:hover {
-  background: #eff6ff;
+  background: var(--color-accent-bg);
 }
 
 .transaction-id {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-weight: 500;
   font-family: 'Monaco', 'Courier New', monospace;
   font-size: 0.813rem;
 }
 
 .transaction-description {
-  color: #0f172a;
+  color: var(--color-text);
   font-weight: 500;
 }
 
 .transaction-vendor {
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .transaction-date {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.813rem;
 }
 
 .transaction-amount {
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text);
 }
 
 .text-right {

--- a/client/src/views/Spending.vue
+++ b/client/src/views/Spending.vue
@@ -448,7 +448,6 @@ export default {
     }
 
     const handleTransactionClick = (transaction) => {
-      console.log('Transaction clicked:', transaction)
       alert(`Transaction Details:\n\nID: ${transaction.id}\nDescription: ${transaction.description}\nVendor: ${transaction.vendor}\nDate: ${formatDateShort(transaction.date)}\nAmount: $${transaction.amount.toLocaleString()}`)
     }
 
@@ -501,11 +500,11 @@ export default {
 }
 
 .stat-change.positive {
-  color: #059669;
+  color: var(--color-success);
 }
 
 .stat-change.negative {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .change-icon {
@@ -527,7 +526,7 @@ export default {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .legend-dot {
@@ -536,12 +535,12 @@ export default {
   border-radius: 3px;
 }
 
-.legend-dot.procurement { background: #3b82f6; }
+.legend-dot.procurement { background: var(--color-accent); }
 .legend-dot.operational { background: #8b5cf6; }
-.legend-dot.labor { background: #10b981; }
-.legend-dot.overhead { background: #f59e0b; }
-.legend-dot.revenue-color { background: #0f172a; }
-.legend-dot.cost-color { background: #ef4444; }
+.legend-dot.labor { background: var(--color-success); }
+.legend-dot.overhead { background: var(--color-warning); }
+.legend-dot.revenue-color { background: var(--color-text); }
+.legend-dot.cost-color { background: var(--color-danger); }
 
 .stats-grid-finance {
   display: grid;
@@ -551,21 +550,21 @@ export default {
 }
 
 .revenue-card {
-  border-left: 4px solid #0f172a;
+  border-left: 4px solid var(--color-text);
 }
 
 .cost-card {
-  border-left: 4px solid #ef4444;
+  border-left: 4px solid var(--color-danger);
 }
 
 .profit-card {
-  border-left: 4px solid #3b82f6;
+  border-left: 4px solid var(--color-accent);
 }
 
 .stat-meta {
   margin-top: 0.5rem;
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .bar-group-revenue {
@@ -597,11 +596,11 @@ export default {
 }
 
 .revenue-bar {
-  background: #0f172a;
+  background: var(--color-text);
 }
 
 .cost-bar {
-  background: #ef4444;
+  background: var(--color-danger);
 }
 
 .revenue-bar:hover, .cost-bar:hover {

--- a/client/src/views/Spending.vue
+++ b/client/src/views/Spending.vue
@@ -389,7 +389,7 @@ export default {
     }
 
     const getRevenueBarHeight = (value) => {
-      const maxValue = maxRevenueValue.value * 1000
+      const maxValue = Math.max(maxRevenueValue.value * 1000, 1)
       return (value / maxValue) * 100
     }
 

--- a/client/vitest.config.js
+++ b/client/vitest.config.js
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const clientDir = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = path.resolve(clientDir, '..')
+
+export default defineConfig({
+  plugins: [vue()],
+  // Allow Vite's file server to serve files from the project root so that
+  // test files in tests/frontend/ (outside client/) can be loaded via /@fs/.
+  server: {
+    fs: {
+      allow: [projectRoot]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(clientDir, 'src'),
+      // Explicitly resolve test-only packages to their locations in
+      // client/node_modules so Vite can find them when transforming test
+      // files that live outside the client/ directory tree.
+      '@vue/test-utils': path.resolve(clientDir, 'node_modules/@vue/test-utils'),
+      'vitest': path.resolve(clientDir, 'node_modules/vitest')
+    }
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    include: [path.join(projectRoot, 'tests/frontend/**/*.test.js')]
+  }
+})

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+python = "3.12"
+node = "22"
+uv = "latest"

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -79,5 +79,59 @@
     "forecasted_demand": 96,
     "trend": "stable",
     "period": "Next 30 days"
+  },
+  {
+    "id": "10",
+    "item_sku": "TMP-201",
+    "item_name": "Temperature Sensor Module",
+    "current_demand": 110,
+    "forecasted_demand": 200,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "11",
+    "item_sku": "SRV-301",
+    "item_name": "Micro Servo Motor",
+    "current_demand": 40,
+    "forecasted_demand": 90,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "12",
+    "item_sku": "SRV-302",
+    "item_name": "Standard Servo Motor",
+    "current_demand": 25,
+    "forecasted_demand": 60,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "13",
+    "item_sku": "PSU-508",
+    "item_name": "Battery Backup Power Supply",
+    "current_demand": 65,
+    "forecasted_demand": 130,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "14",
+    "item_sku": "HMD-202",
+    "item_name": "Humidity Sensor Module",
+    "current_demand": 90,
+    "forecasted_demand": 160,
+    "trend": "increasing",
+    "period": "Next 30 days"
+  },
+  {
+    "id": "15",
+    "item_sku": "PSU-507",
+    "item_name": "Adjustable Bench Power Supply",
+    "current_demand": 80,
+    "forecasted_demand": 140,
+    "trend": "increasing",
+    "period": "Next 30 days"
   }
 ]

--- a/server/data/inventory.json
+++ b/server/data/inventory.json
@@ -9,7 +9,8 @@
     "reorder_point": 200,
     "unit_cost": 24.99,
     "location": "Warehouse A-12",
-    "last_updated": "2025-09-30T10:30:00"
+    "last_updated": "2025-09-30T10:30:00",
+    "lead_time_days": 16
   },
   {
     "id": "2",
@@ -21,7 +22,8 @@
     "reorder_point": 150,
     "unit_cost": 29.99,
     "location": "Warehouse A-13",
-    "last_updated": "2025-09-28T14:20:00"
+    "last_updated": "2025-09-28T14:20:00",
+    "lead_time_days": 18
   },
   {
     "id": "3",
@@ -33,7 +35,8 @@
     "reorder_point": 120,
     "unit_cost": 34.5,
     "location": "Warehouse B-08",
-    "last_updated": "2025-09-25T09:15:00"
+    "last_updated": "2025-09-25T09:15:00",
+    "lead_time_days": 21
   },
   {
     "id": "4",
@@ -45,7 +48,8 @@
     "reorder_point": 150,
     "unit_cost": 89.5,
     "location": "Warehouse B-05",
-    "last_updated": "2025-09-29T14:20:00"
+    "last_updated": "2025-09-29T14:20:00",
+    "lead_time_days": 14
   },
   {
     "id": "5",
@@ -57,7 +61,8 @@
     "reorder_point": 80,
     "unit_cost": 125.0,
     "location": "Warehouse B-06",
-    "last_updated": "2025-09-27T11:45:00"
+    "last_updated": "2025-09-27T11:45:00",
+    "lead_time_days": 12
   },
   {
     "id": "6",
@@ -69,7 +74,8 @@
     "reorder_point": 300,
     "unit_cost": 12.75,
     "location": "Warehouse A-08",
-    "last_updated": "2025-09-30T09:15:00"
+    "last_updated": "2025-09-30T09:15:00",
+    "lead_time_days": 10
   },
   {
     "id": "7",
@@ -81,7 +87,8 @@
     "reorder_point": 400,
     "unit_cost": 8.5,
     "location": "Warehouse C-04",
-    "last_updated": "2025-09-26T13:30:00"
+    "last_updated": "2025-09-26T13:30:00",
+    "lead_time_days": 11
   },
   {
     "id": "8",
@@ -93,7 +100,8 @@
     "reorder_point": 250,
     "unit_cost": 15.99,
     "location": "Warehouse A-09",
-    "last_updated": "2025-09-24T10:00:00"
+    "last_updated": "2025-09-24T10:00:00",
+    "lead_time_days": 13
   },
   {
     "id": "9",
@@ -105,7 +113,8 @@
     "reorder_point": 50,
     "unit_cost": 445.0,
     "location": "Warehouse C-02",
-    "last_updated": "2025-09-30T16:45:00"
+    "last_updated": "2025-09-30T16:45:00",
+    "lead_time_days": 15
   },
   {
     "id": "10",
@@ -117,7 +126,8 @@
     "reorder_point": 30,
     "unit_cost": 725.0,
     "location": "Warehouse C-03",
-    "last_updated": "2025-09-28T12:20:00"
+    "last_updated": "2025-09-28T12:20:00",
+    "lead_time_days": 18
   },
   {
     "id": "11",
@@ -129,7 +139,8 @@
     "reorder_point": 40,
     "unit_cost": 325.0,
     "location": "Warehouse B-10",
-    "last_updated": "2025-09-22T15:30:00"
+    "last_updated": "2025-09-22T15:30:00",
+    "lead_time_days": 16
   },
   {
     "id": "12",
@@ -141,7 +152,8 @@
     "reorder_point": 500,
     "unit_cost": 8.25,
     "location": "Warehouse A-15",
-    "last_updated": "2025-09-30T08:00:00"
+    "last_updated": "2025-09-30T08:00:00",
+    "lead_time_days": 14
   },
   {
     "id": "13",
@@ -153,7 +165,8 @@
     "reorder_point": 400,
     "unit_cost": 6.5,
     "location": "Warehouse A-16",
-    "last_updated": "2025-09-27T09:45:00"
+    "last_updated": "2025-09-27T09:45:00",
+    "lead_time_days": 17
   },
   {
     "id": "14",
@@ -165,7 +178,8 @@
     "reorder_point": 350,
     "unit_cost": 7.75,
     "location": "Warehouse B-12",
-    "last_updated": "2025-09-25T14:15:00"
+    "last_updated": "2025-09-25T14:15:00",
+    "lead_time_days": 15
   },
   {
     "id": "15",
@@ -177,7 +191,8 @@
     "reorder_point": 100,
     "unit_cost": 156.0,
     "location": "Warehouse B-11",
-    "last_updated": "2025-09-29T11:30:00"
+    "last_updated": "2025-09-29T11:30:00",
+    "lead_time_days": 12
   },
   {
     "id": "16",
@@ -189,7 +204,8 @@
     "reorder_point": 120,
     "unit_cost": 95.0,
     "location": "Warehouse C-07",
-    "last_updated": "2025-09-26T16:00:00"
+    "last_updated": "2025-09-26T16:00:00",
+    "lead_time_days": 10
   },
   {
     "id": "17",
@@ -201,7 +217,8 @@
     "reorder_point": 90,
     "unit_cost": 110.5,
     "location": "Warehouse A-14",
-    "last_updated": "2025-09-23T10:45:00"
+    "last_updated": "2025-09-23T10:45:00",
+    "lead_time_days": 11
   },
   {
     "id": "18",
@@ -213,7 +230,8 @@
     "reorder_point": 200,
     "unit_cost": 18.75,
     "location": "Warehouse B-09",
-    "last_updated": "2025-09-21T13:20:00"
+    "last_updated": "2025-09-21T13:20:00",
+    "lead_time_days": 7
   },
   {
     "id": "19",
@@ -225,7 +243,8 @@
     "reorder_point": 350,
     "unit_cost": 12.25,
     "location": "Warehouse A-11",
-    "last_updated": "2025-09-19T11:00:00"
+    "last_updated": "2025-09-19T11:00:00",
+    "lead_time_days": 5
   },
   {
     "id": "20",
@@ -237,7 +256,8 @@
     "reorder_point": 600,
     "unit_cost": 15.5,
     "location": "Warehouse C-05",
-    "last_updated": "2025-09-20T08:30:00"
+    "last_updated": "2025-09-20T08:30:00",
+    "lead_time_days": 14
   },
   {
     "id": "21",
@@ -249,7 +269,8 @@
     "reorder_point": 500,
     "unit_cost": 22.0,
     "location": "Warehouse B-13",
-    "last_updated": "2025-09-18T15:45:00"
+    "last_updated": "2025-09-18T15:45:00",
+    "lead_time_days": 16
   },
   {
     "id": "22",
@@ -261,7 +282,8 @@
     "reorder_point": 40,
     "unit_cost": 285.0,
     "location": "Warehouse C-06",
-    "last_updated": "2025-09-17T09:20:00"
+    "last_updated": "2025-09-17T09:20:00",
+    "lead_time_days": 17
   },
   {
     "id": "23",
@@ -273,7 +295,8 @@
     "reorder_point": 150,
     "unit_cost": 45.5,
     "location": "Warehouse A-10",
-    "last_updated": "2025-09-16T14:30:00"
+    "last_updated": "2025-09-16T14:30:00",
+    "lead_time_days": 8
   },
   {
     "id": "24",
@@ -285,7 +308,8 @@
     "reorder_point": 250,
     "unit_cost": 32.75,
     "location": "Warehouse B-14",
-    "last_updated": "2025-09-15T10:15:00"
+    "last_updated": "2025-09-15T10:15:00",
+    "lead_time_days": 15
   },
   {
     "id": "25",
@@ -297,7 +321,8 @@
     "reorder_point": 180,
     "unit_cost": 18.99,
     "location": "Warehouse A-15",
-    "last_updated": "2025-09-28T08:45:00"
+    "last_updated": "2025-09-28T08:45:00",
+    "lead_time_days": 9
   },
   {
     "id": "26",
@@ -309,7 +334,8 @@
     "reorder_point": 200,
     "unit_cost": 22.50,
     "location": "Warehouse B-16",
-    "last_updated": "2025-09-27T13:20:00"
+    "last_updated": "2025-09-27T13:20:00",
+    "lead_time_days": 7
   },
   {
     "id": "27",
@@ -321,7 +347,8 @@
     "reorder_point": 150,
     "unit_cost": 45.75,
     "location": "Warehouse C-09",
-    "last_updated": "2025-09-26T10:15:00"
+    "last_updated": "2025-09-26T10:15:00",
+    "lead_time_days": 8
   },
   {
     "id": "28",
@@ -333,7 +360,8 @@
     "reorder_point": 100,
     "unit_cost": 38.25,
     "location": "Warehouse A-16",
-    "last_updated": "2025-09-25T16:30:00"
+    "last_updated": "2025-09-25T16:30:00",
+    "lead_time_days": 6
   },
   {
     "id": "29",
@@ -345,7 +373,8 @@
     "reorder_point": 120,
     "unit_cost": 67.50,
     "location": "Warehouse B-17",
-    "last_updated": "2025-09-24T09:00:00"
+    "last_updated": "2025-09-24T09:00:00",
+    "lead_time_days": 10
   },
   {
     "id": "30",
@@ -357,7 +386,8 @@
     "reorder_point": 250,
     "unit_cost": 29.99,
     "location": "Warehouse C-10",
-    "last_updated": "2025-09-23T14:45:00"
+    "last_updated": "2025-09-23T14:45:00",
+    "lead_time_days": 8
   },
   {
     "id": "31",
@@ -369,7 +399,8 @@
     "reorder_point": 80,
     "unit_cost": 125.00,
     "location": "Warehouse A-17",
-    "last_updated": "2025-09-22T11:30:00"
+    "last_updated": "2025-09-22T11:30:00",
+    "lead_time_days": 12
   },
   {
     "id": "32",
@@ -381,6 +412,7 @@
     "reorder_point": 100,
     "unit_cost": 185.50,
     "location": "Warehouse C-11",
-    "last_updated": "2025-09-21T15:20:00"
+    "last_updated": "2025-09-21T15:20:00",
+    "lead_time_days": 11
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,11 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta, date
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+
+# In-memory store for submitted restocking orders.
+restocking_orders: list[dict] = []
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -67,6 +71,7 @@ class InventoryItem(BaseModel):
     unit_cost: float
     location: str
     last_updated: str
+    lead_time_days: int
 
 class Order(BaseModel):
     id: str
@@ -119,6 +124,40 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingCandidate(BaseModel):
+    sku: str
+    name: str
+    category: str
+    warehouse: str
+    quantity_on_hand: int
+    forecasted_demand: int
+    shortfall: int
+    recommended_qty: int
+    unit_cost: float
+    estimated_cost: float
+    lead_time_days: int
+    trend: str
+
+class RestockingOrderLine(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+    lead_time_days: int
+    subtotal: float
+
+class RestockingOrder(BaseModel):
+    id: str
+    submitted_date: str
+    status: str
+    items: List[RestockingOrderLine]
+    total_cost: float
+    max_lead_time_days: int
+    expected_delivery_date: str
+
+class CreateRestockingOrderRequest(BaseModel):
+    items: List[RestockingOrderLine]
 
 # API endpoints
 @app.get("/")
@@ -303,6 +342,87 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking/candidates", response_model=List[RestockingCandidate])
+def get_restocking_candidates(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None
+):
+    """Get restocking candidates by joining demand forecasts with inventory items.
+
+    Returns inventory items where forecasted demand exceeds quantity on hand,
+    sorted by shortfall descending.
+    """
+    # Build a lookup from SKU to inventory item for efficient joining.
+    inventory_by_sku: dict[str, dict] = {item["sku"]: item for item in inventory_items}
+
+    candidates = []
+    for forecast in demand_forecasts:
+        item_sku = forecast["item_sku"]
+        if item_sku not in inventory_by_sku:
+            continue
+
+        inventory_item = inventory_by_sku[item_sku]
+        shortfall = forecast["forecasted_demand"] - inventory_item["quantity_on_hand"]
+        if shortfall <= 0:
+            continue
+
+        candidates.append({
+            "sku": item_sku,
+            "name": inventory_item["name"],
+            "category": inventory_item["category"],
+            "warehouse": inventory_item["warehouse"],
+            "quantity_on_hand": inventory_item["quantity_on_hand"],
+            "forecasted_demand": forecast["forecasted_demand"],
+            "shortfall": shortfall,
+            "recommended_qty": shortfall,
+            "unit_cost": inventory_item["unit_cost"],
+            "estimated_cost": round(shortfall * inventory_item["unit_cost"], 2),
+            "lead_time_days": inventory_item["lead_time_days"],
+            "trend": forecast["trend"],
+        })
+
+    # Apply warehouse and category filters on the inventory-side fields.
+    candidates = apply_filters(candidates, warehouse, category)
+
+    # Sort by shortfall descending so highest-priority items appear first.
+    candidates.sort(key=lambda c: c["shortfall"], reverse=True)
+
+    return candidates
+
+
+@app.post("/api/restocking/orders", response_model=RestockingOrder)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Submit a new restocking order from the provided line items."""
+    if not request.items:
+        raise HTTPException(status_code=400, detail="No items provided")
+
+    order_number = len(restocking_orders) + 1
+    order_id = f"RO-{date.today().year}-{order_number:04d}"
+
+    total_cost = round(sum(line.subtotal for line in request.items), 2)
+    max_lead_time_days = max(line.lead_time_days for line in request.items)
+    expected_delivery_date = (date.today() + timedelta(days=max_lead_time_days)).isoformat()
+
+    order = {
+        "id": order_id,
+        "submitted_date": datetime.now().isoformat(),
+        "status": "Submitted",
+        "items": [line.model_dump() for line in request.items],
+        "total_cost": total_cost,
+        "max_lead_time_days": max_lead_time_days,
+        "expected_delivery_date": expected_delivery_date,
+    }
+
+    restocking_orders.append(order)
+    return order
+
+
+@app.get("/api/restocking/orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all submitted restocking orders, sorted by submitted date descending."""
+    return sorted(restocking_orders, key=lambda o: o["submitted_date"], reverse=True)
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/main.py
+++ b/server/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime, timedelta, date
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
@@ -10,29 +10,36 @@ restocking_orders: list[dict] = []
 
 app = FastAPI(title="Factory Inventory Management System")
 
-# Quarter mapping for date filtering
-QUARTER_MAP = {
-    'Q1-2025': ['2025-01', '2025-02', '2025-03'],
-    'Q2-2025': ['2025-04', '2025-05', '2025-06'],
-    'Q3-2025': ['2025-07', '2025-08', '2025-09'],
-    'Q4-2025': ['2025-10', '2025-11', '2025-12']
-}
+def _parse_quarter(key: str) -> Optional[list[str]]:
+    """Parse a 'Q<N>-<YYYY>' key into its three YYYY-MM month prefixes.
+
+    Returns None for any malformed or out-of-range input — callers treat
+    that as 'no orders match' rather than silently passing the filter.
+    """
+    try:
+        q_part, year_part = key.split('-')
+        quarter_num = int(q_part[1:])
+        year = int(year_part)
+    except (ValueError, IndexError):
+        return None
+    if not 1 <= quarter_num <= 4:
+        return None
+    start = (quarter_num - 1) * 3 + 1
+    return [f"{year}-{m:02d}" for m in range(start, start + 3)]
 
 def filter_by_month(items: list, month: Optional[str]) -> list:
-    """Filter items by month/quarter based on order_date field"""
+    """Filter items by month (YYYY-MM) or quarter (Q<N>-<YYYY>) based on order_date."""
     if not month or month == 'all':
         return items
 
     if month.startswith('Q'):
-        # Handle quarters
-        if month in QUARTER_MAP:
-            months = QUARTER_MAP[month]
-            return [item for item in items if any(m in item.get('order_date', '') for m in months)]
-    else:
-        # Direct month match
-        return [item for item in items if month in item.get('order_date', '')]
+        months = _parse_quarter(month)
+        if months is None:
+            return []
+        return [item for item in items if any(m in item.get('order_date', '') for m in months)]
 
-    return items
+    # Direct month match (YYYY-MM)
+    return [item for item in items if month in item.get('order_date', '')]
 
 def apply_filters(items: list, warehouse: Optional[str] = None, category: Optional[str] = None,
                  status: Optional[str] = None) -> list:
@@ -142,10 +149,10 @@ class RestockingCandidate(BaseModel):
 class RestockingOrderLine(BaseModel):
     sku: str
     name: str
-    quantity: int
-    unit_cost: float
-    lead_time_days: int
-    subtotal: float
+    quantity: int = Field(gt=0)
+    unit_cost: float = Field(ge=0)
+    lead_time_days: int = Field(ge=0)
+    subtotal: float = Field(ge=0)
 
 class RestockingOrder(BaseModel):
     id: str
@@ -268,23 +275,21 @@ def get_recent_transactions():
 
 @app.get("/api/reports/quarterly")
 def get_quarterly_reports():
-    """Get quarterly performance reports"""
-    # Calculate quarterly statistics from orders
+    """Get quarterly performance reports for every year present in the data."""
     quarters = {}
 
     for order in orders:
         order_date = order.get('order_date', '')
-        # Determine quarter
-        if '2025-01' in order_date or '2025-02' in order_date or '2025-03' in order_date:
-            quarter = 'Q1-2025'
-        elif '2025-04' in order_date or '2025-05' in order_date or '2025-06' in order_date:
-            quarter = 'Q2-2025'
-        elif '2025-07' in order_date or '2025-08' in order_date or '2025-09' in order_date:
-            quarter = 'Q3-2025'
-        elif '2025-10' in order_date or '2025-11' in order_date or '2025-12' in order_date:
-            quarter = 'Q4-2025'
-        else:
+        if len(order_date) < 7:
             continue
+        try:
+            year = int(order_date[:4])
+            month_num = int(order_date[5:7])
+        except ValueError:
+            continue
+        if not 1 <= month_num <= 12:
+            continue
+        quarter = f"Q{(month_num - 1) // 3 + 1}-{year}"
 
         if quarter not in quarters:
             quarters[quarter] = {

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -40,3 +40,12 @@ indent-style = "space"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]
+
+[tool.coverage.run]
+source = ["main", "mock_data"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+fail_under = 75

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -15,7 +15,28 @@ dev-dependencies = [
     "pytest-asyncio>=0.23.0",
     "httpx>=0.27.0",
     "pytest-cov>=4.1.0",
+    "ruff>=0.4.0",
 ]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # bugbear
+    "UP",  # pyupgrade
+    "SIM", # simplify
+]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/tests/backend/test_dashboard.py
+++ b/tests/backend/test_dashboard.py
@@ -1,6 +1,8 @@
 """
 Tests for dashboard API endpoints.
 """
+import random
+
 import pytest
 
 
@@ -171,3 +173,79 @@ class TestDashboardEndpoints:
 
         # Allow small floating point differences
         assert abs(dashboard_data["total_inventory_value"] - expected_value) < 0.01
+
+
+class TestDashboardProperties:
+    """Property-based tests for /api/dashboard/summary."""
+
+    def test_random_filter_combos_return_all_keys_and_non_negative_values(self, client):
+        """For 10 random filter combinations, the summary always has the 5 required keys
+        and all numeric values are non-negative.
+
+        Catches: missing keys under certain filter combos (e.g., no-orders case where
+        total_orders_value might be omitted), and sign errors in any computed aggregate.
+        """
+        random.seed(13)
+
+        warehouses = ["London", "San Francisco", "Tokyo", None]
+        categories = ["Actuators", "Circuit Boards", "Controllers", "Power Supplies", "Sensors", None]
+        statuses = ["Backordered", "Delivered", "Processing", "Shipped", None]
+        months = ["2025-01", "2025-06", "2025-12", "Q1-2025", "Q4-2025", None]
+
+        required_keys = [
+            "total_inventory_value",
+            "low_stock_items",
+            "pending_orders",
+            "total_backlog_items",
+            "total_orders_value",
+        ]
+
+        for _ in range(10):
+            params = {}
+            warehouse = random.choice(warehouses)
+            category = random.choice(categories)
+            status = random.choice(statuses)
+            month = random.choice(months)
+
+            if warehouse is not None:
+                params["warehouse"] = warehouse
+            if category is not None:
+                params["category"] = category
+            if status is not None:
+                params["status"] = status
+            if month is not None:
+                params["month"] = month
+
+            query = "&".join(f"{k}={v}" for k, v in params.items())
+            url = f"/api/dashboard/summary?{query}" if query else "/api/dashboard/summary"
+
+            response = client.get(url)
+            assert response.status_code == 200, (
+                f"Expected 200 for params={params}, got {response.status_code}"
+            )
+
+            data = response.json()
+            assert isinstance(data, dict), f"Expected dict response for params={params}"
+
+            # All 5 keys must be present regardless of filter combination.
+            for key in required_keys:
+                assert key in data, (
+                    f"Missing key '{key}' in dashboard summary for params={params}"
+                )
+
+            # All numeric values must be non-negative.
+            assert data["total_inventory_value"] >= 0, (
+                f"total_inventory_value negative for params={params}"
+            )
+            assert data["low_stock_items"] >= 0, (
+                f"low_stock_items negative for params={params}"
+            )
+            assert data["pending_orders"] >= 0, (
+                f"pending_orders negative for params={params}"
+            )
+            assert data["total_backlog_items"] >= 0, (
+                f"total_backlog_items negative for params={params}"
+            )
+            assert data["total_orders_value"] >= 0, (
+                f"total_orders_value negative for params={params}"
+            )

--- a/tests/backend/test_orders.py
+++ b/tests/backend/test_orders.py
@@ -263,3 +263,36 @@ class TestOrdersFuzz:
                     assert order.get("warehouse") == warehouse, (
                         f"Filter warehouse={warehouse} but order has warehouse={order.get('warehouse')}"
                     )
+
+
+class TestFilterByMonthEdgeCases:
+    """Invalid or out-of-range month/quarter keys must not silently pass through.
+
+    The previous implementation fell through to returning the unfiltered list for
+    any quarter key it didn't know about. That was a footgun: a typo or future
+    quarter silently disabled the filter instead of restricting the result set.
+    """
+
+    def test_future_quarter_with_no_data_returns_empty_list(self, client):
+        """Q1-2099 has no matching orders — must return [] not the full dataset."""
+        response = client.get("/api/orders?month=Q1-2099")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_malformed_quarter_key_returns_empty_list(self, client):
+        """'Qfoo-bar' is not a valid quarter — must return [] not the full dataset."""
+        response = client.get("/api/orders?month=Qfoo-bar")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_invalid_quarter_number_returns_empty_list(self, client):
+        """Q5-2025 is not a real quarter — must return [] not the full dataset."""
+        response = client.get("/api/orders?month=Q5-2025")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_quarter_key_missing_year_returns_empty_list(self, client):
+        """'Q1' without a year is malformed — must return [] not the full dataset."""
+        response = client.get("/api/orders?month=Q1")
+        assert response.status_code == 200
+        assert response.json() == []

--- a/tests/backend/test_orders.py
+++ b/tests/backend/test_orders.py
@@ -1,0 +1,265 @@
+"""
+Tests for the orders API endpoint (/api/orders).
+
+Covers:
+  - Empty filter set returns all orders.
+  - Month filter returns only matching orders.
+  - Quarter filter expands to Jan/Feb/Mar.
+  - Status filter restricts results.
+  - Combined warehouse + category + status filters compose correctly.
+  - GET /api/orders/{invalid_id} returns 404.
+  - Fuzz: random filter combos yield valid, schema-compliant, filter-consistent lists.
+"""
+import random
+
+import pytest
+
+
+# Required fields that every order in the response must have.
+ORDER_REQUIRED_FIELDS = [
+    "id",
+    "order_number",
+    "customer",
+    "items",
+    "status",
+    "order_date",
+    "expected_delivery",
+    "total_value",
+]
+
+# Valid filter values drawn from the dataset.
+VALID_WAREHOUSES = ["London", "San Francisco", "Tokyo"]
+VALID_CATEGORIES = ["Actuators", "Circuit Boards", "Controllers", "Power Supplies", "Sensors"]
+VALID_STATUSES = ["Backordered", "Delivered", "Processing", "Shipped"]
+
+
+def _assert_order_schema(order: dict) -> None:
+    """Assert that a single order dict has all required fields with valid types."""
+    for field in ORDER_REQUIRED_FIELDS:
+        assert field in order, f"Order missing required field '{field}': {order.get('order_number')}"
+
+    assert isinstance(order["id"], str)
+    assert isinstance(order["order_number"], str)
+    assert isinstance(order["customer"], str)
+    assert isinstance(order["items"], list)
+    assert isinstance(order["status"], str)
+    assert isinstance(order["order_date"], str)
+    assert isinstance(order["expected_delivery"], str)
+    assert isinstance(order["total_value"], (int, float))
+    assert order["total_value"] >= 0, (
+        f"total_value must be non-negative, got {order['total_value']}"
+    )
+
+
+class TestOrdersFilters:
+    """Test GET /api/orders filtering behaviour."""
+
+    def test_no_filters_returns_all_orders(self, client):
+        """Empty filter set returns the complete orders list.
+
+        Verifies that calling the endpoint without any query parameters returns
+        all orders, and that each item conforms to the expected schema.
+        """
+        response = client.get("/api/orders")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        for order in data:
+            _assert_order_schema(order)
+
+    def test_month_filter_returns_only_january_orders(self, client):
+        """?month=2025-01 returns only orders whose order_date is in January 2025.
+
+        A bug here would return orders from other months — for example if the
+        filter logic checked the wrong field or used substring matching incorrectly.
+        """
+        response = client.get("/api/orders?month=2025-01")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0, "Expected at least one January 2025 order in dataset"
+
+        for order in data:
+            assert "2025-01" in order["order_date"], (
+                f"Order {order['order_number']} has order_date '{order['order_date']}' "
+                f"but month filter was 2025-01"
+            )
+
+    def test_quarter_filter_returns_q1_months(self, client):
+        """?month=Q1-2025 returns orders from January, February, and March 2025.
+
+        Quarter expansion is a real parsing path — a bug here would either return
+        nothing (unrecognised quarter key) or return all orders (guard clause skipped).
+        """
+        response = client.get("/api/orders?month=Q1-2025")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0, "Expected Q1-2025 to match orders in the dataset"
+
+        q1_months = {"2025-01", "2025-02", "2025-03"}
+        for order in data:
+            order_month = order["order_date"][:7]
+            assert order_month in q1_months, (
+                f"Order {order['order_number']} has order_date '{order['order_date']}' "
+                f"which is outside Q1-2025"
+            )
+
+    def test_status_filter_delivered_returns_only_delivered(self, client):
+        """?status=Delivered returns only orders with status 'Delivered'.
+
+        A bug here would return orders of other statuses, breaking the
+        dashboard pending-orders count and the orders view filtering.
+        """
+        response = client.get("/api/orders?status=Delivered")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0, "Expected delivered orders in dataset"
+
+        for order in data:
+            assert order["status"] == "Delivered", (
+                f"Order {order['order_number']} has status '{order['status']}' "
+                f"but status filter was 'Delivered'"
+            )
+
+    def test_combined_filters_compose_correctly(self, client):
+        """?warehouse=X&category=Y&status=Z applies all three constraints.
+
+        Tests the composition of three independent filters. A bug here would
+        typically arise when a filter early-exits or short-circuits on the 'all'
+        sentinel but the logic also skips the remaining explicit filters.
+        """
+        response = client.get(
+            "/api/orders?warehouse=Tokyo&category=Actuators&status=Delivered"
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        for order in data:
+            assert order.get("warehouse") == "Tokyo", (
+                f"Expected warehouse=Tokyo, got '{order.get('warehouse')}'"
+            )
+            assert order.get("category", "").lower() == "actuators", (
+                f"Expected category=Actuators, got '{order.get('category')}'"
+            )
+            assert order["status"] == "Delivered", (
+                f"Expected status=Delivered, got '{order['status']}'"
+            )
+
+    def test_all_filter_sentinel_returns_same_as_no_filter(self, client):
+        """Passing warehouse=all&category=all&status=all returns the full dataset.
+
+        The 'all' sentinel is a special no-op value. This test catches the bug
+        where the sentinel is not recognised and is instead used as a literal
+        filter value, returning zero results.
+        """
+        response_explicit_all = client.get(
+            "/api/orders?warehouse=all&category=all&status=all&month=all"
+        )
+        response_no_filter = client.get("/api/orders")
+
+        assert response_explicit_all.status_code == 200
+        assert response_no_filter.status_code == 200
+
+        assert len(response_explicit_all.json()) == len(response_no_filter.json()), (
+            "Passing 'all' for all filters should return same count as no filters"
+        )
+
+
+class TestOrdersById:
+    """Test GET /api/orders/{order_id}."""
+
+    def test_valid_id_returns_order(self, client):
+        """Fetching a known order ID returns the correct order document."""
+        all_orders = client.get("/api/orders").json()
+        assert len(all_orders) > 0
+
+        first_id = all_orders[0]["id"]
+        response = client.get(f"/api/orders/{first_id}")
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["id"] == first_id
+
+    def test_invalid_id_returns_404(self, client):
+        """GET /api/orders/{invalid_id} returns 404 with a detail message.
+
+        This catches the missing guard clause — without it, the endpoint would
+        either raise an unhandled exception (500) or return None incorrectly.
+        """
+        response = client.get("/api/orders/nonexistent-order-id-999")
+        assert response.status_code == 404
+
+        data = response.json()
+        assert "detail" in data, "404 response must include a 'detail' field"
+
+
+class TestOrdersFuzz:
+    """Fuzz-style tests: random filter combos must always return valid order lists."""
+
+    def test_random_filter_combos_return_valid_schema(self, client):
+        """For 10 random filter combinations, verify every response is a valid
+        list where each item has all required fields and respects the applied
+        status filter.
+
+        Catches: schema regressions introduced when new fields are added/removed,
+        filter interactions that crash the server, and status filter leakage.
+        """
+        random.seed(42)
+
+        # Build a pool of 10 combos; None means 'omit the parameter' (server default).
+        warehouse_pool = VALID_WAREHOUSES + [None]
+        category_pool = VALID_CATEGORIES + [None]
+        status_pool = VALID_STATUSES + [None]
+        month_pool = ["2025-01", "2025-06", "2025-12", "Q1-2025", "Q3-2025", None]
+
+        for _ in range(10):
+            warehouse = random.choice(warehouse_pool)
+            category = random.choice(category_pool)
+            status = random.choice(status_pool)
+            month = random.choice(month_pool)
+
+            params = {}
+            if warehouse is not None:
+                params["warehouse"] = warehouse
+            if category is not None:
+                params["category"] = category
+            if status is not None:
+                params["status"] = status
+            if month is not None:
+                params["month"] = month
+
+            query = "&".join(f"{k}={v}" for k, v in params.items())
+            url = f"/api/orders?{query}" if query else "/api/orders"
+
+            response = client.get(url)
+            assert response.status_code == 200, (
+                f"Expected 200 for params={params}, got {response.status_code}"
+            )
+
+            data = response.json()
+            assert isinstance(data, list), f"Response must be a list for params={params}"
+
+            for order in data:
+                _assert_order_schema(order)
+
+                # If status was specified, every returned order must match it.
+                if status is not None:
+                    assert order["status"].lower() == status.lower(), (
+                        f"Filter status={status} but order has status={order['status']}"
+                    )
+
+                # If warehouse was specified, every returned order must match it.
+                if warehouse is not None:
+                    assert order.get("warehouse") == warehouse, (
+                        f"Filter warehouse={warehouse} but order has warehouse={order.get('warehouse')}"
+                    )

--- a/tests/backend/test_reports.py
+++ b/tests/backend/test_reports.py
@@ -279,3 +279,60 @@ class TestMonthlyTrends:
         assert len(months) == len(set(months)), (
             f"Duplicate month entries found: {months}"
         )
+
+
+class TestQuarterlyReportsYearAgnostic:
+    """Quarterly reports must work for every year in the data, not just 2025.
+
+    The previous implementation hardcoded Q1-Q4 for 2025 via a chain of ifs
+    with `else: continue` — any 2026+ order was silently dropped. After the
+    fix, year is parsed directly from the order date.
+    """
+
+    def test_2026_order_produces_q1_2026_entry(self, client):
+        """Injecting a February 2026 order must produce a Q1-2026 quarter entry."""
+        import main
+
+        fake_order = {
+            "id": "test-2026-q1",
+            "order_number": "ORD-TEST-2026-Q1",
+            "customer": "Year-Agnostic Test",
+            "items": [],
+            "status": "Delivered",
+            "order_date": "2026-02-15T10:00:00",
+            "expected_delivery": "2026-02-20T10:00:00",
+            "total_value": 1000.0,
+        }
+        main.orders.append(fake_order)
+        try:
+            response = client.get("/api/reports/quarterly")
+            assert response.status_code == 200
+            quarters = {entry["quarter"] for entry in response.json()}
+            assert "Q1-2026" in quarters, (
+                f"Expected Q1-2026 in response, got: {sorted(quarters)}"
+            )
+        finally:
+            main.orders.remove(fake_order)
+
+    def test_2024_order_produces_q4_2024_entry(self, client):
+        """A November 2024 order must produce a Q4-2024 quarter (past years work too)."""
+        import main
+
+        fake_order = {
+            "id": "test-2024-q4",
+            "order_number": "ORD-TEST-2024-Q4",
+            "customer": "Past-Year Test",
+            "items": [],
+            "status": "Delivered",
+            "order_date": "2024-11-05T10:00:00",
+            "expected_delivery": "2024-11-10T10:00:00",
+            "total_value": 500.0,
+        }
+        main.orders.append(fake_order)
+        try:
+            response = client.get("/api/reports/quarterly")
+            assert response.status_code == 200
+            quarters = {entry["quarter"] for entry in response.json()}
+            assert "Q4-2024" in quarters
+        finally:
+            main.orders.remove(fake_order)

--- a/tests/backend/test_reports.py
+++ b/tests/backend/test_reports.py
@@ -1,0 +1,281 @@
+"""
+Tests for reporting API endpoints.
+
+Covers:
+  - GET /api/reports/quarterly — structure, sort order, math invariants.
+  - GET /api/reports/monthly-trends — structure, sort order, aggregate invariants.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+server_path = Path(__file__).parent.parent.parent / "server"
+sys.path.insert(0, str(server_path))
+
+
+QUARTERLY_REQUIRED_FIELDS = [
+    "quarter",
+    "total_orders",
+    "total_revenue",
+    "avg_order_value",
+    "fulfillment_rate",
+]
+
+MONTHLY_REQUIRED_FIELDS = [
+    "month",
+    "order_count",
+    "revenue",
+    "delivered_count",
+]
+
+
+class TestQuarterlyReports:
+    """Test suite for GET /api/reports/quarterly."""
+
+    def test_returns_at_most_four_entries(self, client):
+        """Response contains at most 4 quarters (Q1–Q4 of a single year).
+
+        More than 4 would indicate duplicate keys or date parsing that assigns
+        a single order to multiple quarters.
+        """
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) <= 4, (
+            f"Expected at most 4 quarterly entries, got {len(data)}"
+        )
+
+    def test_all_required_fields_present(self, client):
+        """Every quarter entry contains all required fields."""
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 0, "Expected at least one quarterly entry in dataset"
+
+        for entry in data:
+            for field in QUARTERLY_REQUIRED_FIELDS:
+                assert field in entry, (
+                    f"Quarter entry missing required field '{field}': {entry.get('quarter')}"
+                )
+
+    def test_quarters_sorted_ascending(self, client):
+        """Quarter entries are sorted by quarter label in ascending order.
+
+        Ascending order (Q1, Q2, Q3, Q4) is the natural chronological display.
+        Descending or unsorted would make trend analysis confusing.
+        """
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        data = response.json()
+        quarters = [entry["quarter"] for entry in data]
+        assert quarters == sorted(quarters), (
+            f"Quarters not sorted ascending: {quarters}"
+        )
+
+    def test_fulfillment_rate_is_valid_percentage(self, client):
+        """fulfillment_rate is between 0.0 and 100.0 for every quarter."""
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            rate = entry["fulfillment_rate"]
+            assert isinstance(rate, (int, float)), (
+                f"fulfillment_rate must be numeric, got {type(rate)}"
+            )
+            assert 0.0 <= rate <= 100.0, (
+                f"fulfillment_rate {rate} is outside [0, 100] for {entry['quarter']}"
+            )
+
+    def test_fulfillment_rate_math(self, client):
+        """fulfillment_rate equals round(delivered_orders / total_orders * 100, 1).
+
+        The endpoint computes this on the fly from order data. A rounding mistake
+        or division order error would surface here.
+        """
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            total = entry["total_orders"]
+            assert total > 0, f"total_orders must be > 0 for {entry['quarter']}"
+
+            # Reconstruct delivered_orders from fulfillment_rate and total_orders.
+            # We cannot read delivered_orders directly from the response, but we can
+            # verify the rate is consistent with being derived from an integer count.
+            rate = entry["fulfillment_rate"]
+            # rate = round(delivered / total * 100, 1) implies
+            # delivered = round(rate * total / 100) must be an integer in [0, total].
+            implied_delivered = round(rate * total / 100)
+            assert 0 <= implied_delivered <= total, (
+                f"fulfillment_rate {rate} implies {implied_delivered} delivered out of "
+                f"{total} total for {entry['quarter']} — impossible value"
+            )
+
+            # Verify the back-computed rate matches.
+            recomputed_rate = round((implied_delivered / total) * 100, 1)
+            assert abs(recomputed_rate - rate) < 0.2, (
+                f"fulfillment_rate {rate} does not match back-computed {recomputed_rate} "
+                f"for {entry['quarter']}"
+            )
+
+    def test_avg_order_value_math(self, client):
+        """avg_order_value equals round(total_revenue / total_orders, 2).
+
+        A missing round(), wrong denominator, or field-name typo would fail here.
+        """
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            total = entry["total_orders"]
+            assert total > 0
+
+            expected_avg = round(entry["total_revenue"] / total, 2)
+            actual_avg = entry["avg_order_value"]
+
+            assert abs(actual_avg - expected_avg) < 0.01, (
+                f"avg_order_value {actual_avg} != expected {expected_avg} "
+                f"for {entry['quarter']}"
+            )
+
+    def test_total_orders_is_positive_int(self, client):
+        """total_orders is a positive integer for every quarter entry."""
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            assert isinstance(entry["total_orders"], int)
+            assert entry["total_orders"] > 0
+
+    def test_total_revenue_is_non_negative(self, client):
+        """total_revenue is a non-negative number for every quarter entry."""
+        response = client.get("/api/reports/quarterly")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            assert isinstance(entry["total_revenue"], (int, float))
+            assert entry["total_revenue"] >= 0
+
+
+class TestMonthlyTrends:
+    """Test suite for GET /api/reports/monthly-trends."""
+
+    def test_returns_list(self, client):
+        """Response is a non-empty list of monthly trend objects."""
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0, "Expected at least one month in the dataset"
+
+    def test_all_required_fields_present(self, client):
+        """Every monthly entry contains all required fields."""
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            for field in MONTHLY_REQUIRED_FIELDS:
+                assert field in entry, (
+                    f"Monthly entry missing required field '{field}': {entry.get('month')}"
+                )
+
+    def test_month_format_is_yyyy_mm(self, client):
+        """Every 'month' value is in YYYY-MM format.
+
+        A date parsing bug that includes day or time would produce a wrong key,
+        causing months to merge incorrectly or produce malformed output.
+        """
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            month = entry["month"]
+            assert isinstance(month, str)
+            assert len(month) == 7, f"Expected YYYY-MM format, got '{month}'"
+            assert month[4] == "-", f"Expected YYYY-MM format, got '{month}'"
+            year_part = month[:4]
+            month_part = month[5:]
+            assert year_part.isdigit(), f"Year part not numeric in '{month}'"
+            assert month_part.isdigit(), f"Month part not numeric in '{month}'"
+            assert 1 <= int(month_part) <= 12, f"Month value out of range in '{month}'"
+
+    def test_entries_sorted_ascending(self, client):
+        """Monthly entries are sorted by month label ascending (oldest first)."""
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        months = [entry["month"] for entry in response.json()]
+        assert months == sorted(months), (
+            f"Monthly entries not sorted ascending: {months}"
+        )
+
+    def test_sum_of_order_counts_equals_total_orders(self, client):
+        """Sum of order_count across all months equals total orders in the dataset.
+
+        This is a strong invariant: the monthly aggregation must be lossless.
+        Any order dropped during date parsing would cause the sum to diverge.
+        """
+        from mock_data import orders as all_orders
+
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        monthly_sum = sum(entry["order_count"] for entry in response.json())
+        assert monthly_sum == len(all_orders), (
+            f"Monthly order_count sum {monthly_sum} != total orders {len(all_orders)}"
+        )
+
+    def test_sum_of_revenue_equals_total_order_value(self, client):
+        """Sum of monthly revenue equals the sum of all order total_values.
+
+        A data type mismatch, field name error, or order dropped during month
+        extraction would cause this invariant to fail.
+        """
+        from mock_data import orders as all_orders
+
+        expected_total = sum(o.get("total_value", 0) for o in all_orders)
+
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        monthly_revenue_sum = sum(entry["revenue"] for entry in response.json())
+
+        assert abs(monthly_revenue_sum - expected_total) < 0.01, (
+            f"Monthly revenue sum {monthly_revenue_sum} != "
+            f"expected total {expected_total}"
+        )
+
+    def test_delivered_count_never_exceeds_order_count(self, client):
+        """delivered_count <= order_count for every month.
+
+        A logic error where delivered orders are counted against the wrong month
+        or double-counted would violate this constraint.
+        """
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        for entry in response.json():
+            assert entry["delivered_count"] <= entry["order_count"], (
+                f"Month {entry['month']}: delivered_count {entry['delivered_count']} "
+                f"> order_count {entry['order_count']}"
+            )
+
+    def test_no_duplicate_months(self, client):
+        """Each YYYY-MM value appears exactly once in the response.
+
+        Duplicates would indicate a grouping bug where the same month is
+        accumulated into two separate dict keys.
+        """
+        response = client.get("/api/reports/monthly-trends")
+        assert response.status_code == 200
+
+        months = [entry["month"] for entry in response.json()]
+        assert len(months) == len(set(months)), (
+            f"Duplicate month entries found: {months}"
+        )

--- a/tests/backend/test_restocking.py
+++ b/tests/backend/test_restocking.py
@@ -385,3 +385,277 @@ class TestRestockingOrders:
         assert orders[0]["submitted_date"] >= orders[1]["submitted_date"], (
             "Orders are not sorted by submitted_date descending"
         )
+
+
+class TestRestockingOrderValidation:
+    """Boundary and validation tests for POST /api/restocking/orders."""
+
+    def _item_with_quantity(self, quantity: int) -> dict:
+        """Return a restocking order line item with the specified quantity."""
+        return {
+            "sku": "TMP-201",
+            "name": "Temperature Sensor Module",
+            "quantity": quantity,
+            "unit_cost": 89.5,
+            "lead_time_days": 14,
+            "subtotal": round(quantity * 89.5, 2),
+        }
+
+    def test_negative_quantity_rejected(self, client):
+        """POST with a negative quantity is rejected with 422 (Pydantic validation).
+
+        Pydantic does not apply non-negativity constraints automatically for plain int
+        fields. Without an explicit validator or ge=1 constraint, negative quantities
+        would silently pass and corrupt total_cost / subtotal math. This test
+        documents the current behaviour: the server must either accept and handle it
+        gracefully, or reject it.
+
+        The current implementation has no ge constraint, so negative quantities pass
+        Pydantic validation. We document this as the expected current behaviour and
+        assert that the server does not crash (status is not 500). If the server gains
+        proper validation, this test should be updated to assert 422.
+        """
+        import main
+        main.restocking_orders.clear()
+
+        payload = {"items": [self._item_with_quantity(-10)]}
+        response = client.post("/api/restocking/orders", json=payload)
+        # Current behaviour: no ge constraint on quantity → Pydantic accepts it.
+        # The server must not crash with 500. 200 is acceptable if it passes through.
+        assert response.status_code != 500, (
+            "Negative quantity caused an unhandled server error"
+        )
+
+    def test_zero_quantity_rejected_or_accepted_without_crash(self, client):
+        """POST with quantity=0 does not crash the server.
+
+        Zero-quantity items result in a zero subtotal. This verifies the server
+        handles the edge case without a division-by-zero or unhandled exception.
+        Currently zero passes Pydantic validation (no gt=0 constraint), so we
+        assert only that the server responds without error.
+        """
+        import main
+        main.restocking_orders.clear()
+
+        payload = {"items": [self._item_with_quantity(0)]}
+        response = client.post("/api/restocking/orders", json=payload)
+        # The server must not crash with an unhandled 500 for zero quantity.
+        assert response.status_code != 500, (
+            "Zero quantity caused an unhandled server error"
+        )
+
+    def test_two_consecutive_posts_have_distinct_monotonically_increasing_ids(self, client):
+        """Two consecutive POSTs yield distinct IDs that increment: RO-YYYY-0001 → RO-YYYY-0002.
+
+        The ID is derived from len(restocking_orders) + 1, so the second POST must
+        yield a sequence number that is exactly one higher than the first. A bug where
+        the list is not appended correctly before computing the length would cause
+        both orders to share the same ID.
+        """
+        import main
+        from datetime import date
+
+        main.restocking_orders.clear()
+
+        items = [
+            {
+                "sku": "TMP-201",
+                "name": "Temperature Sensor Module",
+                "quantity": 10,
+                "unit_cost": 89.5,
+                "lead_time_days": 14,
+                "subtotal": round(10 * 89.5, 2),
+            }
+        ]
+        payload = {"items": items}
+
+        first_response = client.post("/api/restocking/orders", json=payload)
+        assert first_response.status_code == 200
+        second_response = client.post("/api/restocking/orders", json=payload)
+        assert second_response.status_code == 200
+
+        year = date.today().year
+        first_id = first_response.json()["id"]
+        second_id = second_response.json()["id"]
+
+        assert first_id == f"RO-{year}-0001", f"First ID should be RO-{year}-0001, got {first_id}"
+        assert second_id == f"RO-{year}-0002", f"Second ID should be RO-{year}-0002, got {second_id}"
+        assert first_id != second_id, "Consecutive orders must have distinct IDs"
+
+    def test_expected_delivery_date_is_today_plus_max_lead_time(self, client):
+        """expected_delivery_date = today + max(lead_time_days) for the posted items.
+
+        This verifies the date arithmetic exactly. A bug using timedelta(days=sum(...))
+        or using the wrong field name would produce a wrong delivery date.
+        """
+        import main
+        from datetime import date, timedelta
+
+        main.restocking_orders.clear()
+
+        items = [
+            {
+                "sku": "TMP-201",
+                "name": "Item A",
+                "quantity": 5,
+                "unit_cost": 10.0,
+                "lead_time_days": 7,
+                "subtotal": 50.0,
+            },
+            {
+                "sku": "SRV-301",
+                "name": "Item B",
+                "quantity": 5,
+                "unit_cost": 10.0,
+                "lead_time_days": 21,
+                "subtotal": 50.0,
+            },
+        ]
+        expected_delivery = (date.today() + timedelta(days=21)).isoformat()
+
+        response = client.post("/api/restocking/orders", json={"items": items})
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["expected_delivery_date"] == expected_delivery, (
+            f"Expected delivery {expected_delivery}, got {order['expected_delivery_date']}"
+        )
+
+
+class TestRestockingCandidatesEdgeCases:
+    """Edge case tests for GET /api/restocking/candidates."""
+
+    def test_filter_by_warehouse_with_no_matching_inventory_returns_empty_list(self, client):
+        """Candidates with a warehouse that has no shortfall items returns [] not an error.
+
+        If the filter results in an empty list, the endpoint must return an empty
+        JSON array rather than 404 or 500. This catches the case where an empty
+        candidates list raises an assertion or causes a crash.
+        """
+        # Use a warehouse filter value that is valid but may yield zero restocking
+        # candidates. We cannot guarantee which warehouse has zero shortfalls, so
+        # we verify that any warehouse filter returns 200 with a list.
+        response = client.get("/api/restocking/candidates?warehouse=San Francisco&category=Circuit Boards")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list), "Empty candidate result must be a list, not null or error"
+
+    def test_unknown_warehouse_returns_empty_list_not_error(self, client):
+        """A warehouse name that matches no inventory items returns [] not an error.
+
+        This tests the degenerate case where filtering eliminates all candidates.
+        """
+        response = client.get("/api/restocking/candidates?warehouse=NonExistentCity")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 0, (
+            "A warehouse with no inventory should produce an empty candidates list"
+        )
+
+
+class TestRestockingFuzz:
+    """Fuzz-style tests for restocking round-trip behaviour."""
+
+    def _get_candidates(self, client) -> list[dict]:
+        """Return the full list of restocking candidates."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+        return response.json()
+
+    def test_random_candidate_subsets_round_trip_correctly(self, client):
+        """20 random subsets of candidates can be POSTed and read back with correct
+        structure, sort order, and total_cost invariant.
+
+        Catches: serialisation bugs, total_cost accumulation errors, sort-order
+        regressions after multiple POSTs, and missing fields on GET.
+        """
+        import main
+        import random
+        from datetime import date
+
+        random.seed(7)
+        main.restocking_orders.clear()
+
+        candidates = self._get_candidates(client)
+        assert len(candidates) > 0, "Need candidates to fuzz restocking orders"
+
+        posted_ids: list[str] = []
+
+        for iteration in range(20):
+            # Pick 1–3 candidates at random, using them as order line items.
+            subset_size = random.randint(1, min(3, len(candidates)))
+            subset = random.sample(candidates, subset_size)
+
+            items = [
+                {
+                    "sku": c["sku"],
+                    "name": c["name"],
+                    "quantity": c["recommended_qty"],
+                    "unit_cost": c["unit_cost"],
+                    "lead_time_days": c["lead_time_days"],
+                    "subtotal": c["estimated_cost"],
+                }
+                for c in subset
+            ]
+
+            expected_total = round(sum(item["subtotal"] for item in items), 2)
+
+            response = client.post("/api/restocking/orders", json={"items": items})
+            assert response.status_code == 200, (
+                f"Iteration {iteration}: POST failed with {response.status_code}"
+            )
+
+            order = response.json()
+
+            # Verify required fields are present.
+            for field in ["id", "submitted_date", "status", "items", "total_cost",
+                          "max_lead_time_days", "expected_delivery_date"]:
+                assert field in order, (
+                    f"Iteration {iteration}: missing field '{field}' in created order"
+                )
+
+            # Verify total_cost invariant.
+            assert abs(order["total_cost"] - expected_total) < 0.01, (
+                f"Iteration {iteration}: total_cost {order['total_cost']} != "
+                f"expected {expected_total}"
+            )
+
+            # Verify ID format.
+            year = date.today().year
+            expected_id = f"RO-{year}-{(iteration + 1):04d}"
+            assert order["id"] == expected_id, (
+                f"Iteration {iteration}: expected ID {expected_id}, got {order['id']}"
+            )
+
+            posted_ids.append(order["id"])
+
+        # GET all orders and verify sort order (submitted_date descending) and
+        # that all posted orders are present with all required fields.
+        get_response = client.get("/api/restocking/orders")
+        assert get_response.status_code == 200
+
+        all_orders = get_response.json()
+        assert len(all_orders) == 20, (
+            f"Expected 20 orders after 20 POSTs, got {len(all_orders)}"
+        )
+
+        # Verify submitted_date descending sort.
+        dates = [o["submitted_date"] for o in all_orders]
+        assert dates == sorted(dates, reverse=True), (
+            "GET /api/restocking/orders must return orders sorted by submitted_date descending"
+        )
+
+        # Verify all posted IDs are present and every order has required fields.
+        returned_ids = {o["id"] for o in all_orders}
+        for posted_id in posted_ids:
+            assert posted_id in returned_ids, (
+                f"Posted order {posted_id} not found in GET response"
+            )
+
+        for order in all_orders:
+            for field in ["id", "submitted_date", "status", "items", "total_cost",
+                          "max_lead_time_days", "expected_delivery_date"]:
+                assert field in order, f"GET response order missing field '{field}'"

--- a/tests/backend/test_restocking.py
+++ b/tests/backend/test_restocking.py
@@ -1,0 +1,387 @@
+"""
+Tests for restocking API endpoints.
+
+Covers:
+  - GET /api/restocking/candidates — candidate list, filtering, ordering
+  - POST /api/restocking/orders — order creation, validation
+  - GET /api/restocking/orders — order list after creation
+"""
+import pytest
+
+import sys
+from pathlib import Path
+
+# Ensure module-level restocking_orders list is reset between test sessions
+# by importing the module reference directly.
+server_path = Path(__file__).parent.parent.parent / "server"
+sys.path.insert(0, str(server_path))
+
+
+class TestRestockingCandidates:
+    """Test suite for GET /api/restocking/candidates."""
+
+    def test_get_candidates_returns_non_empty_list(self, client):
+        """Test that the candidates endpoint returns a non-empty list."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    def test_get_candidates_has_expected_keys(self, client):
+        """Test that each candidate has all required fields."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        data = response.json()
+        required_fields = [
+            "sku",
+            "name",
+            "category",
+            "warehouse",
+            "quantity_on_hand",
+            "forecasted_demand",
+            "shortfall",
+            "recommended_qty",
+            "unit_cost",
+            "estimated_cost",
+            "lead_time_days",
+            "trend",
+        ]
+        for candidate in data:
+            for field in required_fields:
+                assert field in candidate, f"Missing field '{field}' in candidate {candidate.get('sku')}"
+
+    def test_get_candidates_shortfall_always_positive(self, client):
+        """Test that shortfall is always a positive integer for every candidate."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 0
+
+        for candidate in data:
+            assert candidate["shortfall"] > 0, (
+                f"Expected positive shortfall for {candidate['sku']}, got {candidate['shortfall']}"
+            )
+
+    def test_get_candidates_sorted_by_shortfall_descending(self, client):
+        """Test that candidates are sorted with highest shortfall first."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 1, "Need at least two candidates to verify sort order"
+
+        shortfalls = [c["shortfall"] for c in data]
+        assert shortfalls == sorted(shortfalls, reverse=True), (
+            f"Candidates not sorted by shortfall descending: {shortfalls}"
+        )
+
+    def test_get_candidates_shortfall_matches_computation(self, client):
+        """Test that shortfall equals forecasted_demand minus quantity_on_hand."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        for candidate in response.json():
+            expected_shortfall = candidate["forecasted_demand"] - candidate["quantity_on_hand"]
+            assert candidate["shortfall"] == expected_shortfall, (
+                f"Shortfall mismatch for {candidate['sku']}: "
+                f"expected {expected_shortfall}, got {candidate['shortfall']}"
+            )
+
+    def test_get_candidates_recommended_qty_equals_shortfall(self, client):
+        """Test that recommended_qty equals the shortfall for each candidate."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        for candidate in response.json():
+            assert candidate["recommended_qty"] == candidate["shortfall"], (
+                f"recommended_qty {candidate['recommended_qty']} != "
+                f"shortfall {candidate['shortfall']} for {candidate['sku']}"
+            )
+
+    def test_get_candidates_estimated_cost_matches_computation(self, client):
+        """Test that estimated_cost equals recommended_qty * unit_cost rounded to 2dp."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        for candidate in response.json():
+            expected_cost = round(candidate["recommended_qty"] * candidate["unit_cost"], 2)
+            assert abs(candidate["estimated_cost"] - expected_cost) < 0.01, (
+                f"estimated_cost mismatch for {candidate['sku']}: "
+                f"expected {expected_cost}, got {candidate['estimated_cost']}"
+            )
+
+    def test_get_candidates_filter_by_warehouse(self, client):
+        """Test that warehouse filter restricts candidates to that warehouse."""
+        # Use Tokyo — it contains Actuators items with shortfall in test data.
+        response = client.get("/api/restocking/candidates?warehouse=Tokyo")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        for candidate in data:
+            assert candidate["warehouse"] == "Tokyo", (
+                f"Expected Tokyo warehouse, got {candidate['warehouse']}"
+            )
+
+    def test_get_candidates_filter_by_category(self, client):
+        """Test that category filter restricts candidates to that category."""
+        response = client.get("/api/restocking/candidates?category=Actuators")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        for candidate in data:
+            assert candidate["category"].lower() == "actuators", (
+                f"Expected Actuators category, got {candidate['category']}"
+            )
+
+    def test_get_candidates_filter_by_warehouse_and_category(self, client):
+        """Test that combined warehouse and category filters both apply."""
+        response = client.get("/api/restocking/candidates?warehouse=Tokyo&category=Actuators")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        for candidate in data:
+            assert candidate["warehouse"] == "Tokyo"
+            assert candidate["category"].lower() == "actuators"
+
+    def test_get_candidates_lead_time_days_is_positive_int(self, client):
+        """Test that lead_time_days is a positive integer for each candidate."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        for candidate in response.json():
+            assert isinstance(candidate["lead_time_days"], int)
+            assert candidate["lead_time_days"] > 0
+
+    def test_get_candidates_trend_is_valid_string(self, client):
+        """Test that trend field is a non-empty string."""
+        response = client.get("/api/restocking/candidates")
+        assert response.status_code == 200
+
+        valid_trends = {"increasing", "decreasing", "stable"}
+        for candidate in response.json():
+            assert isinstance(candidate["trend"], str)
+            assert candidate["trend"] in valid_trends, (
+                f"Unexpected trend value '{candidate['trend']}' for {candidate['sku']}"
+            )
+
+
+class TestRestockingOrders:
+    """Test suite for POST /api/restocking/orders and GET /api/restocking/orders."""
+
+    def _sample_order_items(self) -> list[dict]:
+        """Return a minimal valid list of restocking order line items."""
+        return [
+            {
+                "sku": "TMP-201",
+                "name": "Temperature Sensor Module",
+                "quantity": 75,
+                "unit_cost": 89.5,
+                "lead_time_days": 14,
+                "subtotal": round(75 * 89.5, 2),
+            },
+            {
+                "sku": "SRV-301",
+                "name": "Micro Servo Motor",
+                "quantity": 45,
+                "unit_cost": 445.0,
+                "lead_time_days": 15,
+                "subtotal": round(45 * 445.0, 2),
+            },
+        ]
+
+    def test_post_order_with_valid_items_returns_200(self, client):
+        """Test that posting a valid restocking order returns HTTP 200."""
+        import main
+        main.restocking_orders.clear()
+
+        payload = {"items": self._sample_order_items()}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+    def test_post_order_response_has_expected_fields(self, client):
+        """Test that the created order response contains all required fields."""
+        import main
+        main.restocking_orders.clear()
+
+        payload = {"items": self._sample_order_items()}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        required_fields = [
+            "id",
+            "submitted_date",
+            "status",
+            "items",
+            "total_cost",
+            "max_lead_time_days",
+            "expected_delivery_date",
+        ]
+        for field in required_fields:
+            assert field in order, f"Missing field '{field}' in order response"
+
+    def test_post_order_id_format(self, client):
+        """Test that the generated order ID follows RO-YYYY-NNNN format."""
+        import main
+        from datetime import date
+
+        main.restocking_orders.clear()
+
+        payload = {"items": self._sample_order_items()}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        current_year = date.today().year
+        # ID should be RO-YYYY-NNNN where NNNN is zero-padded to 4 digits.
+        assert order["id"] == f"RO-{current_year}-0001", (
+            f"Unexpected order ID format: {order['id']}"
+        )
+
+    def test_post_order_status_is_submitted(self, client):
+        """Test that newly created orders have status 'Submitted'."""
+        import main
+        main.restocking_orders.clear()
+
+        payload = {"items": self._sample_order_items()}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["status"] == "Submitted"
+
+    def test_post_order_total_cost_computed_correctly(self, client):
+        """Test that total_cost equals the sum of all line item subtotals."""
+        import main
+        main.restocking_orders.clear()
+
+        items = self._sample_order_items()
+        expected_total = round(sum(item["subtotal"] for item in items), 2)
+
+        payload = {"items": items}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        assert abs(order["total_cost"] - expected_total) < 0.01, (
+            f"Expected total_cost {expected_total}, got {order['total_cost']}"
+        )
+
+    def test_post_order_max_lead_time_is_maximum_of_items(self, client):
+        """Test that max_lead_time_days is the maximum lead_time_days across items."""
+        import main
+        main.restocking_orders.clear()
+
+        items = self._sample_order_items()
+        expected_max = max(item["lead_time_days"] for item in items)
+
+        payload = {"items": items}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["max_lead_time_days"] == expected_max, (
+            f"Expected max_lead_time_days {expected_max}, got {order['max_lead_time_days']}"
+        )
+
+    def test_post_order_expected_delivery_date_format(self, client):
+        """Test that expected_delivery_date is a valid YYYY-MM-DD date string."""
+        import main
+        from datetime import date, timedelta
+
+        main.restocking_orders.clear()
+
+        items = self._sample_order_items()
+        max_lead = max(item["lead_time_days"] for item in items)
+        expected_delivery = (date.today() + timedelta(days=max_lead)).isoformat()
+
+        payload = {"items": items}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        # Verify format is YYYY-MM-DD (no time component).
+        delivery = order["expected_delivery_date"]
+        assert len(delivery) == 10, f"Expected YYYY-MM-DD format, got '{delivery}'"
+        assert delivery.count("-") == 2, f"Expected YYYY-MM-DD format, got '{delivery}'"
+        assert delivery == expected_delivery, (
+            f"Expected delivery date {expected_delivery}, got {delivery}"
+        )
+
+    def test_post_order_with_empty_items_returns_400(self, client):
+        """Test that posting an order with no items returns HTTP 400."""
+        import main
+        main.restocking_orders.clear()
+
+        payload = {"items": []}
+        response = client.post("/api/restocking/orders", json=payload)
+        assert response.status_code == 400
+
+        data = response.json()
+        assert "detail" in data
+
+    def test_get_orders_includes_newly_posted_order(self, client):
+        """Test that GET /api/restocking/orders returns orders created via POST."""
+        import main
+        main.restocking_orders.clear()
+
+        # Create an order first.
+        payload = {"items": self._sample_order_items()}
+        post_response = client.post("/api/restocking/orders", json=payload)
+        assert post_response.status_code == 200
+
+        created_order = post_response.json()
+        created_id = created_order["id"]
+
+        # Now fetch all orders and verify ours is present.
+        get_response = client.get("/api/restocking/orders")
+        assert get_response.status_code == 200
+
+        orders = get_response.json()
+        assert isinstance(orders, list)
+        assert len(orders) > 0
+
+        order_ids = [o["id"] for o in orders]
+        assert created_id in order_ids, (
+            f"Created order {created_id} not found in GET /api/restocking/orders"
+        )
+
+    def test_get_orders_returns_empty_list_when_no_orders(self, client):
+        """Test that GET /api/restocking/orders returns an empty list initially."""
+        import main
+        main.restocking_orders.clear()
+
+        response = client.get("/api/restocking/orders")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 0
+
+    def test_get_orders_sorted_by_submitted_date_descending(self, client):
+        """Test that GET /api/restocking/orders is sorted newest-first."""
+        import main
+        main.restocking_orders.clear()
+
+        # Create two orders in sequence.
+        payload = {"items": self._sample_order_items()}
+        client.post("/api/restocking/orders", json=payload)
+        client.post("/api/restocking/orders", json=payload)
+
+        response = client.get("/api/restocking/orders")
+        assert response.status_code == 200
+
+        orders = response.json()
+        assert len(orders) == 2
+
+        # Most recent order (second posted) should have a later or equal submitted_date.
+        assert orders[0]["submitted_date"] >= orders[1]["submitted_date"], (
+            "Orders are not sorted by submitted_date descending"
+        )

--- a/tests/backend/test_restocking.py
+++ b/tests/backend/test_restocking.py
@@ -401,48 +401,31 @@ class TestRestockingOrderValidation:
             "subtotal": round(quantity * 89.5, 2),
         }
 
-    def test_negative_quantity_rejected(self, client):
-        """POST with a negative quantity is rejected with 422 (Pydantic validation).
+    def test_negative_quantity_rejected_with_422(self, client):
+        """POST with a negative quantity must be rejected by Pydantic validation.
 
-        Pydantic does not apply non-negativity constraints automatically for plain int
-        fields. Without an explicit validator or ge=1 constraint, negative quantities
-        would silently pass and corrupt total_cost / subtotal math. This test
-        documents the current behaviour: the server must either accept and handle it
-        gracefully, or reject it.
-
-        The current implementation has no ge constraint, so negative quantities pass
-        Pydantic validation. We document this as the expected current behaviour and
-        assert that the server does not crash (status is not 500). If the server gains
-        proper validation, this test should be updated to assert 422.
+        RestockingOrderLine.quantity is declared with Field(gt=0). Negative values
+        would corrupt total_cost and subtotal math, so they must not reach the handler.
         """
         import main
         main.restocking_orders.clear()
 
         payload = {"items": [self._item_with_quantity(-10)]}
         response = client.post("/api/restocking/orders", json=payload)
-        # Current behaviour: no ge constraint on quantity → Pydantic accepts it.
-        # The server must not crash with 500. 200 is acceptable if it passes through.
-        assert response.status_code != 500, (
-            "Negative quantity caused an unhandled server error"
+        assert response.status_code == 422
+        assert len(main.restocking_orders) == 0, (
+            "Rejected request must not have mutated server state"
         )
 
-    def test_zero_quantity_rejected_or_accepted_without_crash(self, client):
-        """POST with quantity=0 does not crash the server.
-
-        Zero-quantity items result in a zero subtotal. This verifies the server
-        handles the edge case without a division-by-zero or unhandled exception.
-        Currently zero passes Pydantic validation (no gt=0 constraint), so we
-        assert only that the server responds without error.
-        """
+    def test_zero_quantity_rejected_with_422(self, client):
+        """POST with quantity=0 must be rejected — orders must have real line items."""
         import main
         main.restocking_orders.clear()
 
         payload = {"items": [self._item_with_quantity(0)]}
         response = client.post("/api/restocking/orders", json=payload)
-        # The server must not crash with an unhandled 500 for zero quantity.
-        assert response.status_code != 500, (
-            "Zero quantity caused an unhandled server error"
-        )
+        assert response.status_code == 422
+        assert len(main.restocking_orders) == 0
 
     def test_two_consecutive_posts_have_distinct_monotonically_increasing_ids(self, client):
         """Two consecutive POSTs yield distinct IDs that increment: RO-YYYY-0001 → RO-YYYY-0002.

--- a/tests/frontend/restocking-logic.test.js
+++ b/tests/frontend/restocking-logic.test.js
@@ -1,0 +1,287 @@
+// Tests for the budget-selection logic in client/src/views/Restocking.vue
+//
+// Strategy: mount the component with a mocked api module and a stubbed
+// vue-router. We feed controlled candidate data so that the greedy
+// autoSelect algorithm and the computed selectedTotal can be verified in
+// isolation from the network.
+//
+// Candidate shape expected by the component:
+//   { sku, name, warehouse, trend, quantity_on_hand, forecasted_demand,
+//     shortfall, recommended_qty, unit_cost, estimated_cost, lead_time_days }
+//
+// autoSelect uses `estimated_cost` for budget decisions.
+// selectedTotal uses `recommended_qty * unit_cost`.
+
+import { mount, flushPromises } from '@vue/test-utils'
+import { vi } from 'vitest'
+
+// Mock the api module before importing the component so that the component
+// receives the mock at the time its module-level imports resolve.
+vi.mock('../../client/src/api.js', () => ({
+  api: {
+    getRestockingCandidates: vi.fn(),
+    submitRestockingOrder: vi.fn()
+  }
+}))
+
+// Mock vue-router so the component does not throw when useRouter() is called
+// and router.push('/orders') is called after a successful order.
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+// Also mock useFilters so filter state is isolated from the singleton.
+vi.mock('../../client/src/composables/useFilters.js', () => ({
+  useFilters: () => ({
+    getCurrentFilters: () => ({ warehouse: 'all', category: 'all', status: 'all' }),
+    selectedLocation: { value: 'all' },
+    selectedCategory: { value: 'all' }
+  })
+}))
+
+import { api } from '../../client/src/api.js'
+import Restocking from '../../client/src/views/Restocking.vue'
+
+// Build a minimal candidate with all fields the component accesses.
+function makeCandidate(overrides) {
+  return {
+    sku: 'TEST-001',
+    name: 'Test Part',
+    warehouse: 'San Francisco',
+    trend: 'stable',
+    quantity_on_hand: 10,
+    forecasted_demand: 50,
+    shortfall: 40,
+    recommended_qty: 40,
+    unit_cost: 10,
+    estimated_cost: 400,
+    lead_time_days: 7,
+    ...overrides
+  }
+}
+
+async function mountWithCandidates(candidates) {
+  api.getRestockingCandidates.mockResolvedValue(candidates)
+  const wrapper = mount(Restocking, {
+    global: {
+      stubs: {
+        // Stub the router-link if referenced; not needed here but safe.
+        RouterLink: true
+      }
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('Restocking — budget selection logic', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // --- Budget 0: nothing selected ---
+
+  it('selects no items when budget is 0', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 100 }),
+      makeCandidate({ sku: 'B-001', estimated_cost: 200 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Force budget to 0 so autoSelect has nothing to pick.
+    await wrapper.find('input[type="range"]').setValue(0)
+    await wrapper.vm.$nextTick()
+
+    // No checked checkboxes.
+    const checked = wrapper.findAll('input[type="checkbox"]').filter(c => c.element.checked)
+    expect(checked).toHaveLength(0)
+  })
+
+  // --- Budget >= total cost: all items selected ---
+
+  it('selects all items when budget covers the full estimated cost of every candidate', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 300 }),
+      makeCandidate({ sku: 'B-001', estimated_cost: 500 })
+    ]
+    // Total cost = 800. sliderMax will be >= 800.
+    const wrapper = await mountWithCandidates(candidates)
+
+    // The component sets budget = sliderMax on load and auto-selects.
+    const checked = wrapper.findAll('input[type="checkbox"]').filter(c => c.element.checked)
+    expect(checked).toHaveLength(2)
+  })
+
+  // --- Greedy selection: highest-shortfall items that fit ---
+
+  it('selects greedily — picks items whose estimated_cost fits within budget, highest-shortfall first', async () => {
+    // Candidates are returned from the API in the order they appear.
+    // autoSelect iterates in that order and takes each item whose estimated_cost
+    // fits within remaining budget. The component does NOT sort internally —
+    // it trusts the API ordering. We verify greedy fill behaviour by providing
+    // an ordering where the first item fits but the second does not.
+    const candidates = [
+      makeCandidate({ sku: 'CHEAP', estimated_cost: 200, shortfall: 40 }),
+      makeCandidate({ sku: 'EXPENSIVE', estimated_cost: 900, shortfall: 80 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Set budget to 500 so only the first item (200) fits.
+    await wrapper.find('input[type="range"]').setValue(500)
+    await wrapper.vm.$nextTick()
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    // First row selected, second not.
+    expect(checkboxes[0].element.checked).toBe(true)
+    expect(checkboxes[1].element.checked).toBe(false)
+  })
+
+  // --- Manual toggle is respected ---
+
+  it('respects manual toggle: unchecking a selected item removes it from the selection', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 100 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Item is auto-selected since budget covers it.
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.element.checked).toBe(true)
+
+    // Manually click to deselect.
+    await checkbox.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(checkbox.element.checked).toBe(false)
+  })
+
+  it('manual toggle adds an unselected item to the selection', async () => {
+    // Budget set to 0 so nothing is auto-selected.
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 100, recommended_qty: 5, unit_cost: 20 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Force budget to 0.
+    await wrapper.find('input[type="range"]').setValue(0)
+    await wrapper.vm.$nextTick()
+
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.element.checked).toBe(false)
+
+    // Manual click to select.
+    await checkbox.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(checkbox.element.checked).toBe(true)
+  })
+
+  // --- selectedTotal matches sum of selected items' subtotals ---
+
+  it('selectedTotal equals sum of recommended_qty * unit_cost for selected items', async () => {
+    // item A: 10 qty * $20 = $200
+    // item B: 5 qty * $30 = $150
+    // Both fit in budget; total should be $350.
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 200, recommended_qty: 10, unit_cost: 20 }),
+      makeCandidate({ sku: 'B-001', estimated_cost: 150, recommended_qty: 5, unit_cost: 30 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Verify by reading the selectedTotal display in the stat card.
+    const statCards = wrapper.findAll('.stat-card')
+    const totalCard = statCards.find(card => card.text().includes('Selected Total'))
+    expect(totalCard).toBeDefined()
+    // The displayed value should include $350.
+    expect(totalCard.text()).toContain('$350')
+  })
+
+  // --- Place Order button disabled when nothing selected ---
+
+  it('Place Order button is disabled when no items are selected', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 200 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Force budget to 0 so nothing is selected.
+    await wrapper.find('input[type="range"]').setValue(0)
+    await wrapper.vm.$nextTick()
+
+    const button = wrapper.find('button.btn-primary')
+    expect(button.element.disabled).toBe(true)
+  })
+
+  // --- Place Order button disabled when over budget ---
+
+  it('Place Order button is disabled when selectedTotal exceeds budget', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 100, recommended_qty: 5, unit_cost: 20 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Manually select the item (it is auto-selected on load at max budget).
+    // Then shrink the budget below the selected total to trigger overBudget.
+    // item subtotal = 5 * 20 = 100; set budget to 50.
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    if (!checkbox.element.checked) {
+      await checkbox.trigger('click')
+      await wrapper.vm.$nextTick()
+    }
+
+    await wrapper.find('input[type="range"]').setValue(50)
+    // Trigger the budget watcher manually to simulate slider move.
+    await wrapper.vm.$nextTick()
+
+    // Mark userOverride manually so budget watcher does not auto-deselect.
+    // The component only auto-selects when !userOverride. After a manual
+    // toggle userOverride is true, so the budget watcher won't clear selection.
+    // We achieve the over-budget state by clicking the item and then dragging
+    // the slider down below the subtotal.
+
+    const button = wrapper.find('button.btn-primary')
+    expect(button.element.disabled).toBe(true)
+  })
+
+  // --- Place Order button enabled when items selected and within budget ---
+
+  it('Place Order button is enabled when items are selected and within budget', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 200, recommended_qty: 10, unit_cost: 20 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // All items auto-selected at full budget on load.
+    const button = wrapper.find('button.btn-primary')
+    expect(button.element.disabled).toBe(false)
+  })
+
+  // --- Reset auto-select restores greedy selection ---
+
+  it('"Reset to auto-select" re-runs autoSelect and clears manual overrides', async () => {
+    const candidates = [
+      makeCandidate({ sku: 'A-001', estimated_cost: 100 }),
+      makeCandidate({ sku: 'B-001', estimated_cost: 100 })
+    ]
+    const wrapper = await mountWithCandidates(candidates)
+
+    // Deselect all manually.
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    for (const checkbox of checkboxes) {
+      if (checkbox.element.checked) {
+        await checkbox.trigger('click')
+        await wrapper.vm.$nextTick()
+      }
+    }
+    expect(checkboxes.every(c => !c.element.checked)).toBe(true)
+
+    // Reset auto-select.
+    const resetButton = wrapper.find('button.btn-secondary')
+    await resetButton.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Both items should now be re-selected since budget covers both.
+    const rechecked = wrapper.findAll('input[type="checkbox"]').filter(c => c.element.checked)
+    expect(rechecked).toHaveLength(2)
+  })
+})

--- a/tests/frontend/useFilters.test.js
+++ b/tests/frontend/useFilters.test.js
@@ -1,0 +1,130 @@
+// Tests for client/src/composables/useFilters.js
+//
+// useFilters is a module-level singleton: all four filter refs live outside
+// the exported function so they persist across test cases. Every test calls
+// resetFilters() in beforeEach to start from a known clean state.
+
+import { useFilters } from '../../client/src/composables/useFilters.js'
+
+describe('useFilters', () => {
+  let selectedPeriod, selectedLocation, selectedCategory, selectedStatus
+  let hasActiveFilters, resetFilters, getCurrentFilters
+
+  beforeEach(() => {
+    ;({ selectedPeriod, selectedLocation, selectedCategory, selectedStatus,
+        hasActiveFilters, resetFilters, getCurrentFilters } = useFilters())
+    // Ensure we start from a pristine state regardless of prior test mutations.
+    resetFilters()
+  })
+
+  // --- Default state ---
+
+  it('initialises all four filters to "all"', () => {
+    expect(selectedPeriod.value).toBe('all')
+    expect(selectedLocation.value).toBe('all')
+    expect(selectedCategory.value).toBe('all')
+    expect(selectedStatus.value).toBe('all')
+  })
+
+  // --- hasActiveFilters ---
+
+  it('reports no active filters when all are "all"', () => {
+    expect(hasActiveFilters.value).toBe(false)
+  })
+
+  it('reports active filters when selectedPeriod differs from "all"', () => {
+    selectedPeriod.value = '2024-01'
+    expect(hasActiveFilters.value).toBe(true)
+  })
+
+  it('reports active filters when selectedLocation differs from "all"', () => {
+    selectedLocation.value = 'San Francisco'
+    expect(hasActiveFilters.value).toBe(true)
+  })
+
+  it('reports active filters when selectedCategory differs from "all"', () => {
+    selectedCategory.value = 'Sensors'
+    expect(hasActiveFilters.value).toBe(true)
+  })
+
+  it('reports active filters when selectedStatus differs from "all"', () => {
+    selectedStatus.value = 'delivered'
+    expect(hasActiveFilters.value).toBe(true)
+  })
+
+  it('reports active filters when multiple filters are set simultaneously', () => {
+    selectedLocation.value = 'London'
+    selectedCategory.value = 'Circuit Boards'
+    expect(hasActiveFilters.value).toBe(true)
+  })
+
+  // --- resetFilters ---
+
+  it('resetFilters returns every filter to "all"', () => {
+    selectedPeriod.value = '2024-06'
+    selectedLocation.value = 'Tokyo'
+    selectedCategory.value = 'Controllers'
+    selectedStatus.value = 'shipped'
+
+    resetFilters()
+
+    expect(selectedPeriod.value).toBe('all')
+    expect(selectedLocation.value).toBe('all')
+    expect(selectedCategory.value).toBe('all')
+    expect(selectedStatus.value).toBe('all')
+  })
+
+  it('resetFilters causes hasActiveFilters to become false', () => {
+    selectedLocation.value = 'London'
+    expect(hasActiveFilters.value).toBe(true)
+
+    resetFilters()
+
+    expect(hasActiveFilters.value).toBe(false)
+  })
+
+  // --- getCurrentFilters ---
+
+  it('getCurrentFilters shape includes warehouse, category, and status keys', () => {
+    const filters = getCurrentFilters()
+    expect(filters).toHaveProperty('warehouse')
+    expect(filters).toHaveProperty('category')
+    expect(filters).toHaveProperty('status')
+  })
+
+  it('getCurrentFilters maps selectedLocation to the warehouse key', () => {
+    selectedLocation.value = 'San Francisco'
+    const filters = getCurrentFilters()
+    expect(filters.warehouse).toBe('San Francisco')
+  })
+
+  it('getCurrentFilters maps selectedCategory to the category key', () => {
+    selectedCategory.value = 'Actuators'
+    const filters = getCurrentFilters()
+    expect(filters.category).toBe('Actuators')
+  })
+
+  it('getCurrentFilters maps selectedStatus to the status key', () => {
+    selectedStatus.value = 'processing'
+    const filters = getCurrentFilters()
+    expect(filters.status).toBe('processing')
+  })
+
+  it('getCurrentFilters omits month key when period is "all"', () => {
+    const filters = getCurrentFilters()
+    expect(filters).not.toHaveProperty('month')
+  })
+
+  it('getCurrentFilters includes month key when period is set', () => {
+    selectedPeriod.value = '2024-03'
+    const filters = getCurrentFilters()
+    expect(filters.month).toBe('2024-03')
+  })
+
+  it('getCurrentFilters returns "all" for each dimension when no filters are active', () => {
+    const filters = getCurrentFilters()
+    expect(filters.warehouse).toBe('all')
+    expect(filters.category).toBe('all')
+    expect(filters.status).toBe('all')
+  })
+})

--- a/tests/frontend/useI18n.test.js
+++ b/tests/frontend/useI18n.test.js
@@ -1,0 +1,129 @@
+// Tests for client/src/composables/useI18n.js
+//
+// useI18n is a module-level singleton: currentLocale lives outside the exported
+// function. Tests call setLocale('en') in afterEach to restore a clean state
+// so that locale changes in one test cannot bleed into the next.
+//
+// happy-dom provides a localStorage shim, so the composable's localStorage
+// persistence calls work without mocking.
+
+import { useI18n } from '../../client/src/composables/useI18n.js'
+
+describe('useI18n', () => {
+  let t, setLocale, currentLocale, currentCurrency
+
+  beforeEach(() => {
+    ;({ t, setLocale, currentLocale, currentCurrency } = useI18n())
+    // Start every test in the English locale.
+    setLocale('en')
+  })
+
+  afterEach(() => {
+    // Restore English so the module singleton is predictable for subsequent tests.
+    setLocale('en')
+  })
+
+  // --- English default ---
+
+  it('returns English text for a known key when locale is "en"', () => {
+    expect(t('nav.overview')).toBe('Overview')
+  })
+
+  it('returns English text for a nested key', () => {
+    expect(t('orders.title')).toBe('Orders')
+  })
+
+  // --- Unknown keys fall back to the key itself ---
+
+  it('returns the key string when the key does not exist in the current locale', () => {
+    expect(t('nonexistent.key.path')).toBe('nonexistent.key.path')
+  })
+
+  it('returns the key string for a partially valid path that resolves to an object, not a string', () => {
+    // 'nav' exists but is an object, not a string — should return the key.
+    expect(t('nav')).toBe('nav')
+  })
+
+  // --- Japanese locale ---
+
+  it('returns Japanese text after switching to "ja"', () => {
+    setLocale('ja')
+    expect(t('nav.overview')).toBe('概要')
+  })
+
+  it('currentLocale updates to "ja" after setLocale', () => {
+    setLocale('ja')
+    expect(currentLocale.value).toBe('ja')
+  })
+
+  it('currentLocale returns to "en" after resetting', () => {
+    setLocale('ja')
+    setLocale('en')
+    expect(currentLocale.value).toBe('en')
+  })
+
+  // --- English fallback when key missing in ja ---
+
+  it('returns the key when the key is completely absent from both locales while in Japanese', () => {
+    // When in 'ja' and a key doesn't exist in ja, the code tries en as
+    // fallback. If en also lacks it, the key itself is returned. This
+    // exercises both legs of the fallback chain.
+    setLocale('ja')
+    expect(t('completely.absent.key')).toBe('completely.absent.key')
+  })
+
+  // --- Placeholder replacement ---
+
+  it('substitutes {count} placeholder in English', () => {
+    // orders.itemsCount = '{count} items'
+    expect(t('orders.itemsCount', { count: 5 })).toBe('5 items')
+  })
+
+  it('substitutes {count} placeholder in Japanese', () => {
+    // ja orders.itemsCount = '{count}件'
+    setLocale('ja')
+    expect(t('orders.itemsCount', { count: 3 })).toBe('3件')
+  })
+
+  it('substitutes multiple different placeholders', () => {
+    // finance.fromOrders = 'From {count} orders'
+    expect(t('finance.fromOrders', { count: 42 })).toBe('From 42 orders')
+  })
+
+  it('leaves unmatched placeholders unchanged when no params supplied', () => {
+    // The raw template is returned with the braces intact.
+    const result = t('orders.itemsCount')
+    expect(result).toBe('{count} items')
+  })
+
+  it('leaves a placeholder unchanged when the matching param key is absent', () => {
+    const result = t('orders.itemsCount', { total: 99 })
+    expect(result).toBe('{count} items')
+  })
+
+  // --- currentCurrency ---
+
+  it('currentCurrency is "USD" for English locale', () => {
+    expect(currentCurrency.value).toBe('USD')
+  })
+
+  it('currentCurrency is "JPY" for Japanese locale', () => {
+    setLocale('ja')
+    expect(currentCurrency.value).toBe('JPY')
+  })
+
+  it('currentCurrency returns to "USD" after switching back to English', () => {
+    setLocale('ja')
+    setLocale('en')
+    expect(currentCurrency.value).toBe('USD')
+  })
+
+  // --- Invalid locale is ignored ---
+
+  it('ignores setLocale call for an unrecognised locale', () => {
+    setLocale('fr')
+    // Locale must remain unchanged.
+    expect(currentLocale.value).toBe('en')
+    expect(t('nav.overview')).toBe('Overview')
+  })
+})

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -7,5 +7,7 @@ addopts =
     -v
     --strict-markers
     --tb=short
+    --cov=server
+    --cov-report=term-missing
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
## TL;DR

This started as the workshop's Option A (budget-based restocking) + Option B (SaaS redesign). Then we kept going — Reports and Backlog were visibly out of sync with the rest of the app, Dashboard was a 1,271-line monolith, frontend had no test runner, backend coverage had soft spots, and a handful of latent bugs were hiding in the cracks. By the end, we'd modernized the whole codebase: new features, a coherent design system, working test + lint infrastructure, docs that tell you what's going on, and three real bugs fixed with regression tests.

Organized into 10 focused commits — review commit-by-commit if you like. Every step is independently verifiable.

## Features

### Budget-based Restocking (`/restocking`)
- Data-driven budget slider whose max adapts to the candidate set.
- Greedy auto-selection of highest-shortfall items within budget, with per-row user override.
- Backend endpoints: `GET /api/restocking/candidates`, `POST /api/restocking/orders`, `GET /api/restocking/orders`. Orders get `RO-YYYY-NNNN` ids; `expected_delivery_date = today + max(lead_time_days)`.
- Orders tab now renders a "Submitted Restocking Orders" section at the top.
- Added `lead_time_days` to every inventory SKU (varied 3–21 days by category). Added 6 demand-forecast entries for SKUs that have real shortfalls — without them the candidates endpoint would be empty.

### SaaS UI redesign
- Top nav replaced with a collapsible left sidebar. Icon-only rail when collapsed. State persisted to `localStorage`.
- CSS design tokens introduced in `:root` — colors, radii, shadows, spacing, sidebar widths. Every view's scoped styles migrated off hardcoded values (113 hex literals → tokens). Theming is now a single-file change.
- Refined card chrome: subtle shadows, left accent bar for active nav, FilterBar sticky to the main column.

## Quality

### Reports + Backlog modernization
Both were outliers — Options API, hardcoded English, ignored global filters, console.log spam. Both now match the project standard: Composition API, `useI18n()`, `useFilters()` with client-side period filtering, the central `api` client, shared design tokens. `/backlog` was an orphan route (file existed, no navigation path) — now registered with a sidebar entry.

### i18n is actually complete
Finished translations for Dashboard (Actions header, Create/View PO buttons before we removed them), Orders (Submitted Restocking Orders section), and Restocking itself. Added `reports.*`, `backlog.*`, `orders.restockingOrders.*`, `restocking.*`, `nav.reports`, `nav.backlog` to both `en` and `ja` in matching positions. Zero user-visible hardcoded strings remain.

### Dashboard fractal split
Dashboard.vue went from 1,271 lines → ~395 by extracting:
- `KpiSection.vue` — 5 KPI cards with progress bars
- `OrderHealthCard.vue` — donut chart + metrics panel
- `InventoryByCategoryCard.vue` — horizontal bar chart
- `InventoryShortagesCard.vue` — shortage table
- `TopProductsCard.vue` — top products table

Dashboard.vue is now a thin orchestrator: data loading, filter watching, modal state. Every extracted component owns its own props, emits, and scoped styles.

### Dead code removed
The shortages table rendered `Create PO` / `View PO` buttons that set state observed by a `<PurchaseOrderModal>` that was never imported and whose `.vue` file does not exist. Clicks were no-ops. The split made this obvious. Removed cleanly — template, state, handlers, buttons, styles, and unused locale keys.

### Console silence
Zero `console.log` calls remain in `client/src`.

## Bug fixes (with regression tests)

1. **`RestockingOrderLine.quantity` was unvalidated.** Negative or zero values silently corrupted `total_cost`. Added `Field(gt=0)` to `quantity`; `Field(ge=0)` to `unit_cost`, `lead_time_days`, and `subtotal`. Invalid values now return 422 without mutating server state.

2. **`/api/reports/quarterly` only worked for 2025.** The old implementation was an if/elif chain hardcoded to 2025 quarters with `else: continue` — any 2026+ order silently disappeared. Now parses year and month from the order date and computes the quarter key directly. Works for every year in the dataset.

3. **`filter_by_month` silently passed through on invalid quarter keys.** Typos, future quarters, or out-of-range numbers (`Q5-2025`, `Qfoo-bar`, bare `Q1`) returned the unfiltered dataset instead of an empty list. A new `_parse_quarter` helper validates the `Q<N>-<YYYY>` format and rejects anything else.

Each fix is covered by tests that fail against the pre-fix code and pass against the post-fix code.

## Tooling

### Frontend
- **vitest + @vue/test-utils + happy-dom** — 43 unit tests covering `useFilters` (defaults, toggle detection, reset, filter mapping), `useI18n` (translation, locale switch, fallback, placeholder substitution, currency derivation), and Restocking budget math (greedy selection, user override, totals, button disable logic). Scripts: `npm test` / `test:watch` / `test:coverage`.
- **ESLint 10** (flat config, Vue 3 recommended, Prettier-compatible) + **Prettier**. Scripts: `lint` / `lint:fix` / `format` / `format:check`.

### Backend
- **pytest-cov** wired into `pytest.ini` so every run prints a coverage table.
- **Ruff** for linting + formatting, configured in `pyproject.toml` (`line-length 100`, `py312`, rule groups `E/W/F/I/B/UP/SIM`).

No enforcement hooks — configs are committed, cleanup is left for a follow-up PR.

## Docs

- **README overhaul**: tech stack table, mermaid architecture diagram, full API reference (including restocking), project structure tree, design token catalog, dev workflow for both sides, i18n conventions, and an "adding a feature" walkthrough.
- **mise.toml** committed — pins Python 3.12 / Node 22 / uv latest so environments match.

## Numbers

| | Before | After |
|---|---|---|
| Dashboard.vue | 1,271 lines | ~395 lines |
| Frontend tests | 0 | 43 |
| Backend tests | 40 | 102 |
| Backend coverage | ~68% | 82% (main.py: 80% → 97%) |
| Hardcoded hex in scoped styles | 113 | justified literals only |
| `console.log` in client source | 16 | 0 |
| Hardcoded user-visible strings | several | 0 |
| `/api/restocking/*` endpoints | 0 | 3 |

## Test plan

- [ ] `cd server && mise exec -- uv run pytest ../tests/backend/ -v` — 102/102 passing
- [ ] `cd client && mise exec -- npm test` — 43/43 passing
- [ ] `cd client && mise exec -- npm run build` — clean (117 modules transformed)
- [ ] Visit `http://localhost:3000/restocking` — slider updates candidates, auto-select respects budget, manual toggles are respected, Place Order submits
- [ ] Visit `/orders` — "Submitted Restocking Orders" section shows the new order with correct lead time and expected delivery
- [ ] Collapse the sidebar, reload — state persists via localStorage
- [ ] Flip language to Japanese — every view translates (Dashboard, Inventory, Orders, Restocking, Spending, Demand, Backlog, Reports)
- [ ] Set a Time Period filter — every view responds (including Reports, which used to ignore filters)
- [ ] Open DevTools Console — silent while clicking around
- [ ] `POST /api/restocking/orders` with `quantity: -1` — returns 422, server state unmutated
- [ ] `GET /api/orders?month=Q1-2099` — returns `[]` not the full dataset
- [ ] `GET /api/reports/quarterly` with a 2026 order in memory — response includes `Q1-2026`

## Commit layout

```
76c6a7c  Fix three latent backend bugs surfaced by the coverage uplift
c45a3c1  Strengthen backend test coverage (63 -> 96, 68% -> 82%)
c580018  Split Dashboard.vue into components and remove dead PO UI
9bb84b1  Migrate view scoped styles to design tokens
5e07caa  Add dev tooling: vitest, eslint, prettier, ruff
329d94d  Rewrite README and commit mise toolchain pin
fcd88ca  Finish i18n pass and remove stray console.log
19a16ca  Bring Reports and Backlog up to project standards
c6d78b1  Fix dead task API calls, chart div-by-zero, and Reports v-for keys
8b9b9c8  Add budget-based restocking tab and SaaS-style sidebar redesign
```
