### PR TITLE
feat: replace top nav with dark-slate vertical sidebar

### DIFF
--- a/.claude/commands/sidebar-redesign.md
+++ b/.claude/commands/sidebar-redesign.md
@@ -1,0 +1,91 @@
+# Sidebar Redesign
+
+Transform the Vue 3 application's UI from a top navigation bar to a modern SaaS-style interface with a fixed vertical sidebar on the left.
+
+## Phase 1 — Analyse the current layout
+
+Read `client/src/App.vue` in full. Identify:
+- All `<router-link>` nav items (route path and label)
+- Any utility components in the top nav (language switcher, profile menu, user info, etc.)
+- Where `<FilterBar>` or equivalent filter/toolbar components are rendered
+- The global CSS layout classes (flex direction, max-width constraints, padding on `.main-content` or equivalent)
+
+Also read `client/src/components/FilterBar.vue` (if it exists) to understand how it is structured and whether it should move into the sidebar or sit above the main content area.
+
+## Phase 2 — Create the Sidebar component
+
+Create `client/src/components/Sidebar.vue`. The sidebar must:
+
+**Structure (top → bottom)**
+1. **Logo block** — company name and subtitle (pulled from i18n `t('nav.companyName')` / `t('nav.subtitle')` if available, otherwise hardcode)
+2. **Navigation links** — one `<router-link>` per route, each with:
+   - A small inline SVG icon (choose a relevant icon per route: grid/dashboard, box/inventory, receipt/orders, chart/finance, trending/demand, file/reports, etc.)
+   - The link label
+   - Active state highlighted with a solid accent colour background and white text
+   - Hover state with a subtle background tint
+3. **Bottom utility strip** — LanguageSwitcher (if present) and ProfileMenu (if present) pinned to the bottom with `margin-top: auto`
+
+**Design tokens to use**
+- Sidebar background: `#0f172a` (dark slate)
+- Active link: `#2563eb` background, `#ffffff` text
+- Inactive link: `#94a3b8` text, transparent background
+- Hover link: `rgba(255,255,255,0.07)` background
+- Sidebar width: `220px`, fixed/sticky, full viewport height
+- Typography: `font-size: 0.875rem`, `font-weight: 500`
+- Icon size: `18px × 18px`, vertically centred with `gap: 0.625rem`
+- Section dividers: `1px solid rgba(255,255,255,0.08)`
+
+**Active route detection**
+Use `useRoute()` from `vue-router` to compare `route.path` against each link's `to` prop. For the root route (`/`), match exactly; for all others, use `startsWith`.
+
+## Phase 3 — Rewrite App.vue layout
+
+Modify `client/src/App.vue`:
+
+1. **Remove** the `<header class="top-nav">` block entirely.
+2. **Import and register** `<Sidebar>` in place of the removed header.
+3. **Update the root template** to a horizontal flex layout:
+   ```
+   <div class="app">
+     <Sidebar />
+     <div class="app-body">
+       <FilterBar />          <!-- sticky filter strip at top of content area -->
+       <main class="main-content">
+         <router-view />
+       </main>
+     </div>
+   </div>
+   ```
+4. **Update global CSS** in the `<style>` block:
+   - `.app`: `display: flex; flex-direction: row; min-height: 100vh;`
+   - `.app-body`: `flex: 1; display: flex; flex-direction: column; overflow: hidden;`
+   - `.main-content`: remove the `max-width` and centre-margin constraints — let the content fill the available width naturally with `padding: 1.5rem 2rem;`
+   - Remove all `.top-nav`, `.nav-container`, `.nav-tabs`, `.logo`, `.subtitle` rules — they are now owned by Sidebar.vue's scoped styles.
+
+5. Keep all modal components (`ProfileDetailsModal`, `TasksModal`) and their event wiring exactly as-is.
+
+## Phase 4 — Style the FilterBar for the new layout
+
+If `FilterBar.vue` exists, ensure it renders as a horizontal sticky strip across the top of `.app-body`:
+- `background: #ffffff`
+- `border-bottom: 1px solid #e2e8f0`
+- `padding: 0.75rem 2rem`
+- `position: sticky; top: 0; z-index: 50`
+
+Do not move FilterBar into the sidebar — keep it above the main content area.
+
+## Phase 5 — Verify
+
+After all edits:
+1. Check that every `<router-link>` from the old top nav exists in Sidebar.vue with the correct `to` prop and a matching SVG icon.
+2. Confirm that `ProfileMenu` and `LanguageSwitcher` (if they existed in the old nav) are still mounted and receive the same props/emits.
+3. Confirm that modal wiring (`@show-profile-details`, `@show-tasks`) is unchanged.
+4. Open `http://localhost:3000` using Playwright MCP (`mcp__playwright__browser_navigate`) and take a screenshot to visually verify the sidebar is rendering correctly.
+
+## Constraints
+
+- Do not change any view files (`client/src/views/*.vue`) — only `App.vue` and the new `Sidebar.vue` (and `FilterBar.vue` styles if needed).
+- Preserve all i18n `t()` calls — do not hardcode strings that are already translated.
+- Use `<style scoped>` in `Sidebar.vue`.
+- Do not install any new npm packages.
+- Delegate all `.vue` file creation and editing to the `vue-expert` subagent.

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,15 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
-        <LanguageSwitcher />
-        <ProfileMenu
-          @show-profile-details="showProfileDetails = true"
-          @show-tasks="showTasks = true"
-        />
-      </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    <Sidebar
+      @show-profile-details="showProfileDetails = true"
+      @show-tasks="showTasks = true"
+    />
+    <div class="app-body">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -60,19 +33,17 @@ import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
 import FilterBar from './components/FilterBar.vue'
-import ProfileMenu from './components/ProfileMenu.vue'
+import Sidebar from './components/Sidebar.vue'
 import ProfileDetailsModal from './components/ProfileDetailsModal.vue'
 import TasksModal from './components/TasksModal.vue'
-import LanguageSwitcher from './components/LanguageSwitcher.vue'
 
 export default {
   name: 'App',
   components: {
     FilterBar,
-    ProfileMenu,
+    Sidebar,
     ProfileDetailsModal,
-    TasksModal,
-    LanguageSwitcher
+    TasksModal
   },
   setup() {
     const { currentUser } = useAuth()
@@ -178,100 +149,22 @@ body {
 
 .app {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
+.app-body {
+  flex: 1;
   display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
-}
-
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
-}
-
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
-}
-
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .main-content {
   flex: 1;
-  max-width: 1600px;
-  width: 100%;
-  margin: 0 auto;
   padding: 1.5rem 2rem;
+  overflow-y: auto;
 }
 
 .page-header {

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -102,17 +102,15 @@ export default {
 
 <style scoped>
 .filters-bar {
-  background: #f8fafc;
+  background: #ffffff;
   border-bottom: 1px solid #e2e8f0;
   padding: 0.75rem 0;
   position: sticky;
-  top: 70px;
+  top: 0;
   z-index: 90;
 }
 
 .filters-container {
-  max-width: 1600px;
-  margin: 0 auto;
   padding: 0 2rem;
   display: flex;
   align-items: center;

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -1,0 +1,183 @@
+<template>
+  <aside class="sidebar">
+    <div class="sidebar-logo">
+      <span class="sidebar-company">{{ t('nav.companyName') }}</span>
+      <span class="sidebar-subtitle">{{ t('nav.subtitle') }}</span>
+    </div>
+
+    <nav class="sidebar-nav">
+      <router-link
+        v-for="link in navLinks"
+        :key="link.to"
+        :to="link.to"
+        class="sidebar-link"
+        :class="{ active: isActive(link) }"
+      >
+        <svg
+          v-html="link.icon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="sidebar-icon"
+        ></svg>
+        <span>{{ link.label }}</span>
+      </router-link>
+    </nav>
+
+    <div class="sidebar-bottom">
+      <LanguageSwitcher />
+      <ProfileMenu
+        @show-profile-details="$emit('show-profile-details')"
+        @show-tasks="$emit('show-tasks')"
+      />
+    </div>
+  </aside>
+</template>
+
+<script>
+import { useRoute } from 'vue-router'
+import { useI18n } from '../composables/useI18n'
+import ProfileMenu from './ProfileMenu.vue'
+import LanguageSwitcher from './LanguageSwitcher.vue'
+
+export default {
+  name: 'Sidebar',
+  components: {
+    ProfileMenu,
+    LanguageSwitcher
+  },
+  emits: ['show-profile-details', 'show-tasks'],
+  setup() {
+    const route = useRoute()
+    const { t } = useI18n()
+
+    const navLinks = [
+      {
+        to: '/',
+        get label() { return t('nav.overview') },
+        exact: true,
+        icon: '<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>'
+      },
+      {
+        to: '/inventory',
+        get label() { return t('nav.inventory') },
+        icon: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>'
+      },
+      {
+        to: '/orders',
+        get label() { return t('nav.orders') },
+        icon: '<path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>'
+      },
+      {
+        to: '/spending',
+        get label() { return t('nav.finance') },
+        icon: '<line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>'
+      },
+      {
+        to: '/demand',
+        get label() { return t('nav.demandForecast') },
+        icon: '<polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>'
+      },
+      {
+        to: '/reports',
+        label: 'Reports',
+        icon: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>'
+      }
+    ]
+
+    const isActive = (link) => {
+      if (link.exact || link.to === '/') {
+        return route.path === '/'
+      }
+      return route.path.startsWith(link.to)
+    }
+
+    return { t, navLinks, isActive }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar {
+  background: #0f172a;
+  width: 220px;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  overflow-y: auto;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  z-index: 100;
+}
+
+.sidebar-logo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1.5rem 1.25rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidebar-company {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+  letter-spacing: -0.015em;
+}
+
+.sidebar-subtitle {
+  font-size: 0.7rem;
+  color: #64748b;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem 0.75rem;
+  flex: 1;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #94a3b8;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  margin-bottom: 0.125rem;
+}
+
+.sidebar-link:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: #e2e8f0;
+}
+
+.sidebar-link.active {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.sidebar-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.sidebar-bottom {
+  padding: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,631 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Factory Inventory Management — Architecture</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f8fafc;
+      color: #0f172a;
+      line-height: 1.6;
+    }
+
+    header {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 2.5rem 3rem;
+      border-bottom: 3px solid #3b82f6;
+    }
+    header h1 { font-size: 1.75rem; font-weight: 700; letter-spacing: -0.02em; }
+    header p  { margin-top: 0.4rem; color: #94a3b8; font-size: 0.95rem; }
+
+    main { max-width: 1100px; margin: 0 auto; padding: 2.5rem 2rem 4rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #475569;
+      margin-bottom: 1.25rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    /* ── TECH STACK ── */
+    .stack-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .stack-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 1.25rem 1.5rem;
+    }
+    .stack-card .layer {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #94a3b8;
+      margin-bottom: 0.4rem;
+    }
+    .stack-card .name {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #0f172a;
+    }
+    .stack-card .detail {
+      font-size: 0.82rem;
+      color: #64748b;
+      margin-top: 0.25rem;
+    }
+    .stack-card .badge {
+      display: inline-block;
+      margin-top: 0.6rem;
+      padding: 0.15rem 0.55rem;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      font-weight: 600;
+    }
+    .blue  { background: #dbeafe; color: #1d4ed8; }
+    .green { background: #dcfce7; color: #15803d; }
+    .slate { background: #f1f5f9; color: #475569; }
+
+    /* ── ARCHITECTURE DIAGRAM ── */
+    .diagram {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 2rem 2rem 1.75rem;
+      overflow-x: auto;
+    }
+
+    .arch-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0;
+      flex-wrap: nowrap;
+      margin-bottom: 0.5rem;
+    }
+
+    .box {
+      border-radius: 8px;
+      padding: 0.75rem 1.1rem;
+      text-align: center;
+      min-width: 130px;
+      border: 1.5px solid transparent;
+    }
+    .box .box-title { font-weight: 700; font-size: 0.9rem; }
+    .box .box-sub   { font-size: 0.72rem; margin-top: 0.2rem; opacity: 0.75; }
+
+    .box-frontend  { background: #eff6ff; border-color: #93c5fd; color: #1e3a5f; }
+    .box-api       { background: #f0fdf4; border-color: #86efac; color: #14532d; }
+    .box-data      { background: #fef9c3; border-color: #fde047; color: #713f12; }
+    .box-filter    { background: #faf5ff; border-color: #c4b5fd; color: #4c1d95; }
+    .box-grey      { background: #f8fafc; border-color: #cbd5e1; color: #334155; }
+
+    .arrow {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 0 0.3rem;
+      min-width: 60px;
+    }
+    .arrow .line {
+      height: 2px;
+      width: 100%;
+      background: #cbd5e1;
+      position: relative;
+    }
+    .arrow .label {
+      font-size: 0.65rem;
+      color: #94a3b8;
+      margin-top: 0.2rem;
+      white-space: nowrap;
+    }
+    /* arrowhead */
+    .arrow .line::after {
+      content: '';
+      position: absolute;
+      right: -1px;
+      top: -4px;
+      border: 5px solid transparent;
+      border-left-color: #cbd5e1;
+    }
+
+    .diagram-caption {
+      text-align: center;
+      font-size: 0.78rem;
+      color: #94a3b8;
+      margin-top: 1.25rem;
+    }
+
+    /* ── DATA FLOW ── */
+    .flow-steps {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+    .flow-step {
+      display: flex;
+      align-items: flex-start;
+      gap: 1.25rem;
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+      position: relative;
+    }
+    .flow-step + .flow-step { margin-top: 0.5rem; }
+    .flow-step + .flow-step::before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: -9px;
+      left: 28px;
+      width: 2px;
+      height: 8px;
+      background: #cbd5e1;
+    }
+    .step-num {
+      flex-shrink: 0;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: #0f172a;
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 0.1rem;
+    }
+    .step-body .step-title { font-weight: 700; font-size: 0.9rem; }
+    .step-body .step-desc  { font-size: 0.82rem; color: #64748b; margin-top: 0.2rem; }
+    .step-body code {
+      background: #f1f5f9;
+      border-radius: 4px;
+      padding: 0.05rem 0.35rem;
+      font-size: 0.78rem;
+      color: #0f172a;
+      font-family: 'SF Mono', 'Fira Mono', monospace;
+    }
+
+    /* ── API ENDPOINTS ── */
+    .endpoints-table {
+      width: 100%;
+      border-collapse: collapse;
+      background: #fff;
+      border-radius: 10px;
+      overflow: hidden;
+      border: 1px solid #e2e8f0;
+      font-size: 0.85rem;
+    }
+    .endpoints-table th {
+      background: #f8fafc;
+      padding: 0.65rem 1rem;
+      text-align: left;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: #64748b;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .endpoints-table td {
+      padding: 0.6rem 1rem;
+      border-bottom: 1px solid #f1f5f9;
+      vertical-align: top;
+    }
+    .endpoints-table tr:last-child td { border-bottom: none; }
+    .endpoints-table code {
+      font-family: 'SF Mono', 'Fira Mono', monospace;
+      font-size: 0.8rem;
+      color: #0f172a;
+    }
+    .method {
+      display: inline-block;
+      padding: 0.1rem 0.45rem;
+      border-radius: 4px;
+      font-size: 0.68rem;
+      font-weight: 700;
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+    .filter-tag {
+      display: inline-block;
+      background: #f1f5f9;
+      color: #475569;
+      border-radius: 4px;
+      padding: 0.05rem 0.4rem;
+      font-size: 0.72rem;
+      margin: 0.1rem 0.1rem 0 0;
+    }
+
+    /* ── FILTER SYSTEM ── */
+    .filter-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .filter-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+    }
+    .filter-card .filter-name { font-weight: 700; font-size: 0.88rem; }
+    .filter-card .filter-values {
+      font-size: 0.78rem;
+      color: #64748b;
+      margin-top: 0.35rem;
+    }
+    .filter-card .filter-scope {
+      display: inline-block;
+      margin-top: 0.5rem;
+      font-size: 0.7rem;
+      padding: 0.1rem 0.45rem;
+      border-radius: 4px;
+      background: #faf5ff;
+      color: #6d28d9;
+      font-weight: 600;
+    }
+
+    /* ── FRONTEND VIEWS ── */
+    .views-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.75rem;
+    }
+    .view-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 0.85rem 1rem;
+    }
+    .view-card .route { font-size: 0.72rem; color: #94a3b8; font-family: monospace; }
+    .view-card .view-name { font-weight: 700; font-size: 0.88rem; margin-top: 0.15rem; }
+    .view-card .view-desc { font-size: 0.75rem; color: #64748b; margin-top: 0.2rem; }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Factory Inventory Management System</h1>
+  <p>System Architecture &amp; Technical Reference</p>
+</header>
+
+<main>
+
+  <!-- TECH STACK -->
+  <section>
+    <h2>Tech Stack</h2>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="layer">Frontend</div>
+        <div class="name">Vue 3</div>
+        <div class="detail">Composition API, Vue Router 4, Vite build tool</div>
+        <span class="badge blue">Port 3000</span>
+      </div>
+      <div class="stack-card">
+        <div class="layer">HTTP Client</div>
+        <div class="name">Axios</div>
+        <div class="detail">Centralised in <code style="font-size:0.78rem;background:#f1f5f9;padding:0.05rem 0.3rem;border-radius:3px;">src/api.js</code> with query param helpers</div>
+        <span class="badge slate">REST/JSON</span>
+      </div>
+      <div class="stack-card">
+        <div class="layer">Backend</div>
+        <div class="name">FastAPI</div>
+        <div class="detail">Python 3.11+, Pydantic v2 models, Uvicorn ASGI</div>
+        <span class="badge green">Port 8001</span>
+      </div>
+      <div class="stack-card">
+        <div class="layer">Data Layer</div>
+        <div class="name">In-Memory JSON</div>
+        <div class="detail">JSON files in <code style="font-size:0.78rem;background:#f1f5f9;padding:0.05rem 0.3rem;border-radius:3px;">server/data/</code> loaded at startup — no database</div>
+        <span class="badge slate">mock_data.py</span>
+      </div>
+      <div class="stack-card">
+        <div class="layer">Package Manager</div>
+        <div class="name">uv (Python) / npm</div>
+        <div class="detail">uv for backend deps, npm for frontend</div>
+        <span class="badge slate">Tooling</span>
+      </div>
+      <div class="stack-card">
+        <div class="layer">Testing</div>
+        <div class="name">pytest + httpx</div>
+        <div class="detail">FastAPI TestClient, pytest-asyncio, pytest-cov</div>
+        <span class="badge slate">tests/backend/</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ARCHITECTURE DIAGRAM -->
+  <section>
+    <h2>System Architecture</h2>
+    <div class="diagram">
+      <div class="arch-row">
+        <div class="box box-frontend">
+          <div class="box-title">Browser</div>
+          <div class="box-sub">Vue 3 + Vite<br/>localhost:3000</div>
+        </div>
+        <div class="arrow">
+          <div class="line"></div>
+          <div class="label">axios + filters</div>
+        </div>
+        <div class="box box-api">
+          <div class="box-title">FastAPI</div>
+          <div class="box-sub">Python + Uvicorn<br/>localhost:8001</div>
+        </div>
+        <div class="arrow">
+          <div class="line"></div>
+          <div class="label">reads at startup</div>
+        </div>
+        <div class="box box-data">
+          <div class="box-title">JSON Files</div>
+          <div class="box-sub">server/data/*.json<br/>loaded into memory</div>
+        </div>
+      </div>
+
+      <div style="display:flex;justify-content:center;gap:3rem;margin-top:1.75rem;flex-wrap:wrap;">
+        <div class="box box-filter" style="min-width:170px;">
+          <div class="box-title">useFilters()</div>
+          <div class="box-sub">Singleton composable<br/>shared filter state</div>
+        </div>
+        <div class="box box-grey" style="min-width:170px;">
+          <div class="box-title">Pydantic Models</div>
+          <div class="box-sub">Response validation<br/>InventoryItem, Order…</div>
+        </div>
+        <div class="box box-grey" style="min-width:170px;">
+          <div class="box-title">mock_data.py</div>
+          <div class="box-sub">Loads &amp; exposes JSON<br/>as Python dicts</div>
+        </div>
+      </div>
+
+      <p class="diagram-caption">CORS is open (*) in development. No auth layer — demo only.</p>
+    </div>
+  </section>
+
+  <!-- DATA FLOW -->
+  <section>
+    <h2>Request Data Flow</h2>
+    <div class="flow-steps">
+      <div class="flow-step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <div class="step-title">User changes a filter</div>
+          <div class="step-desc">The <code>FilterBar.vue</code> component updates the <code>useFilters()</code> singleton composable. All views share this reactive state.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <div class="step-title">View triggers an API call</div>
+          <div class="step-desc">Each view calls the relevant method in <code>client/src/api.js</code>, passing active filter values as <code>URLSearchParams</code>. Filters with value <code>'all'</code> are omitted from the query string.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <div class="step-title">FastAPI receives the request</div>
+          <div class="step-desc"><code>server/main.py</code> routes the request. Filter params are read from the query string and passed to <code>apply_filters()</code> and <code>filter_by_month()</code> utilities.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <div class="step-title">In-memory data is filtered</div>
+          <div class="step-desc">Data loaded by <code>mock_data.py</code> at startup is filtered on copies — originals are never mutated. A <code>QUARTER_MAP</code> maps Q1–Q4 labels to month lists.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">5</div>
+        <div class="step-body">
+          <div class="step-title">Pydantic validates the response</div>
+          <div class="step-desc">FastAPI serialises the result through Pydantic models (<code>InventoryItem</code>, <code>Order</code>, <code>DemandForecast</code>, etc.) before returning JSON.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="step-num">6</div>
+        <div class="step-body">
+          <div class="step-title">Vue renders from computed properties</div>
+          <div class="step-desc">Raw response is stored in a <code>ref</code> (e.g. <code>allOrders</code>). Computed properties derive filtered, sorted, and formatted views of that data for the template.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FILTER SYSTEM -->
+  <section>
+    <h2>Filter System</h2>
+    <div class="filter-grid">
+      <div class="filter-card">
+        <div class="filter-name">Time Period</div>
+        <div class="filter-values">Monthly (Jan–Dec 2025) or quarterly (Q1–Q4). Maps to <code style="font-size:0.75rem;background:#f1f5f9;padding:0.05rem 0.3rem;border-radius:3px;">month</code> query param.</div>
+        <span class="filter-scope">Orders / Dashboard</span>
+      </div>
+      <div class="filter-card">
+        <div class="filter-name">Location (Warehouse)</div>
+        <div class="filter-values">North, South, East warehouses — or All.</div>
+        <span class="filter-scope">Inventory / Orders / Dashboard</span>
+      </div>
+      <div class="filter-card">
+        <div class="filter-name">Category</div>
+        <div class="filter-values">Circuit Boards, Sensors, Actuators, Controllers, Power Supplies.</div>
+        <span class="filter-scope">Inventory / Orders / Dashboard</span>
+      </div>
+      <div class="filter-card">
+        <div class="filter-name">Order Status</div>
+        <div class="filter-values">Delivered, Shipped, Processing, Backordered.</div>
+        <span class="filter-scope">Orders / Dashboard</span>
+      </div>
+    </div>
+    <p style="margin-top:0.85rem;font-size:0.8rem;color:#64748b;">
+      Note: Inventory does not support the Time Period filter (no time dimension on stock levels).
+    </p>
+  </section>
+
+  <!-- API ENDPOINTS -->
+  <section>
+    <h2>API Endpoints</h2>
+    <table class="endpoints-table">
+      <thead>
+        <tr>
+          <th>Method</th>
+          <th>Path</th>
+          <th>Description</th>
+          <th>Supported Filters</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/inventory</code></td>
+          <td>All inventory items</td>
+          <td><span class="filter-tag">warehouse</span><span class="filter-tag">category</span></td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/inventory/{item_id}</code></td>
+          <td>Single inventory item</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/orders</code></td>
+          <td>All orders</td>
+          <td><span class="filter-tag">warehouse</span><span class="filter-tag">category</span><span class="filter-tag">status</span><span class="filter-tag">month</span></td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/orders/{order_id}</code></td>
+          <td>Single order</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/dashboard/summary</code></td>
+          <td>KPIs and metrics</td>
+          <td><span class="filter-tag">warehouse</span><span class="filter-tag">category</span><span class="filter-tag">status</span><span class="filter-tag">month</span></td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/demand</code></td>
+          <td>Demand forecasts</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/backlog</code></td>
+          <td>Backlog items with PO status</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/spending/summary</code></td>
+          <td>Overall spending stats</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/spending/monthly</code></td>
+          <td>Month-by-month breakdown</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/spending/categories</code></td>
+          <td>Spending by category</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/spending/transactions</code></td>
+          <td>Recent transactions</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/reports/quarterly</code></td>
+          <td>Q1–Q4 2025 rollup</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><span class="method">GET</span></td>
+          <td><code>/api/reports/monthly-trends</code></td>
+          <td>Month-by-month trends</td>
+          <td>—</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- FRONTEND VIEWS -->
+  <section>
+    <h2>Frontend Views</h2>
+    <div class="views-grid">
+      <div class="view-card">
+        <div class="route">/</div>
+        <div class="view-name">Dashboard</div>
+        <div class="view-desc">KPIs, order health donut, inventory value by category</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/inventory</div>
+        <div class="view-name">Inventory</div>
+        <div class="view-desc">Stock table with detail modal per item</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/orders</div>
+        <div class="view-name">Orders</div>
+        <div class="view-desc">Order list with status filtering and detail modal</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/demand</div>
+        <div class="view-name">Demand Forecast</div>
+        <div class="view-desc">Projected demand trends by category</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/spending</div>
+        <div class="view-name">Spending</div>
+        <div class="view-desc">Financial analytics, monthly breakdown, transactions</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/reports</div>
+        <div class="view-name">Reports</div>
+        <div class="view-desc">Quarterly and monthly trend reports</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- KEY FILES -->
+  <section>
+    <h2>Key File Locations</h2>
+    <table class="endpoints-table">
+      <thead>
+        <tr><th>File</th><th>Purpose</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>client/src/api.js</code></td><td>All axios calls — single source of truth for frontend HTTP requests</td></tr>
+        <tr><td><code>client/src/composables/useFilters.js</code></td><td>Singleton filter state shared across every view</td></tr>
+        <tr><td><code>client/src/App.vue</code></td><td>Root layout, global nav, FilterBar, shared styles</td></tr>
+        <tr><td><code>server/main.py</code></td><td>All FastAPI routes and filtering logic</td></tr>
+        <tr><td><code>server/mock_data.py</code></td><td>Loads JSON files into module-level dicts at startup</td></tr>
+        <tr><td><code>server/data/*.json</code></td><td>Source of truth for all demo data (inventory, orders, spending, etc.)</td></tr>
+        <tr><td><code>tests/backend/</code></td><td>pytest suite — conftest.py fixtures, per-endpoint test files</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replaces the top nav bar with a SaaS-style fixed vertical sidebar (220px wide, `#0f172a` background)
- Adds `Sidebar.vue` with 6 nav links (inline SVG icons, active route detection), logo block, and `ProfileMenu` + `LanguageSwitcher` pinned at the bottom
- Rewrites `App.vue` layout from `flex-direction: column` to `row`, with sidebar + `.app-body` wrapping `FilterBar` and main content
- Updates `FilterBar.vue`: `top: 70px` → `top: 0`, removes `max-width` constraint, white background for contrast
- Adds `docs/architecture.html` as a standalone system architecture reference
- Adds `.claude/commands/sidebar-redesign.md` custom skill

## Test plan
- [x] All 6 nav routes load (Overview, Inventory, Orders, Finance, Demand Forecast, Reports)
- [x] Active route highlights correctly on each page
- [x] `ProfileMenu` and `LanguageSwitcher` still emit `show-profile-details` / `show-tasks` events
- [x] `FilterBar` sticky positioning works at the top of the content area
- [x] i18n `t()` calls preserved for company name, subtitle, and nav labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)