### PR TITLE
Add Restocking tab and architecture overview page

### DIFF
--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Architecture · Factory Inventory Management System</title>
+<style>
+  :root {
+    --slate-950: #020617;
+    --slate-900: #0f172a;
+    --slate-800: #1e293b;
+    --slate-700: #334155;
+    --slate-600: #475569;
+    --slate-500: #64748b;
+    --slate-400: #94a3b8;
+    --slate-300: #cbd5e1;
+    --slate-200: #e2e8f0;
+    --slate-100: #f1f5f9;
+    --slate-50:  #f8fafc;
+    --green-500: #22c55e;
+    --blue-500:  #3b82f6;
+    --yellow-500: #eab308;
+    --red-500: #ef4444;
+    --mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--slate-50);
+    color: var(--slate-900);
+    font-family: var(--sans);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 64px 32px 96px;
+  }
+
+  /* ===== Header ===== */
+  header.page-header {
+    border-bottom: 1px solid var(--slate-200);
+    padding-bottom: 32px;
+    margin-bottom: 48px;
+  }
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--slate-500);
+    margin-bottom: 12px;
+  }
+  h1 {
+    font-size: 36px;
+    font-weight: 700;
+    margin: 0 0 12px;
+    letter-spacing: -0.02em;
+    color: var(--slate-900);
+  }
+  header.page-header p {
+    font-size: 16px;
+    color: var(--slate-600);
+    max-width: 720px;
+    margin: 0;
+  }
+
+  /* ===== Section ===== */
+  section {
+    margin-bottom: 56px;
+  }
+  h2 {
+    font-size: 22px;
+    font-weight: 600;
+    margin: 0 0 20px;
+    letter-spacing: -0.01em;
+    color: var(--slate-900);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  h2::before {
+    content: '';
+    display: inline-block;
+    width: 4px;
+    height: 18px;
+    background: var(--slate-900);
+    border-radius: 2px;
+  }
+  h3 {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 8px;
+    color: var(--slate-900);
+  }
+
+  /* ===== Tech Stack Cards ===== */
+  .stack-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  .card {
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 8px;
+    padding: 20px;
+  }
+  .card-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+  .card-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .dot-frontend { background: var(--blue-500); }
+  .dot-backend  { background: var(--green-500); }
+  .dot-data     { background: var(--yellow-500); }
+  .card-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--slate-500);
+    font-weight: 600;
+  }
+  .card-name {
+    font-size: 17px;
+    font-weight: 600;
+    margin: 0 0 4px;
+    color: var(--slate-900);
+  }
+  .card-version {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--slate-500);
+    margin: 0 0 14px;
+  }
+  .card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 13px;
+    color: var(--slate-600);
+  }
+  .card li {
+    padding: 4px 0;
+    border-top: 1px solid var(--slate-100);
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .card li:first-child { border-top: none; }
+  .card li .v {
+    font-family: var(--mono);
+    color: var(--slate-500);
+    font-size: 12px;
+  }
+
+  /* ===== Architecture Diagram ===== */
+  .diagram-wrap {
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 8px;
+    padding: 32px 24px;
+  }
+  .diagram-wrap svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+
+  /* ===== Data Flow Steps ===== */
+  .flow {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+  .flow-step {
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 8px;
+    padding: 16px 18px;
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+  }
+  .step-num {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: var(--slate-900);
+    color: white;
+    font-size: 12px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-family: var(--mono);
+  }
+  .step-body { flex: 1; min-width: 0; }
+  .step-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin: 0 0 4px;
+    color: var(--slate-900);
+  }
+  .step-desc {
+    font-size: 13px;
+    color: var(--slate-600);
+    margin: 0;
+  }
+  .step-desc code {
+    font-family: var(--mono);
+    font-size: 12px;
+    background: var(--slate-100);
+    color: var(--slate-700);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+
+  /* ===== Endpoint Table ===== */
+  .endpoint-table {
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  thead th {
+    background: var(--slate-50);
+    color: var(--slate-500);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 11px;
+    font-weight: 600;
+    text-align: left;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--slate-200);
+  }
+  tbody td {
+    padding: 12px 16px;
+    border-top: 1px solid var(--slate-100);
+    color: var(--slate-700);
+    vertical-align: top;
+  }
+  .method {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+  .method-get  { background: #dcfce7; color: #15803d; }
+  .method-post { background: #dbeafe; color: #1d4ed8; }
+  .method-del  { background: #fee2e2; color: #b91c1c; }
+  .method-patch { background: #fef3c7; color: #a16207; }
+  td.path {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--slate-900);
+    white-space: nowrap;
+  }
+  td.filters {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--slate-500);
+  }
+
+  /* ===== Tree ===== */
+  .tree {
+    background: var(--slate-900);
+    color: var(--slate-100);
+    border-radius: 8px;
+    padding: 20px 24px;
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.7;
+    overflow-x: auto;
+  }
+  .tree .dir { color: var(--blue-500); font-weight: 600; }
+  .tree .file { color: var(--slate-300); }
+  .tree .comment { color: var(--slate-500); }
+
+  /* ===== Footer ===== */
+  footer.page-footer {
+    margin-top: 64px;
+    padding-top: 24px;
+    border-top: 1px solid var(--slate-200);
+    font-size: 12px;
+    color: var(--slate-500);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  footer a {
+    color: var(--slate-700);
+    text-decoration: none;
+    font-family: var(--mono);
+  }
+  footer a:hover { color: var(--slate-900); text-decoration: underline; }
+
+  @media (max-width: 768px) {
+    .container { padding: 32px 20px 64px; }
+    h1 { font-size: 28px; }
+    .stack-grid { grid-template-columns: 1fr; }
+    .flow { grid-template-columns: 1fr; }
+    footer.page-footer { flex-direction: column; gap: 8px; align-items: flex-start; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+  <header class="page-header">
+    <div class="eyebrow">System Architecture</div>
+    <h1>Factory Inventory Management System</h1>
+    <p>A demo full-stack application for tracking inventory, orders, demand forecasts, backlog, and spending across a multi-warehouse operation. Vue 3 SPA on the front, FastAPI on the back, JSON files as the data store.</p>
+  </header>
+
+  <!-- ===== Tech Stack ===== -->
+  <section>
+    <h2>Tech Stack</h2>
+    <div class="stack-grid">
+
+      <div class="card">
+        <div class="card-title">
+          <span class="card-dot dot-frontend"></span>
+          <span class="card-label">Frontend</span>
+        </div>
+        <p class="card-name">Vue 3 SPA</p>
+        <p class="card-version">port 3000</p>
+        <ul>
+          <li><span>Vue</span><span class="v">^3.4.21</span></li>
+          <li><span>Vue Router</span><span class="v">^4.3.0</span></li>
+          <li><span>Axios</span><span class="v">^1.6.7</span></li>
+          <li><span>Vite</span><span class="v">^5.2.0</span></li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-title">
+          <span class="card-dot dot-backend"></span>
+          <span class="card-label">Backend</span>
+        </div>
+        <p class="card-name">FastAPI</p>
+        <p class="card-version">port 8001</p>
+        <ul>
+          <li><span>FastAPI</span><span class="v">&gt;=0.110</span></li>
+          <li><span>Uvicorn</span><span class="v">&gt;=0.24</span></li>
+          <li><span>Pydantic</span><span class="v">&gt;=2.5</span></li>
+          <li><span>Python</span><span class="v">&gt;=3.11</span></li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-title">
+          <span class="card-dot dot-data"></span>
+          <span class="card-label">Data</span>
+        </div>
+        <p class="card-name">JSON Files (in-memory)</p>
+        <p class="card-version">no database</p>
+        <ul>
+          <li><span>inventory.json</span><span class="v">items</span></li>
+          <li><span>orders.json</span><span class="v">orders</span></li>
+          <li><span>backlog_items.json</span><span class="v">backlog</span></li>
+          <li><span>spending.json</span><span class="v">finance</span></li>
+        </ul>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ===== Architecture Diagram ===== -->
+  <section>
+    <h2>System Architecture</h2>
+    <div class="diagram-wrap">
+      <svg viewBox="0 0 1000 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="System architecture diagram">
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+            <path d="M0,0 L10,5 L0,10 z" fill="#64748b"/>
+          </marker>
+          <style>
+            .tier-bg { fill: white; stroke: #e2e8f0; stroke-width: 1; }
+            .tier-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 11px; font-weight: 600; fill: #64748b; letter-spacing: 0.08em; text-transform: uppercase; }
+            .node { fill: white; stroke-width: 1.5; }
+            .node-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 13px; font-weight: 600; fill: #0f172a; }
+            .node-sub  { font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace; font-size: 11px; fill: #64748b; }
+            .arrow { stroke: #64748b; stroke-width: 1.5; fill: none; }
+            .arrow-label { font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace; font-size: 10px; fill: #475569; }
+          </style>
+        </defs>
+
+        <!-- Tier backgrounds -->
+        <rect class="tier-bg" x="20"  y="20"  width="200" height="320" rx="6" />
+        <rect class="tier-bg" x="270" y="20"  width="260" height="320" rx="6" />
+        <rect class="tier-bg" x="580" y="20"  width="200" height="320" rx="6" />
+        <rect class="tier-bg" x="830" y="20"  width="150" height="320" rx="6" />
+
+        <!-- Tier titles -->
+        <text class="tier-title" x="120" y="44" text-anchor="middle">Client</text>
+        <text class="tier-title" x="400" y="44" text-anchor="middle">Vue 3 SPA — port 3000</text>
+        <text class="tier-title" x="680" y="44" text-anchor="middle">FastAPI — port 8001</text>
+        <text class="tier-title" x="905" y="44" text-anchor="middle">Data Layer</text>
+
+        <!-- Client node -->
+        <rect class="node" x="50" y="150" width="140" height="60" rx="6" stroke="#3b82f6" />
+        <text class="node-text" x="120" y="178" text-anchor="middle">Browser</text>
+        <text class="node-sub"  x="120" y="196" text-anchor="middle">localhost:3000</text>
+
+        <!-- Vue layer: 3 stacked boxes -->
+        <rect class="node" x="290" y="80"  width="220" height="62" rx="6" stroke="#3b82f6" />
+        <text class="node-text" x="400" y="105" text-anchor="middle">Views (Router)</text>
+        <text class="node-sub"  x="400" y="124" text-anchor="middle">Dashboard, Inventory, Orders…</text>
+
+        <rect class="node" x="290" y="155" width="220" height="62" rx="6" stroke="#3b82f6" />
+        <text class="node-text" x="400" y="180" text-anchor="middle">Composables</text>
+        <text class="node-sub"  x="400" y="199" text-anchor="middle">useFilters · useAuth · useI18n</text>
+
+        <rect class="node" x="290" y="230" width="220" height="62" rx="6" stroke="#3b82f6" />
+        <text class="node-text" x="400" y="255" text-anchor="middle">api.js (Axios)</text>
+        <text class="node-sub"  x="400" y="274" text-anchor="middle">centralized HTTP client</text>
+
+        <!-- FastAPI layer: 3 stacked boxes -->
+        <rect class="node" x="600" y="80"  width="160" height="62" rx="6" stroke="#22c55e" />
+        <text class="node-text" x="680" y="105" text-anchor="middle">Routes</text>
+        <text class="node-sub"  x="680" y="124" text-anchor="middle">/api/inventory · /orders</text>
+
+        <rect class="node" x="600" y="155" width="160" height="62" rx="6" stroke="#22c55e" />
+        <text class="node-text" x="680" y="180" text-anchor="middle">Filter Helpers</text>
+        <text class="node-sub"  x="680" y="199" text-anchor="middle">apply_filters · by_month</text>
+
+        <rect class="node" x="600" y="230" width="160" height="62" rx="6" stroke="#22c55e" />
+        <text class="node-text" x="680" y="255" text-anchor="middle">Pydantic Models</text>
+        <text class="node-sub"  x="680" y="274" text-anchor="middle">response validation</text>
+
+        <!-- Data layer -->
+        <rect class="node" x="850" y="110" width="110" height="50" rx="6" stroke="#eab308" />
+        <text class="node-text" x="905" y="132" text-anchor="middle">mock_data.py</text>
+        <text class="node-sub"  x="905" y="148" text-anchor="middle">in-memory</text>
+
+        <rect class="node" x="850" y="200" width="110" height="50" rx="6" stroke="#eab308" />
+        <text class="node-text" x="905" y="222" text-anchor="middle">data/*.json</text>
+        <text class="node-sub"  x="905" y="238" text-anchor="middle">7 source files</text>
+
+        <!-- Arrows: Client → Vue -->
+        <path class="arrow" d="M190,180 L290,180" marker-end="url(#arrow)"/>
+        <text class="arrow-label" x="240" y="172" text-anchor="middle">HTTP</text>
+
+        <!-- Arrows: Vue internal flow (views → composables → api) -->
+        <path class="arrow" d="M400,142 L400,153" marker-end="url(#arrow)"/>
+        <path class="arrow" d="M400,217 L400,228" marker-end="url(#arrow)"/>
+
+        <!-- Arrows: api.js → FastAPI Routes -->
+        <path class="arrow" d="M510,261 C 545,261 560,111 600,111" marker-end="url(#arrow)"/>
+        <text class="arrow-label" x="555" y="190" text-anchor="middle">JSON / CORS</text>
+
+        <!-- Arrows: FastAPI internal -->
+        <path class="arrow" d="M680,142 L680,153" marker-end="url(#arrow)"/>
+        <path class="arrow" d="M680,217 L680,228" marker-end="url(#arrow)"/>
+
+        <!-- Arrows: FastAPI → Data layer -->
+        <path class="arrow" d="M760,186 L850,135" marker-end="url(#arrow)"/>
+        <path class="arrow" d="M905,160 L905,200" marker-end="url(#arrow)"/>
+        <text class="arrow-label" x="920" y="183" text-anchor="middle">load</text>
+      </svg>
+    </div>
+  </section>
+
+  <!-- ===== Data Flow ===== -->
+  <section>
+    <h2>Data Flow — Request Lifecycle</h2>
+    <div class="flow">
+
+      <div class="flow-step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <p class="step-title">User adjusts a filter</p>
+          <p class="step-desc"><code>FilterBar.vue</code> updates shared refs in the <code>useFilters</code> composable (warehouse, category, status, month).</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <p class="step-title">View reacts to filter change</p>
+          <p class="step-desc">A view (e.g. <code>Dashboard.vue</code>) watches the filters and calls the matching method on <code>api.js</code>.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <p class="step-title">Axios HTTP request</p>
+          <p class="step-desc"><code>api.js</code> builds <code>URLSearchParams</code>, skipping any filter set to <code>"all"</code>, and GETs <code>http://localhost:8001/api/...</code>.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <p class="step-title">FastAPI route receives request</p>
+          <p class="step-desc">CORS middleware allows cross-origin. The route accepts query params as <code>Optional[str]</code> and delegates to filter helpers.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">5</div>
+        <div class="step-body">
+          <p class="step-title">In-memory filtering</p>
+          <p class="step-desc"><code>apply_filters</code> and <code>filter_by_month</code> in <code>main.py</code> iterate the in-memory list and return a filtered copy.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">6</div>
+        <div class="step-body">
+          <p class="step-title">Pydantic validates response</p>
+          <p class="step-desc">The <code>response_model</code> serializes results through <code>InventoryItem</code>, <code>Order</code>, etc. — guaranteeing shape.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">7</div>
+        <div class="step-body">
+          <p class="step-title">Vue stores raw data in refs</p>
+          <p class="step-desc">Raw arrays land in refs like <code>allOrders</code> and <code>inventoryItems</code>. Derived values live in <code>computed()</code>.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="step-num">8</div>
+        <div class="step-body">
+          <p class="step-title">Template renders</p>
+          <p class="step-desc">Tables, custom-SVG charts, and CSS-Grid dashboards re-render. Modals open per-row for detail views.</p>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ===== API Endpoints ===== -->
+  <section>
+    <h2>API Endpoints</h2>
+    <div class="endpoint-table">
+      <table>
+        <thead>
+          <tr>
+            <th style="width: 70px;">Method</th>
+            <th>Path</th>
+            <th>Purpose</th>
+            <th>Filters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/inventory</td><td>List inventory items</td><td class="filters">warehouse, category</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/inventory/{id}</td><td>Get one item</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/orders</td><td>List orders</td><td class="filters">warehouse, category, status, month</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/orders/{id}</td><td>Get one order</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/demand</td><td>Demand forecasts</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/backlog</td><td>Backlog items + PO status</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/dashboard/summary</td><td>KPI roll-up</td><td class="filters">warehouse, category, status, month</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/spending/summary</td><td>Spending summary</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/spending/monthly</td><td>Monthly breakdown</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/spending/categories</td><td>By category</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/spending/transactions</td><td>Recent transactions</td><td class="filters">—</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/reports/quarterly</td><td>Quarterly stats</td><td class="filters">computed</td></tr>
+          <tr><td><span class="method method-get">GET</span></td><td class="path">/api/reports/monthly-trends</td><td>Month-over-month</td><td class="filters">computed</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ===== Project Structure ===== -->
+  <section>
+    <h2>Project Structure</h2>
+    <div class="tree">
+<span class="dir">inventory-management/</span>
+├── <span class="dir">client/</span>                         <span class="comment"># Vue 3 SPA (Vite, port 3000)</span>
+│   ├── <span class="dir">src/</span>
+│   │   ├── <span class="dir">views/</span>                  <span class="comment"># Route-level pages</span>
+│   │   │   ├── <span class="file">Dashboard.vue</span>
+│   │   │   ├── <span class="file">Inventory.vue</span>
+│   │   │   ├── <span class="file">Orders.vue</span>
+│   │   │   ├── <span class="file">Demand.vue</span>
+│   │   │   ├── <span class="file">Spending.vue</span>
+│   │   │   └── <span class="file">Reports.vue</span>
+│   │   ├── <span class="dir">components/</span>             <span class="comment"># FilterBar, modals, ProfileMenu…</span>
+│   │   ├── <span class="dir">composables/</span>            <span class="comment"># useFilters · useAuth · useI18n</span>
+│   │   ├── <span class="dir">locales/</span>                <span class="comment"># en.js · ja.js</span>
+│   │   ├── <span class="dir">utils/</span>                  <span class="comment"># currency formatting</span>
+│   │   ├── <span class="file">api.js</span>                 <span class="comment"># Axios client</span>
+│   │   ├── <span class="file">App.vue</span>
+│   │   └── <span class="file">main.js</span>                <span class="comment"># Router + app mount</span>
+│   └── <span class="file">package.json</span>
+│
+├── <span class="dir">server/</span>                         <span class="comment"># FastAPI (uv, port 8001)</span>
+│   ├── <span class="dir">data/</span>                       <span class="comment"># JSON source-of-truth</span>
+│   │   ├── <span class="file">inventory.json</span>
+│   │   ├── <span class="file">orders.json</span>
+│   │   ├── <span class="file">backlog_items.json</span>
+│   │   ├── <span class="file">demand_forecasts.json</span>
+│   │   ├── <span class="file">purchase_orders.json</span>
+│   │   ├── <span class="file">spending.json</span>
+│   │   └── <span class="file">transactions.json</span>
+│   ├── <span class="file">main.py</span>                    <span class="comment"># Endpoints + Pydantic models</span>
+│   ├── <span class="file">mock_data.py</span>               <span class="comment"># Loads JSON on import</span>
+│   └── <span class="file">pyproject.toml</span>
+│
+├── <span class="dir">tests/</span>                          <span class="comment"># pytest + FastAPI TestClient</span>
+└── <span class="file">CLAUDE.md</span>
+    </div>
+  </section>
+
+  <footer class="page-footer">
+    <div>Architecture overview · in-memory demo · no persistence</div>
+    <div>
+      <a href="http://localhost:3000" target="_blank" rel="noopener">localhost:3000</a>
+      &nbsp;·&nbsp;
+      <a href="http://localhost:8001/docs" target="_blank" rel="noopener">localhost:8001/docs</a>
+    </div>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,6 +22,9 @@
           <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
             {{ t('nav.demandForecast') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,10 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async createRestockingOrder(payload) {
+    const response = await axios.post(`${API_BASE_URL}/orders/restock`, payload)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -125,7 +126,35 @@ export default {
       totalValue: 'Total Value',
       status: 'Status',
       expectedDelivery: 'Expected Delivery',
-      actualDelivery: 'Actual Delivery'
+      actualDelivery: 'Actual Delivery',
+      leadTime: 'Lead Time'
+    },
+    submittedOrders: 'Submitted Orders',
+    submittedOrdersDescription: 'Restocking orders submitted in this session',
+    leadTimeDays: '{days} days'
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Set a budget and place a restocking order based on demand forecasts',
+    availableBudget: 'Available Budget',
+    recommendedTotal: 'Recommended Total',
+    budgetRemaining: 'Budget Remaining',
+    recommendations: 'Recommended Items',
+    recommendationsDescription: 'Items the budget can cover, prioritized by demand trend',
+    placeOrder: 'Place Order',
+    placing: 'Placing order...',
+    noItemsFit: 'No items fit within this budget.',
+    submittedMessage: 'Restocking order {orderNumber} submitted. View it in the Orders tab.',
+    customerLabel: 'Internal Restocking',
+    table: {
+      sku: 'SKU',
+      itemName: 'Item Name',
+      trend: 'Trend',
+      restockQty: 'Restock Qty',
+      unitCost: 'Unit Cost',
+      subtotal: 'Subtotal'
     }
   },
 

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '再入荷',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -125,7 +126,35 @@ export default {
       totalValue: '合計金額',
       status: 'ステータス',
       expectedDelivery: '予定配達日',
-      actualDelivery: '実際の配達日'
+      actualDelivery: '実際の配達日',
+      leadTime: 'リードタイム'
+    },
+    submittedOrders: '送信済み注文',
+    submittedOrdersDescription: 'このセッションで送信された再入荷注文',
+    leadTimeDays: '{days}日'
+  },
+
+  // Restocking
+  restocking: {
+    title: '再入荷',
+    description: '予算を設定し、需要予測に基づいて再入荷注文を行います',
+    availableBudget: '利用可能な予算',
+    recommendedTotal: '推奨合計',
+    budgetRemaining: '残り予算',
+    recommendations: '推奨品目',
+    recommendationsDescription: '需要動向に基づき、予算内に収まる品目',
+    placeOrder: '注文する',
+    placing: '注文を送信中...',
+    noItemsFit: 'この予算に収まる品目はありません。',
+    submittedMessage: '再入荷注文 {orderNumber} を送信しました。注文タブで確認してください。',
+    customerLabel: '社内再入荷',
+    table: {
+      sku: 'SKU',
+      itemName: '品目名',
+      trend: 'トレンド',
+      restockQty: '再入荷数量',
+      unitCost: '単価',
+      subtotal: '小計'
     }
   },
 
@@ -373,6 +402,7 @@ export default {
     'Superior Manufacturing': 'スーペリアマニュファクチャリング',
     'Cascade Manufacturing': 'カスケードマニュファクチャリング',
     'Acme Manufacturing Corp': 'アクメ製造',
+    'Internal Restocking': '社内再入荷',
     'TechBuild Industries': 'テックビルド工業',
     'Advanced Components Inc': 'アドバンストコンポーネンツ',
     'Premier Industries': 'プレミア工業',

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,6 +5,7 @@ import Dashboard from './views/Dashboard.vue'
 import Inventory from './views/Inventory.vue'
 import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
+import Restocking from './views/Restocking.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
 
@@ -15,6 +16,7 @@ const router = createRouter({
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
+    { path: '/restocking', component: Restocking },
     { path: '/spending', component: Spending },
     { path: '/reports', component: Reports }
   ]

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -8,28 +8,83 @@
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
+      <!-- Stat cards are sourced from regularOrders so restocking orders don't skew the counts -->
       <div class="stats-grid">
         <div class="stat-card success">
           <div class="stat-label">{{ t('status.delivered') }}</div>
-          <div class="stat-value">{{ getOrdersByStatus('Delivered').length }}</div>
+          <div class="stat-value">{{ getRegularOrdersByStatus('Delivered').length }}</div>
         </div>
         <div class="stat-card info">
           <div class="stat-label">{{ t('status.shipped') }}</div>
-          <div class="stat-value">{{ getOrdersByStatus('Shipped').length }}</div>
+          <div class="stat-value">{{ getRegularOrdersByStatus('Shipped').length }}</div>
         </div>
         <div class="stat-card warning">
           <div class="stat-label">{{ t('status.processing') }}</div>
-          <div class="stat-value">{{ getOrdersByStatus('Processing').length }}</div>
+          <div class="stat-value">{{ getRegularOrdersByStatus('Processing').length }}</div>
         </div>
         <div class="stat-card danger">
           <div class="stat-label">{{ t('status.backordered') }}</div>
-          <div class="stat-value">{{ getOrdersByStatus('Backordered').length }}</div>
+          <div class="stat-value">{{ getRegularOrdersByStatus('Backordered').length }}</div>
         </div>
       </div>
 
+      <!-- Submitted (restocking) orders — only rendered when at least one exists -->
+      <div v-if="restockingOrders.length > 0" class="card">
+        <div class="card-header">
+          <div>
+            <h3 class="card-title">{{ t('orders.submittedOrders') }}</h3>
+            <p class="card-sub-description">{{ t('orders.submittedOrdersDescription') }}</p>
+          </div>
+        </div>
+        <div class="table-container">
+          <table class="orders-table restock-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-customer">{{ t('orders.table.customer') }}</th>
+                <th class="col-items">{{ t('orders.table.items') }}</th>
+                <th class="col-status">{{ t('orders.table.status') }}</th>
+                <th class="col-date">{{ t('orders.table.orderDate') }}</th>
+                <th class="col-lead-time">{{ t('orders.table.leadTime') }}</th>
+                <th class="col-value">{{ t('orders.table.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- Use order.id as key — never index -->
+              <tr v-for="order in restockingOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-customer">{{ translateCustomerName(order.customer) }}</td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="item in order.items" :key="item.sku || item.name" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_price }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-status">
+                  <span :class="['badge', getOrderStatusClass(order.status)]">
+                    {{ t(`status.${order.status.toLowerCase()}`) }}
+                  </span>
+                </td>
+                <td class="col-date">{{ formatDate(order.order_date) }}</td>
+                <td class="col-lead-time">{{ t('orders.leadTimeDays', { days: order.lead_time_days }) }}</td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Regular orders table (excludes restocking orders) -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
+          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ regularOrders.length }})</h3>
         </div>
         <div class="table-container">
           <table class="orders-table">
@@ -45,7 +100,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="order in orders" :key="order.id">
+              <tr v-for="order in regularOrders" :key="order.id">
                 <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
                 <td class="col-customer">{{ translateCustomerName(order.customer) }}</td>
                 <td class="col-items">
@@ -129,8 +184,18 @@ export default {
       loadOrders()
     })
 
-    const getOrdersByStatus = (status) => {
-      return orders.value.filter(order => order.status === status)
+    // Partition orders: restocking orders are shown in their own section;
+    // regular orders drive the main table and the stat card counts.
+    const restockingOrders = computed(() =>
+      orders.value.filter(o => o.source === 'restocking')
+    )
+    const regularOrders = computed(() =>
+      orders.value.filter(o => o.source !== 'restocking')
+    )
+
+    // Status counts are scoped to regular orders so the dashboard math stays consistent
+    const getRegularOrdersByStatus = (status) => {
+      return regularOrders.value.filter(order => order.status === status)
     }
 
     const getOrderStatusClass = (status) => {
@@ -160,7 +225,9 @@ export default {
       loading,
       error,
       orders,
-      getOrdersByStatus,
+      restockingOrders,
+      regularOrders,
+      getRegularOrdersByStatus,
       getOrderStatusClass,
       formatDate,
       currencySymbol,
@@ -201,6 +268,17 @@ export default {
 
 .col-value {
   width: 120px;
+}
+
+.col-lead-time {
+  width: 110px;
+}
+
+/* Sub-description under submitted orders card title */
+.card-sub-description {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-top: 0.25rem;
 }
 
 /* Items details styling */

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,389 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Budget Card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.availableBudget') }}</h3>
+        </div>
+        <div class="budget-body">
+          <div class="budget-slider-block">
+            <label class="budget-slider-label">
+              {{ formatCurrency(budget, currentCurrency) }}
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="500000"
+              step="5000"
+              v-model.number="budget"
+              class="budget-slider"
+            />
+            <div class="slider-range-labels">
+              <span>{{ formatCurrency(0, currentCurrency) }}</span>
+              <span>{{ formatCurrency(500000, currentCurrency) }}</span>
+            </div>
+          </div>
+          <div class="budget-stats">
+            <div class="budget-stat-card">
+              <div class="budget-stat-label">{{ t('restocking.recommendedTotal') }}</div>
+              <div class="budget-stat-value">{{ formatCurrency(totalCost, currentCurrency) }}</div>
+            </div>
+            <div class="budget-stat-card" :class="{ 'over-budget': budgetRemaining < 0 }">
+              <div class="budget-stat-label">{{ t('restocking.budgetRemaining') }}</div>
+              <div class="budget-stat-value">{{ formatCurrency(budgetRemaining, currentCurrency) }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Success Banner -->
+      <div v-if="submittedOrderNumber" class="success-banner">
+        {{ t('restocking.submittedMessage', { orderNumber: submittedOrderNumber }) }}
+      </div>
+
+      <!-- Recommendations Card -->
+      <div class="card">
+        <div class="card-header">
+          <div>
+            <h3 class="card-title">{{ t('restocking.recommendations') }}</h3>
+            <p class="card-description">{{ t('restocking.recommendationsDescription') }}</p>
+          </div>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>{{ t('restocking.table.sku') }}</th>
+                <th>{{ t('restocking.table.itemName') }}</th>
+                <th>{{ t('restocking.table.trend') }}</th>
+                <th>{{ t('restocking.table.restockQty') }}</th>
+                <th>{{ t('restocking.table.unitCost') }}</th>
+                <th>{{ t('restocking.table.subtotal') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-if="recommendations.length === 0">
+                <td colspan="6" class="empty-state">{{ t('restocking.noItemsFit') }}</td>
+              </tr>
+              <!-- Use item.id as key per CLAUDE.md — never use index -->
+              <tr v-for="item in recommendations" :key="item.id">
+                <td><strong>{{ item.item_sku }}</strong></td>
+                <td>{{ item.item_name }}</td>
+                <td>
+                  <span :class="['badge', getTrendBadgeClass(item.trend)]">
+                    {{ t(`trends.${item.trend}`) }}
+                  </span>
+                </td>
+                <td>{{ item.restock_quantity }}</td>
+                <td>{{ formatCurrency(item.unit_cost, currentCurrency) }}</td>
+                <td><strong>{{ formatCurrency(item.subtotal, currentCurrency) }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="place-order-footer">
+          <button
+            class="btn-primary"
+            :disabled="recommendations.length === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? t('restocking.placing') : t('restocking.placeOrder') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+import { formatCurrency } from '../utils/currency'
+
+const DEFAULT_BUDGET = 100000
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency } = useI18n()
+
+    // --- Raw state refs ---
+    const forecasts = ref([])
+    const inventory = ref([])
+    const loading = ref(false)
+    const error = ref(null)
+    const submitting = ref(false)
+    const submittedOrderNumber = ref(null)
+    const budget = ref(DEFAULT_BUDGET)
+
+    // --- Derived lookup: SKU -> inventory item ---
+    const inventoryBySku = computed(() =>
+      Object.fromEntries(inventory.value.map(i => [i.sku, i]))
+    )
+
+    // --- Candidates: all forecast rows with a positive restock gap and a known price ---
+    // restock_quantity = max(0, forecasted_demand - current_demand)
+    // Items with zero gap or missing price are excluded (nothing to order / can't value them)
+    const candidates = computed(() => {
+      return forecasts.value
+        .map(f => {
+          const restock_quantity = Math.max(0, (f.forecasted_demand ?? 0) - (f.current_demand ?? 0))
+          const invItem = inventoryBySku.value[f.item_sku]
+          const unit_cost = invItem?.unit_cost ?? 0
+          const subtotal = restock_quantity * unit_cost
+          return { ...f, restock_quantity, unit_cost, subtotal }
+        })
+        .filter(c => c.restock_quantity > 0 && c.unit_cost > 0)
+        .sort((a, b) => {
+          // Increasing trend first, then by subtotal desc, then SKU as tiebreaker
+          const trendOrder = { increasing: 0, stable: 1, decreasing: 2 }
+          const ta = trendOrder[a.trend] ?? 3
+          const tb = trendOrder[b.trend] ?? 3
+          if (ta !== tb) return ta - tb
+          if (b.subtotal !== a.subtotal) return b.subtotal - a.subtotal
+          return a.item_sku.localeCompare(b.item_sku)
+        })
+    })
+
+    // --- Greedy fit: include each candidate whose running total still fits in budget.
+    //     We scan ALL candidates rather than stopping at the first overflow, because a
+    //     cheaper item appearing later may still fit within the remaining budget.
+    const recommendations = computed(() => {
+      let running = 0
+      const result = []
+      for (const c of candidates.value) {
+        if (running + c.subtotal <= budget.value) {
+          running += c.subtotal
+          result.push(c)
+        }
+      }
+      return result
+    })
+
+    const totalCost = computed(() =>
+      recommendations.value.reduce((sum, r) => sum + r.subtotal, 0)
+    )
+
+    const budgetRemaining = computed(() => budget.value - totalCost.value)
+
+    // --- Data loading ---
+    const loadData = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        const [forecastData, inventoryData] = await Promise.all([
+          api.getDemandForecasts(),
+          api.getInventory()
+        ])
+        forecasts.value = forecastData
+        inventory.value = inventoryData
+      } catch (err) {
+        error.value = t('common.error') + ': ' + err.message
+        console.error('Restocking load error:', err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    // --- Place order ---
+    const placeOrder = async () => {
+      if (recommendations.value.length === 0 || submitting.value) return
+
+      submitting.value = true
+      error.value = null
+      try {
+        const payload = {
+          items: recommendations.value.map(r => ({
+            sku: r.item_sku,
+            name: r.item_name,
+            quantity: r.restock_quantity,
+            unit_price: r.unit_cost
+          })),
+          total_value: totalCost.value
+        }
+        const response = await api.createRestockingOrder(payload)
+        submittedOrderNumber.value = response.order_number
+
+        // Auto-clear the success banner after 8 seconds
+        setTimeout(() => {
+          submittedOrderNumber.value = null
+        }, 8000)
+      } catch (err) {
+        error.value = 'Failed to place order: ' + err.message
+        console.error('Restocking order error:', err)
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    // --- Trend badge: mirror Demand.vue color semantics ---
+    // increasing -> success (green), stable -> info (blue), decreasing -> warning (amber)
+    const getTrendBadgeClass = (trend) => {
+      const map = { increasing: 'success', stable: 'info', decreasing: 'warning' }
+      return map[trend] ?? 'info'
+    }
+
+    onMounted(loadData)
+
+    return {
+      t,
+      currentCurrency,
+      budget,
+      loading,
+      error,
+      submitting,
+      submittedOrderNumber,
+      recommendations,
+      totalCost,
+      budgetRemaining,
+      placeOrder,
+      getTrendBadgeClass,
+      formatCurrency
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* Budget card body: slider on the left (~60%), stat blocks on the right */
+.budget-body {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+.budget-slider-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.budget-slider-label {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+/* Label style matched to FilterBar .filter-group label */
+.budget-slider-block label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.budget-slider {
+  width: 100%;
+  accent-color: #0f172a;
+  cursor: pointer;
+  height: 6px;
+}
+
+.slider-range-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.budget-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.budget-stat-card {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.875rem 1.125rem;
+}
+
+.budget-stat-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
+}
+
+.budget-stat-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.budget-stat-card.over-budget .budget-stat-value {
+  color: #dc2626;
+}
+
+/* Card description (sub-title under card-title in the recommendations header) */
+.card-description {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-top: 0.25rem;
+}
+
+/* Empty-state row */
+.empty-state {
+  color: #64748b;
+  text-align: center;
+  padding: 2rem;
+  font-style: italic;
+}
+
+/* Place Order button footer */
+.place-order-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
+  border-top: 1px solid #e2e8f0;
+  margin-top: 0.5rem;
+}
+
+.btn-primary {
+  background: #0f172a;
+  color: white;
+  padding: 0.6rem 1.5rem;
+  border-radius: 6px;
+  border: none;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1e293b;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Success banner */
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 0.875rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  font-weight: 500;
+  margin-bottom: 1.25rem;
+}
+</style>

--- a/server/main.py
+++ b/server/main.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+
+# Lead time applied to every internal restocking order (calendar days).
+# Per product spec: fixed 14-day default; not configurable from the UI.
+RESTOCKING_LEAD_TIME_DAYS = 14
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -80,6 +86,10 @@ class Order(BaseModel):
     actual_delivery: Optional[str] = None
     warehouse: Optional[str] = None
     category: Optional[str] = None
+    # Tags an order as internally generated (e.g. "restocking") so the
+    # Orders view can partition it into its own section.
+    source: Optional[str] = None
+    lead_time_days: Optional[int] = None
 
 class DemandForecast(BaseModel):
     id: str
@@ -119,6 +129,16 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_price: float
+
+class CreateRestockingOrderRequest(BaseModel):
+    items: List[RestockingOrderItem]
+    total_value: float
 
 # API endpoints
 @app.get("/")
@@ -160,6 +180,38 @@ def get_order(order_id: str):
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
     return order
+
+@app.post("/api/orders/restock", response_model=Order)
+def create_restocking_order(payload: CreateRestockingOrderRequest):
+    """Create an internal restocking order from the Restocking page."""
+    if not payload.items:
+        raise HTTPException(status_code=400, detail="At least one item is required")
+
+    # Order numbers count existing restocking orders so submissions in
+    # the same session get monotonically increasing identifiers.
+    existing_count = sum(1 for o in orders if o.get("source") == "restocking")
+    order_number = f"RST-2025-{existing_count + 1:04d}"
+
+    now = datetime.now()
+    new_order = {
+        "id": str(uuid4()),
+        "order_number": order_number,
+        "customer": "Internal Restocking",
+        "items": [item.model_dump() for item in payload.items],
+        "status": "Processing",
+        "order_date": now.isoformat(),
+        "expected_delivery": (now + timedelta(days=RESTOCKING_LEAD_TIME_DAYS)).isoformat(),
+        "total_value": payload.total_value,
+        "actual_delivery": None,
+        "warehouse": None,
+        "category": None,
+        "source": "restocking",
+        "lead_time_days": RESTOCKING_LEAD_TIME_DAYS,
+    }
+    # Mutates the module-level orders list so subsequent GETs surface it
+    # without a backend restart. Resets on process restart (demo only).
+    orders.append(new_order)
+    return new_order
 
 @app.get("/api/demand", response_model=List[DemandForecast])
 def get_demand_forecasts():


### PR DESCRIPTION
- New /restocking view: budget slider drives a greedy auto-pick of demand-forecast items priced from inventory.json
- POST /api/orders/restock endpoint appends to the in-memory orders list with source="restocking" and a fixed 14-day lead time
- Orders view gains a Submitted Orders section above the main table that surfaces restocking submissions with the lead-time column; restocking orders are filtered out of the regular orders table
- Static architecture.html at the repo root documents the system layout for new contributors