### PR TITLE
SaaS-style vertical sidebar redesign

### DIFF
--- a/.claude/commands/frontend-redesign.md
+++ b/.claude/commands/frontend-redesign.md
@@ -1,0 +1,137 @@
+# Skill: frontend-redesign
+
+You are redesigning a Vue 3 application's UI into a modern SaaS-style interface.
+
+## What This Skill Does
+Converts a horizontal top navigation bar into a fixed vertical sidebar on the left, shifts main content to fill the remaining space, and applies polished SaaS-style spacing and typography — without changing any application logic or functionality.
+
+## Steps to Execute
+
+### 1. Inventory the current layout
+Read these files before making any changes:
+- `client/src/App.vue` — current nav structure and global styles
+- `client/src/components/FilterBar.vue` — current sticky positioning
+
+### 2. Rewrite App.vue layout
+
+Replace the `<header class="top-nav">` block with `<aside class="sidebar">`.
+
+**Sidebar structure:**
+```html
+<aside class="sidebar" :class="{ collapsed }">
+  <!-- Top: logo + toggle -->
+  <div class="sidebar-header">
+    <div class="sidebar-logo" v-if="!collapsed">
+      <h1>{{ companyName }}</h1>
+      <span class="sidebar-subtitle">{{ subtitle }}</span>
+    </div>
+    <button class="sidebar-toggle" @click="collapsed = !collapsed">
+      <!-- chevron SVG -->
+    </button>
+  </div>
+
+  <!-- Nav links -->
+  <nav class="sidebar-nav">
+    <router-link v-for="item in navItems" :to="item.path" :class="{ active: $route.path === item.path }">
+      <!-- SVG icon -->
+      <span class="nav-label" v-if="!collapsed">{{ t(item.key) }}</span>
+    </router-link>
+  </nav>
+
+  <!-- Bottom: profile + language -->
+  <div class="sidebar-footer">
+    <LanguageSwitcher />
+    <ProfileMenu @show-profile="showProfileDetails = true" @show-tasks="showTasks = true" />
+  </div>
+</aside>
+```
+
+**Main content shift:**
+```html
+<div class="app-body" :class="{ 'sidebar-collapsed': collapsed }">
+  <FilterBar />
+  <main class="main-content">
+    <router-view />
+  </main>
+</div>
+```
+
+**CSS rules to add/replace:**
+```css
+.sidebar {
+  position: fixed;
+  left: 0; top: 0;
+  width: 220px; height: 100vh;
+  background: #0f172a;
+  display: flex; flex-direction: column;
+  transition: width 0.2s ease;
+  z-index: 100;
+  overflow: hidden;
+}
+.sidebar.collapsed { width: 64px; }
+
+.app-body {
+  margin-left: 220px;
+  transition: margin-left 0.2s ease;
+  min-height: 100vh;
+  display: flex; flex-direction: column;
+}
+.app-body.sidebar-collapsed { margin-left: 64px; }
+
+.sidebar-nav a {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 16px;
+  color: #94a3b8;
+  text-decoration: none;
+  border-radius: 6px;
+  margin: 2px 8px;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.sidebar-nav a:hover { background: #1e293b; color: #e2e8f0; }
+.sidebar-nav a.active { background: #2563eb; color: #fff; }
+
+.nav-label { font-size: 0.875rem; font-weight: 500; }
+```
+
+### 3. Update FilterBar.vue
+
+Remove sticky positioning — it now renders inline at the top of the content area:
+
+**Remove:**
+```css
+position: sticky;
+top: 70px;
+z-index: 90;
+```
+
+**Keep everything else unchanged.**
+
+### 4. Nav Icons
+
+Use these inline SVGs for each route (16×16, `currentColor`):
+
+| Route | Icon shape |
+|-------|-----------|
+| `/` (Overview) | Grid/squares |
+| `/inventory` | Box/cube |
+| `/orders` | List/clipboard |
+| `/spending` | Chart bar |
+| `/demand` | Trending up arrow |
+| `/reports` | Document |
+
+### 5. Verify
+
+After changes:
+- [ ] Sidebar visible on left, content fills right
+- [ ] All 6 nav links work with correct active states
+- [ ] FilterBar renders inline (not sticky)
+- [ ] Collapse toggle works: 220px ↔ 64px, labels hide/show
+- [ ] No layout overflow on any page
+
+## Design Tokens (do not change these)
+- Sidebar bg: `#0f172a`
+- Active nav: `#2563eb` bg, white text
+- Inactive nav: `#94a3b8` text
+- Content bg: `#f8fafc`
+- Border: `#e2e8f0`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ npm install && npm run dev
 - Data: `server/data/*.json`
 - Styles: `client/src/App.vue`
 
+## Coding Conventions
+- Always document non-obvious logic changes with comments
+
 ## Design System
 - Colors: Slate/gray (#0f172a, #64748b, #e2e8f0)
 - Status: green/blue/yellow/red

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,80 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
+    <aside class="sidebar" :class="{ collapsed }">
+      <div class="sidebar-header">
+        <div class="sidebar-logo" v-if="!collapsed">
           <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
+          <span class="sidebar-subtitle">{{ t('nav.subtitle') }}</span>
         </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
+        <button class="sidebar-toggle" @click="collapsed = !collapsed" :title="collapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+            <path v-if="!collapsed" fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd"/>
+            <path v-else fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"/>
+          </svg>
+        </button>
+      </div>
+
+      <nav class="sidebar-nav">
+        <router-link to="/" :class="{ active: $route.path === '/' }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18" flex-shrink="0">
+            <path fill-rule="evenodd" d="M4.25 2A2.25 2.25 0 002 4.25v2.5A2.25 2.25 0 004.25 9h2.5A2.25 2.25 0 009 6.75v-2.5A2.25 2.25 0 006.75 2h-2.5zm0 9A2.25 2.25 0 002 13.25v2.5A2.25 2.25 0 004.25 18h2.5A2.25 2.25 0 009 15.75v-2.5A2.25 2.25 0 006.75 11h-2.5zm9-9A2.25 2.25 0 0011 4.25v2.5A2.25 2.25 0 0013.25 9h2.5A2.25 2.25 0 0018 6.75v-2.5A2.25 2.25 0 0015.75 2h-2.5zm0 9A2.25 2.25 0 0011 13.25v2.5A2.25 2.25 0 0013.25 18h2.5A2.25 2.25 0 0018 15.75v-2.5A2.25 2.25 0 0015.75 11h-2.5z" clip-rule="evenodd"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.overview') }}</span>
+        </router-link>
+
+        <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+            <path d="M2 3a1 1 0 00-1 1v1a1 1 0 001 1h16a1 1 0 001-1V4a1 1 0 00-1-1H2z"/>
+            <path fill-rule="evenodd" d="M2 7.5h16l-1.581 6.324A2 2 0 0114.462 15H5.538a2 2 0 01-1.957-1.576L2 7.5zm6 1a.5.5 0 00-.5.5v2a.5.5 0 00.5.5h4a.5.5 0 00.5-.5V9a.5.5 0 00-.5-.5H8z" clip-rule="evenodd"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.inventory') }}</span>
+        </router-link>
+
+        <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+            <path fill-rule="evenodd" d="M6 3.75A2.75 2.75 0 018.75 1h2.5A2.75 2.75 0 0114 3.75v.443c.572.055 1.14.122 1.706.2C17.053 4.582 18 5.75 18 7.07v3.469c0 1.126-.694 2.191-1.83 2.54-1.952.599-4.024.921-6.17.921s-4.219-.322-6.17-.921C2.694 12.73 2 11.665 2 10.539V7.07c0-1.321.947-2.489 2.294-2.676A41.047 41.047 0 016 4.193V3.75zm6.5 0v.325a41.622 41.622 0 00-5 0V3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25zM10 10a1 1 0 00-1 1v.01a1 1 0 001 1h.01a1 1 0 001-1V11a1 1 0 00-1-1H10z" clip-rule="evenodd"/>
+            <path d="M3 15.055v-.684c.126.053.255.1.39.142 2.1.644 4.313.987 6.61.987 2.297 0 4.51-.343 6.61-.987.135-.041.264-.089.39-.142v.684c0 1.347-.985 2.53-2.363 2.686a41.454 41.454 0 01-9.274 0C3.985 17.585 3 16.402 3 15.055z"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.orders') }}</span>
+        </router-link>
+
+        <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+            <path d="M15.5 2A1.5 1.5 0 0014 3.5v13a1.5 1.5 0 001.5 1.5h1a1.5 1.5 0 001.5-1.5v-13A1.5 1.5 0 0016.5 2h-1zM9.5 6A1.5 1.5 0 008 7.5v9A1.5 1.5 0 009.5 18h1a1.5 1.5 0 001.5-1.5v-9A1.5 1.5 0 0010.5 6h-1zM3.5 10A1.5 1.5 0 002 11.5v5A1.5 1.5 0 003.5 18h1A1.5 1.5 0 006 16.5v-5A1.5 1.5 0 004.5 10h-1z"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.finance') }}</span>
+        </router-link>
+
+        <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+            <path fill-rule="evenodd" d="M12.577 4.878a.75.75 0 01.919-.53l4.78 1.281a.75.75 0 01.531.919l-1.281 4.78a.75.75 0 01-1.449-.387l.81-3.022a19.407 19.407 0 00-5.594 5.203.75.75 0 01-1.139.093L7 10.06l-4.72 4.72a.75.75 0 01-1.06-1.061l5.25-5.25a.75.75 0 011.06 0l3.074 3.073a20.923 20.923 0 015.545-4.931l-3.042-.815a.75.75 0 01-.53-.918z" clip-rule="evenodd"/>
+          </svg>
+          <span class="nav-label">{{ t('nav.demandForecast') }}</span>
+        </router-link>
+
+        <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+            <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
+          </svg>
+          <span class="nav-label">Reports</span>
+        </router-link>
+      </nav>
+
+      <div class="sidebar-footer">
         <LanguageSwitcher />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    </aside>
+
+    <div class="app-body" :class="{ 'sidebar-collapsed': collapsed }">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -80,6 +118,7 @@ export default {
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
+    const collapsed = ref(false)
 
     // Merge mock tasks from currentUser with API tasks
     const tasks = computed(() => {
@@ -97,7 +136,6 @@ export default {
     const addTask = async (taskData) => {
       try {
         const newTask = await api.createTask(taskData)
-        // Add new task to the beginning of the array
         apiTasks.value.unshift(newTask)
       } catch (err) {
         console.error('Failed to add task:', err)
@@ -106,17 +144,11 @@ export default {
 
     const deleteTask = async (taskId) => {
       try {
-        // Check if it's a mock task (from currentUser)
         const isMockTask = currentUser.value.tasks.some(t => t.id === taskId)
-
         if (isMockTask) {
-          // Remove from mock tasks
           const index = currentUser.value.tasks.findIndex(t => t.id === taskId)
-          if (index !== -1) {
-            currentUser.value.tasks.splice(index, 1)
-          }
+          if (index !== -1) currentUser.value.tasks.splice(index, 1)
         } else {
-          // Remove from API tasks
           await api.deleteTask(taskId)
           apiTasks.value = apiTasks.value.filter(t => t.id !== taskId)
         }
@@ -127,19 +159,13 @@ export default {
 
     const toggleTask = async (taskId) => {
       try {
-        // Check if it's a mock task (from currentUser)
         const mockTask = currentUser.value.tasks.find(t => t.id === taskId)
-
         if (mockTask) {
-          // Toggle mock task status
           mockTask.status = mockTask.status === 'pending' ? 'completed' : 'pending'
         } else {
-          // Toggle API task
           const updatedTask = await api.toggleTask(taskId)
           const index = apiTasks.value.findIndex(t => t.id === taskId)
-          if (index !== -1) {
-            apiTasks.value[index] = updatedTask
-          }
+          if (index !== -1) apiTasks.value[index] = updatedTask
         }
       } catch (err) {
         console.error('Failed to toggle task:', err)
@@ -150,6 +176,7 @@ export default {
 
     return {
       t,
+      collapsed,
       showProfileDetails,
       showTasks,
       tasks,
@@ -178,92 +205,162 @@ body {
 
 .app {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
+/* ── SIDEBAR ── */
+.sidebar {
+  position: fixed;
+  left: 0;
   top: 0;
+  width: 220px;
+  height: 100vh;
+  background: #0f172a;
+  display: flex;
+  flex-direction: column;
+  transition: width 0.2s ease;
   z-index: 100;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
+.sidebar.collapsed {
+  width: 64px;
+}
+
+.sidebar-header {
   display: flex;
   align-items: center;
-  padding: 0 2rem;
-  height: 70px;
+  justify-content: space-between;
+  padding: 1.25rem 1rem 1rem;
+  border-bottom: 1px solid #1e293b;
+  min-height: 68px;
+  gap: 0.5rem;
 }
 
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
+.sidebar.collapsed .sidebar-header {
+  justify-content: center;
 }
 
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
+.sidebar-logo h1 {
+  font-size: 1rem;
   font-weight: 700;
-  color: #0f172a;
+  color: #f8fafc;
   letter-spacing: -0.025em;
+  white-space: nowrap;
 }
 
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
+.sidebar-subtitle {
+  display: block;
+  font-size: 0.7rem;
+  color: #475569;
+  margin-top: 2px;
+  white-space: nowrap;
 }
 
-.nav-tabs {
+.sidebar-toggle {
+  background: transparent;
+  border: none;
+  color: #475569;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
   display: flex;
-  gap: 0.25rem;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
 }
 
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
+.sidebar-toggle:hover {
+  background: #1e293b;
+  color: #94a3b8;
+}
+
+/* ── SIDEBAR NAV ── */
+.sidebar-nav {
+  flex: 1;
+  padding: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 14px;
+  margin: 0 8px;
   color: #64748b;
   text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
+  border-radius: 7px;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  min-width: 0;
 }
 
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
+.sidebar-nav a:hover {
+  background: #1e293b;
+  color: #cbd5e1;
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
+.sidebar-nav a.active {
   background: #2563eb;
+  color: #ffffff;
+}
+
+.sidebar-nav a svg {
+  flex-shrink: 0;
+}
+
+.nav-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar.collapsed .nav-label {
+  display: none;
+}
+
+.sidebar.collapsed .sidebar-nav a {
+  justify-content: center;
+  padding: 10px;
+  margin: 0 8px;
+}
+
+/* ── SIDEBAR FOOTER ── */
+.sidebar-footer {
+  border-top: 1px solid #1e293b;
+  padding: 0.75rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sidebar.collapsed .sidebar-footer {
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ── APP BODY ── */
+.app-body {
+  margin-left: 220px;
+  transition: margin-left 0.2s ease;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.app-body.sidebar-collapsed {
+  margin-left: 64px;
 }
 
 .main-content {
@@ -274,6 +371,7 @@ body {
   padding: 1.5rem 2rem;
 }
 
+/* ── GLOBAL SHARED STYLES ── */
 .page-header {
   margin-bottom: 1.5rem;
 }
@@ -327,21 +425,10 @@ body {
   letter-spacing: -0.025em;
 }
 
-.stat-card.warning .stat-value {
-  color: #ea580c;
-}
-
-.stat-card.success .stat-value {
-  color: #059669;
-}
-
-.stat-card.danger .stat-value {
-  color: #dc2626;
-}
-
-.stat-card.info .stat-value {
-  color: #2563eb;
-}
+.stat-card.warning .stat-value { color: #ea580c; }
+.stat-card.success .stat-value { color: #059669; }
+.stat-card.danger .stat-value  { color: #dc2626; }
+.stat-card.info .stat-value    { color: #2563eb; }
 
 .card {
   background: white;
@@ -417,55 +504,16 @@ tbody tr:hover {
   letter-spacing: 0.025em;
 }
 
-.badge.success {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.badge.warning {
-  background: #fed7aa;
-  color: #92400e;
-}
-
-.badge.danger {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.info {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
-.badge.increasing {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.badge.decreasing {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.stable {
-  background: #e0e7ff;
-  color: #3730a3;
-}
-
-.badge.high {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.medium {
-  background: #fed7aa;
-  color: #92400e;
-}
-
-.badge.low {
-  background: #dbeafe;
-  color: #1e40af;
-}
+.badge.success    { background: #d1fae5; color: #065f46; }
+.badge.warning    { background: #fed7aa; color: #92400e; }
+.badge.danger     { background: #fecaca; color: #991b1b; }
+.badge.info       { background: #dbeafe; color: #1e40af; }
+.badge.increasing { background: #d1fae5; color: #065f46; }
+.badge.decreasing { background: #fecaca; color: #991b1b; }
+.badge.stable     { background: #e0e7ff; color: #3730a3; }
+.badge.high       { background: #fecaca; color: #991b1b; }
+.badge.medium     { background: #fed7aa; color: #92400e; }
+.badge.low        { background: #dbeafe; color: #1e40af; }
 
 .loading {
   text-align: center;

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -105,9 +105,6 @@ export default {
   background: #f8fafc;
   border-bottom: 1px solid #e2e8f0;
   padding: 0.75rem 0;
-  position: sticky;
-  top: 70px;
-  z-index: 90;
 }
 
 .filters-container {

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,571 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventory Management — Architecture</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      line-height: 1.6;
+      padding: 48px 24px;
+    }
+
+    .page { max-width: 1080px; margin: 0 auto; }
+
+    h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    h2 { font-size: 1.1rem; font-weight: 600; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 16px; }
+    h3 { font-size: 0.95rem; font-weight: 600; color: #cbd5e1; margin-bottom: 8px; }
+
+    .subtitle { color: #64748b; font-size: 0.95rem; margin-top: 4px; }
+
+    .divider { border: none; border-top: 1px solid #1e293b; margin: 40px 0; }
+
+    /* ── SECTION ── */
+    .section { margin-bottom: 48px; }
+
+    /* ── ARCH DIAGRAM ── */
+    .arch {
+      display: grid;
+      grid-template-columns: 1fr 48px 1fr;
+      gap: 0;
+      align-items: center;
+      margin-top: 8px;
+    }
+
+    .box {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 20px 24px;
+    }
+
+    .box-title {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #64748b;
+      margin-bottom: 12px;
+    }
+
+    .tag {
+      display: inline-block;
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      padding: 3px 8px;
+      font-size: 0.78rem;
+      color: #94a3b8;
+      margin: 3px 3px 3px 0;
+      font-family: "SF Mono", monospace;
+    }
+
+    .tag.blue  { border-color: #3b82f6; color: #93c5fd; }
+    .tag.green { border-color: #22c55e; color: #86efac; }
+    .tag.amber { border-color: #f59e0b; color: #fcd34d; }
+
+    .arrow {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      color: #475569;
+      font-size: 0.7rem;
+      text-align: center;
+    }
+    .arrow-line {
+      width: 2px;
+      height: 32px;
+      background: linear-gradient(to bottom, #3b82f6, #8b5cf6);
+      border-radius: 2px;
+    }
+    .arrow-label { color: #64748b; font-size: 0.68rem; font-family: "SF Mono", monospace; }
+
+    /* ── STACK TABLE ── */
+    .stack-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-top: 8px;
+    }
+
+    .stack-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 20px;
+    }
+
+    .stack-card .label { font-size: 0.78rem; color: #64748b; font-family: "SF Mono", monospace; }
+    .stack-card .value { font-size: 0.9rem; color: #e2e8f0; margin-bottom: 8px; }
+
+    /* ── ENDPOINTS ── */
+    .endpoints { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+
+    .endpoint {
+      display: grid;
+      grid-template-columns: 56px 220px 1fr;
+      align-items: baseline;
+      gap: 12px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 7px;
+      padding: 10px 16px;
+    }
+
+    .method {
+      font-size: 0.72rem;
+      font-weight: 700;
+      font-family: "SF Mono", monospace;
+      color: #22c55e;
+      letter-spacing: 0.05em;
+    }
+    .method.post { color: #f59e0b; }
+
+    .path {
+      font-size: 0.82rem;
+      font-family: "SF Mono", monospace;
+      color: #93c5fd;
+    }
+
+    .desc { font-size: 0.82rem; color: #64748b; }
+
+    /* ── DATA FLOW ── */
+    .flow {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      margin-top: 8px;
+    }
+
+    .flow-step {
+      display: grid;
+      grid-template-columns: 32px 1fr;
+      gap: 16px;
+      align-items: flex-start;
+    }
+
+    .flow-step + .flow-step .step-connector { padding-top: 0; }
+
+    .step-num {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: #1e293b;
+      border: 2px solid #3b82f6;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: #93c5fd;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    .step-line {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .step-body { padding-bottom: 20px; }
+    .step-title { font-size: 0.9rem; font-weight: 600; color: #e2e8f0; }
+    .step-detail { font-size: 0.82rem; color: #64748b; margin-top: 2px; font-family: "SF Mono", monospace; }
+
+    /* ── DATA MODELS ── */
+    .models-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      margin-top: 8px;
+    }
+
+    .model-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .model-name {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #f8fafc;
+      margin-bottom: 8px;
+      font-family: "SF Mono", monospace;
+    }
+
+    .field {
+      font-size: 0.75rem;
+      color: #64748b;
+      display: flex;
+      justify-content: space-between;
+      padding: 2px 0;
+      border-bottom: 1px solid #0f172a;
+    }
+    .field:last-child { border-bottom: none; }
+    .field-name { color: #94a3b8; }
+    .field-type { font-family: "SF Mono", monospace; color: #8b5cf6; }
+
+    /* ── FOOTER ── */
+    .footer { text-align: center; font-size: 0.78rem; color: #334155; margin-top: 64px; }
+
+    @media (max-width: 640px) {
+      .arch { grid-template-columns: 1fr; }
+      .stack-grid { grid-template-columns: 1fr; }
+      .models-grid { grid-template-columns: 1fr; }
+      .endpoint { grid-template-columns: 56px 1fr; }
+      .endpoint .desc { display: none; }
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <div class="section">
+    <h1>Factory Inventory Management System</h1>
+    <p class="subtitle">System architecture, tech stack, and data flow</p>
+  </div>
+
+  <hr class="divider" />
+
+  <!-- ARCHITECTURE OVERVIEW -->
+  <div class="section">
+    <h2>System Architecture</h2>
+    <div class="arch">
+
+      <!-- Frontend -->
+      <div class="box">
+        <div class="box-title">Frontend &mdash; Port 3000</div>
+        <h3>Vue 3 SPA</h3>
+        <div style="margin-bottom:12px">
+          <span class="tag blue">Vue 3.4</span>
+          <span class="tag blue">Vite 5.2</span>
+          <span class="tag blue">Vue Router 4.3</span>
+          <span class="tag blue">Axios 1.6</span>
+        </div>
+        <h3 style="margin-top:12px">Views</h3>
+        <div>
+          <span class="tag">Dashboard</span>
+          <span class="tag">Inventory</span>
+          <span class="tag">Orders</span>
+          <span class="tag">Demand</span>
+          <span class="tag">Spending</span>
+          <span class="tag">Reports</span>
+          <span class="tag">Backlog</span>
+        </div>
+        <h3 style="margin-top:12px">Composables</h3>
+        <div>
+          <span class="tag">useFilters</span>
+          <span class="tag">useAuth</span>
+          <span class="tag">useI18n</span>
+        </div>
+      </div>
+
+      <!-- Arrow -->
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-label">HTTP / JSON</div>
+        <div class="arrow-line"></div>
+      </div>
+
+      <!-- Backend -->
+      <div class="box">
+        <div class="box-title">Backend &mdash; Port 8001</div>
+        <h3>Python FastAPI</h3>
+        <div style="margin-bottom:12px">
+          <span class="tag green">FastAPI 0.110+</span>
+          <span class="tag green">Uvicorn 0.24+</span>
+          <span class="tag green">Pydantic 2.5+</span>
+          <span class="tag green">Python 3.14</span>
+        </div>
+        <h3 style="margin-top:12px">API Groups</h3>
+        <div>
+          <span class="tag">/api/inventory</span>
+          <span class="tag">/api/orders</span>
+          <span class="tag">/api/dashboard</span>
+          <span class="tag">/api/demand</span>
+          <span class="tag">/api/backlog</span>
+          <span class="tag">/api/spending</span>
+          <span class="tag">/api/reports</span>
+        </div>
+        <h3 style="margin-top:12px">Data Layer</h3>
+        <div>
+          <span class="tag amber">JSON files</span>
+          <span class="tag amber">In-memory</span>
+          <span class="tag amber">No database</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <hr class="divider" />
+
+  <!-- TECH STACK -->
+  <div class="section">
+    <h2>Tech Stack</h2>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="label">UI Framework</div>
+        <div class="value">Vue 3 — Composition API</div>
+        <div class="label">Build Tool</div>
+        <div class="value">Vite 5.2 (dev server + HMR)</div>
+        <div class="label">Routing</div>
+        <div class="value">Vue Router 4.3 — SPA client-side</div>
+        <div class="label">HTTP Client</div>
+        <div class="value">Axios 1.6 — REST calls to backend</div>
+      </div>
+      <div class="stack-card">
+        <div class="label">Web Framework</div>
+        <div class="value">FastAPI — async REST API</div>
+        <div class="label">Server</div>
+        <div class="value">Uvicorn — ASGI, CORS middleware</div>
+        <div class="label">Validation</div>
+        <div class="value">Pydantic 2.5 — response models</div>
+        <div class="label">Data</div>
+        <div class="value">JSON files loaded into memory at startup</div>
+      </div>
+    </div>
+  </div>
+
+  <hr class="divider" />
+
+  <!-- API ENDPOINTS -->
+  <div class="section">
+    <h2>API Endpoints</h2>
+    <div class="endpoints">
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/inventory</span>
+        <span class="desc">All items — filters: warehouse, category</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/inventory/{id}</span>
+        <span class="desc">Single inventory item</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/orders</span>
+        <span class="desc">All orders — filters: warehouse, category, status, month</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/orders/{id}</span>
+        <span class="desc">Single order</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/dashboard/summary</span>
+        <span class="desc">KPI summary — all filters</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/demand</span>
+        <span class="desc">Demand forecasts (no filters)</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/backlog</span>
+        <span class="desc">Backlog items with purchase order flags</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/spending/summary</span>
+        <span class="desc">Procurement, operational, labor, overhead totals</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/spending/monthly</span>
+        <span class="desc">Monthly cost breakdown (12 months)</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/spending/categories</span>
+        <span class="desc">Spending by category with % change</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/spending/transactions</span>
+        <span class="desc">200+ transaction records</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/reports/quarterly</span>
+        <span class="desc">Quarterly performance (revenue, fulfillment rate)</span>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span>
+        <span class="path">/api/reports/monthly-trends</span>
+        <span class="desc">Monthly order count and revenue trends</span>
+      </div>
+      <div class="endpoint">
+        <span class="method post">POST</span>
+        <span class="path">/api/purchase-orders</span>
+        <span class="desc">Create purchase order (stub)</span>
+      </div>
+    </div>
+  </div>
+
+  <hr class="divider" />
+
+  <!-- DATA FLOW -->
+  <div class="section">
+    <h2>Request Data Flow</h2>
+    <div class="flow">
+
+      <div class="flow-step">
+        <div class="step-line"><div class="step-num">1</div></div>
+        <div class="step-body">
+          <div class="step-title">User selects a filter</div>
+          <div class="step-detail">FilterBar.vue → useFilters() composable (shared singleton state)</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-line"><div class="step-num">2</div></div>
+        <div class="step-body">
+          <div class="step-title">View triggers API call</div>
+          <div class="step-detail">api.js → getCurrentFilters() → builds URLSearchParams (skips "all" values)</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-line"><div class="step-num">3</div></div>
+        <div class="step-body">
+          <div class="step-title">Axios sends HTTP GET</div>
+          <div class="step-detail">GET /api/orders?warehouse=Tokyo&amp;status=Delivered</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-line"><div class="step-num">4</div></div>
+        <div class="step-body">
+          <div class="step-title">FastAPI endpoint receives request</div>
+          <div class="step-detail">main.py → apply_filters() → filter_by_month() → in-memory array filtering</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-line"><div class="step-num">5</div></div>
+        <div class="step-body">
+          <div class="step-title">Pydantic serializes response</div>
+          <div class="step-detail">response_model=List[Order] validates and serializes filtered data → JSON</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-line"><div class="step-num">6</div></div>
+        <div class="step-body">
+          <div class="step-title">Vue updates reactive state</div>
+          <div class="step-detail">orders.value = response.data → computed properties re-derive → template re-renders</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <hr class="divider" />
+
+  <!-- DATA MODELS -->
+  <div class="section">
+    <h2>Core Data Models</h2>
+    <div class="models-grid">
+
+      <div class="model-card">
+        <div class="model-name">InventoryItem</div>
+        <div class="field"><span class="field-name">id, sku, name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">category, warehouse</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">quantity_on_hand</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">reorder_point</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">unit_cost</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">location, last_updated</span><span class="field-type">str</span></div>
+      </div>
+
+      <div class="model-card">
+        <div class="model-name">Order</div>
+        <div class="field"><span class="field-name">id, order_number</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">customer, warehouse</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">items</span><span class="field-type">List[OrderItem]</span></div>
+        <div class="field"><span class="field-name">status</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">order_date, expected_delivery</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">total_value</span><span class="field-type">float</span></div>
+      </div>
+
+      <div class="model-card">
+        <div class="model-name">BacklogItem</div>
+        <div class="field"><span class="field-name">id, order_id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">item_sku, item_name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">quantity_needed</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">quantity_available</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">days_delayed</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">priority</span><span class="field-type">str</span></div>
+      </div>
+
+      <div class="model-card">
+        <div class="model-name">DemandForecast</div>
+        <div class="field"><span class="field-name">id, item_sku, item_name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">current_demand</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">forecasted_demand</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">trend</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">period</span><span class="field-type">str</span></div>
+      </div>
+
+      <div class="model-card">
+        <div class="model-name">Transaction</div>
+        <div class="field"><span class="field-name">id, transaction_id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">description, category</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">amount</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">date</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">type</span><span class="field-type">Expense | Revenue</span></div>
+      </div>
+
+      <div class="model-card">
+        <div class="model-name">DashboardSummary</div>
+        <div class="field"><span class="field-name">total_inventory_value</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">low_stock_items</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">pending_orders</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">total_backlog_items</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">total_orders_value</span><span class="field-type">float</span></div>
+      </div>
+
+    </div>
+  </div>
+
+  <hr class="divider" />
+
+  <!-- KEY PATTERNS -->
+  <div class="section">
+    <h2>Key Design Patterns</h2>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <h3>Singleton Filter Composable</h3>
+        <p style="font-size:0.82rem;color:#64748b;margin-top:4px">useFilters() uses module-level refs — all views share the same filter state without prop drilling.</p>
+      </div>
+      <div class="stack-card">
+        <h3>In-Memory Filtering</h3>
+        <p style="font-size:0.82rem;color:#64748b;margin-top:4px">JSON files loaded once at startup. All filters create new arrays — no mutations. "all" acts as a skip sentinel.</p>
+      </div>
+      <div class="stack-card">
+        <h3>Custom SVG Charts</h3>
+        <p style="font-size:0.82rem;color:#64748b;margin-top:4px">No chart library. Donut charts use stroke-dasharray; bar charts use CSS Grid. Lightweight but manual.</p>
+      </div>
+      <div class="stack-card">
+        <h3>Modal-Driven Detail Views</h3>
+        <p style="font-size:0.82rem;color:#64748b;margin-top:4px">No dedicated routes for detail pages. Clicking a table row opens a modal — parent manages modal state.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">Factory Inventory Management System &mdash; Architecture Overview</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replaced horizontal top nav bar with a fixed vertical sidebar (220px wide, dark slate background)
- Added collapsible icon-only mode (64px) with animated toggle button
- Moved FilterBar to render inline at the top of the main content area
- Added reusable `frontend-redesign` Claude Code skill for applying this pattern to other Vue 3 apps
- Added HTML architecture page documenting system design, tech stack, API endpoints, and data flow

## Test plan
- [ ] Visit `http://localhost:3000` — sidebar visible on left, content fills remaining space
- [ ] All 6 nav links navigate correctly with blue active state
- [ ] Toggle button collapses sidebar to icon-only mode and expands back
- [ ] FilterBar filters still work on all pages
- [ ] No layout overflow on any view (Dashboard, Inventory, Orders, Spending, Demand, Reports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)