### PR TITLE
Add Restocking tab, SaaS sidebar redesign, and collapsible nav

### DIFF
--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,747 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventory Management — System Architecture</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    /* ── Layout ── */
+    .page { max-width: 1200px; margin: 0 auto; padding: 48px 32px 80px; }
+
+    /* ── Header ── */
+    header { margin-bottom: 56px; }
+    header h1 { font-size: 2rem; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px; }
+    header p  { color: #94a3b8; margin-top: 6px; font-size: 0.95rem; }
+
+    /* ── Section titles ── */
+    .section { margin-bottom: 56px; }
+    .section-title {
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #64748b;
+      margin-bottom: 20px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid #1e293b;
+    }
+
+    /* ── Cards ── */
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 20px 24px;
+    }
+    .card-title {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #94a3b8;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 10px;
+    }
+
+    /* ── Tech Stack grid ── */
+    .stack-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 12px;
+    }
+    .stack-item {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 16px 20px;
+    }
+    .stack-item .layer {
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #64748b;
+      margin-bottom: 4px;
+    }
+    .stack-item .name { font-size: 0.95rem; font-weight: 600; color: #f1f5f9; }
+    .stack-item .detail { font-size: 0.8rem; color: #94a3b8; margin-top: 2px; }
+
+    /* ── Architecture diagram ── */
+    .arch-diagram {
+      display: grid;
+      grid-template-columns: 1fr 48px 1fr 48px 1fr;
+      align-items: start;
+      gap: 0;
+    }
+    .arch-layer {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 20px;
+    }
+    .arch-layer-title {
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 14px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #334155;
+    }
+    .arch-layer.frontend .arch-layer-title { color: #60a5fa; }
+    .arch-layer.backend  .arch-layer-title { color: #34d399; }
+    .arch-layer.data     .arch-layer-title { color: #f59e0b; }
+
+    .arch-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      padding: 7px 0;
+      border-bottom: 1px solid #0f172a;
+      font-size: 0.82rem;
+    }
+    .arch-item:last-child { border-bottom: none; }
+    .arch-item .dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      margin-top: 6px;
+      flex-shrink: 0;
+    }
+    .frontend .dot { background: #3b82f6; }
+    .backend  .dot { background: #10b981; }
+    .data     .dot { background: #d97706; }
+
+    .arch-item .item-name { color: #e2e8f0; font-weight: 500; }
+    .arch-item .item-desc { color: #64748b; font-size: 0.75rem; margin-top: 1px; }
+
+    .arch-arrow {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding-top: 60px;
+      gap: 6px;
+      color: #475569;
+      font-size: 0.65rem;
+      text-align: center;
+      line-height: 1.4;
+    }
+    .arch-arrow svg { opacity: 0.5; }
+
+    /* ── Data flow ── */
+    .flow-steps {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+    .flow-step {
+      display: grid;
+      grid-template-columns: 28px 1fr;
+      gap: 16px;
+      align-items: start;
+    }
+    .flow-connector {
+      display: grid;
+      grid-template-columns: 28px 1fr;
+      gap: 16px;
+      height: 24px;
+    }
+    .flow-connector .line {
+      display: flex;
+      justify-content: center;
+    }
+    .flow-connector .line::before {
+      content: '';
+      width: 2px;
+      height: 100%;
+      background: #334155;
+    }
+    .step-number {
+      width: 28px; height: 28px;
+      border-radius: 50%;
+      background: #334155;
+      color: #94a3b8;
+      font-size: 0.75rem;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .step-body { padding-bottom: 4px; }
+    .step-title { font-size: 0.88rem; font-weight: 600; color: #f1f5f9; }
+    .step-desc  { font-size: 0.8rem; color: #94a3b8; margin-top: 2px; }
+    .step-code  {
+      display: inline-block;
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      padding: 2px 8px;
+      font-family: "SF Mono", "Fira Code", monospace;
+      font-size: 0.72rem;
+      color: #93c5fd;
+      margin-top: 5px;
+    }
+
+    /* ── API endpoints table ── */
+    .endpoint-group { margin-bottom: 28px; }
+    .endpoint-group-title {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #64748b;
+      margin-bottom: 10px;
+    }
+    .endpoint-row {
+      display: grid;
+      grid-template-columns: 52px 260px 1fr;
+      gap: 12px;
+      align-items: baseline;
+      padding: 8px 0;
+      border-bottom: 1px solid #1e293b;
+      font-size: 0.82rem;
+    }
+    .endpoint-row:last-child { border-bottom: none; }
+    .method {
+      font-family: "SF Mono", "Fira Code", monospace;
+      font-size: 0.68rem;
+      font-weight: 700;
+      border-radius: 4px;
+      padding: 2px 6px;
+      text-align: center;
+    }
+    .method.get  { background: #0c4a6e; color: #38bdf8; }
+    .method.post { background: #14532d; color: #4ade80; }
+    .method.patch{ background: #431407; color: #fb923c; }
+    .method.del  { background: #4c0519; color: #f87171; }
+    .endpoint-path {
+      font-family: "SF Mono", "Fira Code", monospace;
+      color: #e2e8f0;
+      font-size: 0.78rem;
+    }
+    .endpoint-desc { color: #94a3b8; }
+    .param-tag {
+      display: inline-block;
+      background: #1e3a5f;
+      color: #7dd3fc;
+      border-radius: 3px;
+      padding: 1px 6px;
+      font-size: 0.68rem;
+      font-family: monospace;
+      margin-left: 4px;
+    }
+
+    /* ── Views grid ── */
+    .views-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 12px;
+    }
+    .view-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 16px 20px;
+    }
+    .view-route {
+      font-family: monospace;
+      font-size: 0.72rem;
+      color: #60a5fa;
+      margin-bottom: 4px;
+    }
+    .view-name { font-weight: 600; font-size: 0.92rem; color: #f1f5f9; margin-bottom: 6px; }
+    .view-desc { font-size: 0.8rem; color: #94a3b8; margin-bottom: 10px; }
+    .filter-tags { display: flex; flex-wrap: wrap; gap: 5px; }
+    .filter-tag {
+      font-size: 0.67rem;
+      border-radius: 4px;
+      padding: 2px 7px;
+      font-weight: 500;
+    }
+    .tag-period   { background: #312e81; color: #a5b4fc; }
+    .tag-location { background: #134e4a; color: #6ee7b7; }
+    .tag-category { background: #1c1917; color: #a8a29e; border: 1px solid #44403c; }
+    .tag-status   { background: #422006; color: #fcd34d; }
+
+    /* ── Footer ── */
+    footer {
+      margin-top: 64px;
+      padding-top: 24px;
+      border-top: 1px solid #1e293b;
+      font-size: 0.78rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <h1>Factory Inventory Management</h1>
+    <p>System Architecture &mdash; Full-stack Vue 3 + FastAPI demo application</p>
+  </header>
+
+  <!-- ── 1. Tech Stack ── -->
+  <section class="section">
+    <div class="section-title">Tech Stack</div>
+    <div class="stack-grid">
+      <div class="stack-item">
+        <div class="layer">Frontend</div>
+        <div class="name">Vue 3</div>
+        <div class="detail">Composition API &middot; SPA</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">Build Tool</div>
+        <div class="name">Vite</div>
+        <div class="detail">Port 3000 &middot; HMR</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">Routing</div>
+        <div class="name">Vue Router 4</div>
+        <div class="detail">7 client-side routes</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">HTTP Client</div>
+        <div class="name">Axios</div>
+        <div class="detail">Centralized in api.js</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">Backend</div>
+        <div class="name">FastAPI</div>
+        <div class="detail">Python &middot; Port 8001</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">Validation</div>
+        <div class="name">Pydantic</div>
+        <div class="detail">Request &amp; response models</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">Data</div>
+        <div class="name">JSON Files</div>
+        <div class="detail">In-memory &middot; No DB</div>
+      </div>
+      <div class="stack-item">
+        <div class="layer">i18n</div>
+        <div class="name">EN &amp; JA</div>
+        <div class="detail">useI18n composable</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 2. System Architecture ── -->
+  <section class="section">
+    <div class="section-title">System Architecture</div>
+    <div class="arch-diagram">
+
+      <!-- Frontend -->
+      <div class="arch-layer frontend">
+        <div class="arch-layer-title">Frontend &mdash; :3000</div>
+
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">App.vue</div>
+            <div class="item-desc">Root layout, navbar, FilterBar</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">Views (7)</div>
+            <div class="item-desc">Dashboard · Inventory · Orders · Demand · Spending · Reports · Backlog</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">Components (12+)</div>
+            <div class="item-desc">FilterBar · Modals · ProfileMenu · LanguageSwitcher</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">Composables</div>
+            <div class="item-desc">useFilters · useI18n · useAuth</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">api.js</div>
+            <div class="item-desc">20+ Axios methods, query param builder</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Arrow -->
+      <div class="arch-arrow">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M4 10h12M12 6l4 4-4 4" stroke="#64748b" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <div>HTTP<br/>REST</div>
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M16 10H4M8 6L4 10l4 4" stroke="#64748b" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+
+      <!-- Backend -->
+      <div class="arch-layer backend">
+        <div class="arch-layer-title">Backend &mdash; :8001</div>
+
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">main.py</div>
+            <div class="item-desc">FastAPI app, 21 endpoints, CORS</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">Filter logic</div>
+            <div class="item-desc">apply_filters() · filter_by_month()</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">Pydantic models</div>
+            <div class="item-desc">InventoryItem · Order · DemandForecast · BacklogItem</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">mock_data.py</div>
+            <div class="item-desc">JSON loader, in-memory data store</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">Tests</div>
+            <div class="item-desc">pytest · FastAPI TestClient</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Arrow -->
+      <div class="arch-arrow">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M4 10h12M12 6l4 4-4 4" stroke="#64748b" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <div>reads</div>
+      </div>
+
+      <!-- Data -->
+      <div class="arch-layer data">
+        <div class="arch-layer-title">Data &mdash; server/data/</div>
+
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">inventory.json</div>
+            <div class="item-desc">~30 SKUs, 5 categories, 2 warehouses</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">orders.json</div>
+            <div class="item-desc">~100+ orders, 2025, all statuses</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">backlog_items.json</div>
+            <div class="item-desc">Shortages with priority flags</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">demand_forecasts.json</div>
+            <div class="item-desc">Trend: increasing / stable / decreasing</div>
+          </div>
+        </div>
+        <div class="arch-item">
+          <div class="dot"></div>
+          <div>
+            <div class="item-name">spending.json &amp; transactions.json</div>
+            <div class="item-desc">Finance, cost breakdown, monthly data</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── 3. Data Flow ── -->
+  <section class="section">
+    <div class="section-title">Filter Data Flow</div>
+    <div class="flow-steps">
+
+      <div class="flow-step">
+        <div class="step-number">1</div>
+        <div class="step-body">
+          <div class="step-title">User sets a filter</div>
+          <div class="step-desc">FilterBar.vue renders 4 dropdowns: Period, Location, Category, Status. Selection updates the shared composable.</div>
+          <div class="step-code">useFilters() → selectedPeriod.value = '2025-03'</div>
+        </div>
+      </div>
+      <div class="flow-connector"><div class="line"></div></div>
+
+      <div class="flow-step">
+        <div class="step-number">2</div>
+        <div class="step-body">
+          <div class="step-title">Views react to changes</div>
+          <div class="step-desc">Each view watches the filter refs. Any change triggers a data reload via <code style="color:#93c5fd;background:#0f172a;padding:1px 5px;border-radius:3px;font-size:0.78rem">watch([selectedPeriod, ...], loadData)</code>.</div>
+          <div class="step-code">Dashboard.vue, Orders.vue, Inventory.vue, …</div>
+        </div>
+      </div>
+      <div class="flow-connector"><div class="line"></div></div>
+
+      <div class="flow-step">
+        <div class="step-number">3</div>
+        <div class="step-body">
+          <div class="step-title">API client builds query string</div>
+          <div class="step-desc">api.js calls getCurrentFilters(), skips 'all' values, and appends remaining params to the URL.</div>
+          <div class="step-code">GET /api/orders?warehouse=Chicago&amp;status=Shipped&amp;month=2025-03</div>
+        </div>
+      </div>
+      <div class="flow-connector"><div class="line"></div></div>
+
+      <div class="flow-step">
+        <div class="step-number">4</div>
+        <div class="step-body">
+          <div class="step-title">Backend filters in memory</div>
+          <div class="step-desc">FastAPI parses query params, runs apply_filters() for warehouse/category/status, and filter_by_month() for period (handles both YYYY-MM and Q1-2025 formats).</div>
+          <div class="step-code">apply_filters(items, warehouse, category, status)</div>
+        </div>
+      </div>
+      <div class="flow-connector"><div class="line"></div></div>
+
+      <div class="flow-step">
+        <div class="step-number">5</div>
+        <div class="step-body">
+          <div class="step-title">Validated response returned</div>
+          <div class="step-desc">Pydantic validates the filtered array and FastAPI serialises to JSON. Frontend receives it and Vue updates the DOM reactively.</div>
+          <div class="step-code">response.data → view ref → computed → template</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── 4. Frontend Views ── -->
+  <section class="section">
+    <div class="section-title">Frontend Views</div>
+    <div class="views-grid">
+
+      <div class="view-card">
+        <div class="view-route">/ &nbsp;·&nbsp; Dashboard.vue</div>
+        <div class="view-name">Dashboard</div>
+        <div class="view-desc">KPI cards, order health donut, inventory by category, top products &amp; shortages tables.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-period">period</span>
+          <span class="filter-tag tag-location">location</span>
+          <span class="filter-tag tag-category">category</span>
+          <span class="filter-tag tag-status">status</span>
+        </div>
+      </div>
+
+      <div class="view-card">
+        <div class="view-route">/inventory &nbsp;·&nbsp; Inventory.vue</div>
+        <div class="view-name">Inventory</div>
+        <div class="view-desc">Stock table with real-time search. SKU, quantity on hand, reorder point, unit cost, status badges.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-location">location</span>
+          <span class="filter-tag tag-category">category</span>
+        </div>
+      </div>
+
+      <div class="view-card">
+        <div class="view-route">/orders &nbsp;·&nbsp; Orders.vue</div>
+        <div class="view-name">Orders</div>
+        <div class="view-desc">Full order list with expandable line items, status breakdown stats, and order detail modal.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-period">period</span>
+          <span class="filter-tag tag-location">location</span>
+          <span class="filter-tag tag-category">category</span>
+          <span class="filter-tag tag-status">status</span>
+        </div>
+      </div>
+
+      <div class="view-card">
+        <div class="view-route">/backlog &nbsp;·&nbsp; Backlog.vue</div>
+        <div class="view-name">Backlog</div>
+        <div class="view-desc">Inventory shortages by priority. Shows qty needed vs available, days delayed, and PO status.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-location">location</span>
+          <span class="filter-tag tag-category">category</span>
+        </div>
+      </div>
+
+      <div class="view-card">
+        <div class="view-route">/demand &nbsp;·&nbsp; Demand.vue</div>
+        <div class="view-name">Demand Forecasting</div>
+        <div class="view-desc">Trend cards (increasing / stable / decreasing) with current vs forecasted demand and % change.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-category" style="background:#1c1917;color:#a8a29e;border:1px solid #44403c">no filters</span>
+        </div>
+      </div>
+
+      <div class="view-card">
+        <div class="view-route">/spending &nbsp;·&nbsp; Spending.vue</div>
+        <div class="view-name">Spending</div>
+        <div class="view-desc">Revenue vs costs bar charts, monthly cost flow, category breakdown, recent transactions.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-period">period</span>
+        </div>
+      </div>
+
+      <div class="view-card">
+        <div class="view-route">/reports &nbsp;·&nbsp; Reports.vue</div>
+        <div class="view-name">Reports</div>
+        <div class="view-desc">Quarterly performance table and monthly revenue trend chart. YTD summary statistics.</div>
+        <div class="filter-tags">
+          <span class="filter-tag tag-category" style="background:#1c1917;color:#a8a29e;border:1px solid #44403c">no filters</span>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── 5. API Endpoints ── -->
+  <section class="section">
+    <div class="section-title">API Endpoints</div>
+
+    <div class="endpoint-group">
+      <div class="endpoint-group-title">Inventory</div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/inventory</span>
+        <span class="endpoint-desc">All items<span class="param-tag">warehouse</span><span class="param-tag">category</span></span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/inventory/{item_id}</span>
+        <span class="endpoint-desc">Single item detail</span>
+      </div>
+    </div>
+
+    <div class="endpoint-group">
+      <div class="endpoint-group-title">Orders</div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/orders</span>
+        <span class="endpoint-desc">All orders<span class="param-tag">warehouse</span><span class="param-tag">category</span><span class="param-tag">status</span><span class="param-tag">month</span></span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/orders/{order_id}</span>
+        <span class="endpoint-desc">Single order detail</span>
+      </div>
+    </div>
+
+    <div class="endpoint-group">
+      <div class="endpoint-group-title">Dashboard, Demand &amp; Backlog</div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/dashboard/summary</span>
+        <span class="endpoint-desc">KPI aggregates<span class="param-tag">warehouse</span><span class="param-tag">category</span><span class="param-tag">status</span><span class="param-tag">month</span></span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/demand</span>
+        <span class="endpoint-desc">Demand forecasts (no filters)</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/backlog</span>
+        <span class="endpoint-desc">Inventory shortages (no filters)</span>
+      </div>
+    </div>
+
+    <div class="endpoint-group">
+      <div class="endpoint-group-title">Spending &amp; Reports</div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/spending/summary</span>
+        <span class="endpoint-desc">Revenue, cost, profit totals</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/spending/monthly</span>
+        <span class="endpoint-desc">Month-by-month cost breakdown</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/spending/categories</span>
+        <span class="endpoint-desc">Spending by category</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/spending/transactions</span>
+        <span class="endpoint-desc">Recent transactions list</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/reports/quarterly</span>
+        <span class="endpoint-desc">Quarterly performance metrics</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/reports/monthly-trends</span>
+        <span class="endpoint-desc">Month-over-month order &amp; revenue</span>
+      </div>
+    </div>
+
+    <div class="endpoint-group">
+      <div class="endpoint-group-title">Purchase Orders &amp; Tasks (stubs)</div>
+      <div class="endpoint-row">
+        <span class="method post">POST</span>
+        <span class="endpoint-path">/api/purchase-orders</span>
+        <span class="endpoint-desc">Create PO for backlog item</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method get">GET</span>
+        <span class="endpoint-path">/api/purchase-orders/{backlog_item_id}</span>
+        <span class="endpoint-desc">Get PO by backlog item</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method post">POST</span>
+        <span class="endpoint-path">/api/tasks</span>
+        <span class="endpoint-desc">Create task</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method patch">PATCH</span>
+        <span class="endpoint-path">/api/tasks/{task_id}</span>
+        <span class="endpoint-desc">Toggle task completion</span>
+      </div>
+      <div class="endpoint-row">
+        <span class="method del">DELETE</span>
+        <span class="endpoint-path">/api/tasks/{task_id}</span>
+        <span class="endpoint-desc">Delete task</span>
+      </div>
+    </div>
+
+  </section>
+
+  <footer>
+    Factory Inventory Management &mdash; Architecture Reference &mdash; Generated 2026-05-26
+  </footer>
+
+</div>
+</body>
+</html>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1370,6 +1370,7 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -1429,6 +1430,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,48 +1,54 @@
 <template>
-  <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
+  <div :class="['app-shell', { 'sidebar-collapsed': collapsed }]">
+    <!-- LEFT SIDEBAR -->
+    <aside :class="['sidebar', { collapsed }]">
+      <div class="sidebar-header">
+        <div class="sidebar-brand" v-show="!collapsed">
+          <div class="logo-name">{{ t('nav.companyName') }}</div>
+          <div class="logo-subtitle">{{ t('nav.subtitle') }}</div>
         </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
-        <LanguageSwitcher />
+        <button class="sidebar-toggle" @click="toggleSidebar" :title="collapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+          <span class="toggle-icon">{{ collapsed ? '›' : '‹' }}</span>
+        </button>
+      </div>
+
+      <nav class="sidebar-nav">
+        <router-link
+          v-for="item in navItems"
+          :key="item.path"
+          :to="item.path"
+          :class="['nav-item', { active: $route.path === item.path }]"
+          :title="collapsed ? t(item.labelKey) : ''"
+        >
+          <span class="nav-icon">{{ item.icon }}</span>
+          <span class="nav-label" v-show="!collapsed">{{ t(item.labelKey) }}</span>
+        </router-link>
+      </nav>
+
+      <div class="sidebar-spacer"></div>
+
+      <div :class="['sidebar-footer', { collapsed }]">
+        <LanguageSwitcher v-show="!collapsed" />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    </aside>
 
+    <!-- RIGHT CONTENT -->
+    <div class="content-area">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
+
+    <!-- MODALS (unchanged) -->
     <ProfileDetailsModal
       :is-open="showProfileDetails"
       @close="showProfileDetails = false"
     />
-
     <TasksModal
       :is-open="showTasks"
       :tasks="tasks"
@@ -55,7 +61,7 @@
 </template>
 
 <script>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
@@ -80,6 +86,32 @@ export default {
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
+
+    // Collapsed state — auto-collapse on viewports narrower than 1024px
+    const collapsed = ref(false)
+
+    const toggleSidebar = () => {
+      collapsed.value = !collapsed.value
+    }
+
+    // Auto-collapse on small screens and keep in sync on resize
+    const mq = window.matchMedia('(max-width: 1024px)')
+    const handleMq = (e) => { collapsed.value = e.matches }
+    collapsed.value = mq.matches
+
+    onUnmounted(() => mq.removeEventListener('change', handleMq))
+    // register listener — done after collapsed.value is set so no double-trigger on mount
+    mq.addEventListener('change', handleMq)
+
+    const navItems = [
+      { path: '/',            labelKey: 'nav.overview',       icon: '◈' },
+      { path: '/inventory',   labelKey: 'nav.inventory',      icon: '▤' },
+      { path: '/orders',      labelKey: 'nav.orders',         icon: '◎' },
+      { path: '/spending',    labelKey: 'nav.finance',        icon: '◇' },
+      { path: '/demand',      labelKey: 'nav.demandForecast', icon: '↗' },
+      { path: '/reports',     labelKey: 'nav.reports',        icon: '▦' },
+      { path: '/restocking',  labelKey: 'nav.restocking',     icon: '↺' },
+    ]
 
     // Merge mock tasks from currentUser with API tasks
     const tasks = computed(() => {
@@ -150,18 +182,40 @@ export default {
 
     return {
       t,
+      navItems,
       showProfileDetails,
       showTasks,
       tasks,
       addTask,
       deleteTask,
-      toggleTask
+      toggleTask,
+      collapsed,
+      toggleSidebar,
     }
   }
 }
 </script>
 
 <style>
+:root {
+  --color-bg: #f8fafc;
+  --color-sidebar-bg: #ffffff;
+  --color-sidebar-border: #e2e8f0;
+  --color-surface: #ffffff;
+  --color-border: #e2e8f0;
+  --color-text-primary: #0f172a;
+  --color-text-muted: #64748b;
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+  --color-accent-subtle: rgba(37, 99, 235, 0.08);
+  --color-nav-hover: rgba(37, 99, 235, 0.05);
+  --sidebar-width: 240px;
+  --sidebar-width-collapsed: 56px;
+  --sidebar-transition: 0.22s ease;
+  --content-padding: 1.5rem 2rem;
+  --border-radius: 10px;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -170,108 +224,10 @@ export default {
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
+  background: var(--color-bg);
+  color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-.app {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
-}
-
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
-}
-
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
-}
-
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
-}
-
-.main-content {
-  flex: 1;
-  max-width: 1600px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 1.5rem 2rem;
 }
 
 .page-header {
@@ -281,13 +237,13 @@ body {
 .page-header h2 {
   font-size: 1.875rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-primary);
   margin-bottom: 0.375rem;
   letter-spacing: -0.025em;
 }
 
 .page-header p {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.938rem;
 }
 
@@ -299,10 +255,10 @@ body {
 }
 
 .stat-card {
-  background: white;
+  background: var(--color-surface);
   padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--color-border);
   transition: all 0.2s ease;
 }
 
@@ -312,7 +268,7 @@ body {
 }
 
 .stat-label {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.875rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -323,7 +279,7 @@ body {
 .stat-value {
   font-size: 2.25rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-primary);
   letter-spacing: -0.025em;
 }
 
@@ -340,14 +296,14 @@ body {
 }
 
 .stat-card.info .stat-value {
-  color: #2563eb;
+  color: var(--color-accent);
 }
 
 .card {
-  background: white;
-  border-radius: 10px;
+  background: var(--color-surface);
+  border-radius: var(--border-radius);
   padding: 1.25rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-border);
   margin-bottom: 1.25rem;
 }
 
@@ -357,13 +313,13 @@ body {
   align-items: center;
   margin-bottom: 1rem;
   padding-bottom: 0.875rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .card-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-primary);
   letter-spacing: -0.025em;
 }
 
@@ -377,9 +333,9 @@ table {
 }
 
 thead {
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 th {
@@ -404,7 +360,7 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background: #f8fafc;
+  background: var(--color-bg);
 }
 
 .badge {
@@ -470,7 +426,7 @@ tbody tr:hover {
 .loading {
   text-align: center;
   padding: 3rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.938rem;
 }
 
@@ -482,5 +438,181 @@ tbody tr:hover {
   border-radius: 8px;
   margin: 1rem 0;
   font-size: 0.938rem;
+}
+</style>
+
+<style scoped>
+.app-shell {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.sidebar {
+  background: var(--color-sidebar-bg);
+  border-right: 1px solid var(--color-sidebar-border);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;         /* clips labels during collapse animation */
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  transition: width var(--sidebar-transition), min-width var(--sidebar-transition);
+  flex-shrink: 0;
+}
+
+.sidebar.collapsed {
+  width: var(--sidebar-width-collapsed);
+  min-width: var(--sidebar-width-collapsed);
+}
+
+.sidebar-header {
+  padding: 0.875rem 0.75rem;
+  border-bottom: 1px solid var(--color-sidebar-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 56px;
+}
+
+.sidebar-brand {
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+}
+
+.logo-name {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  letter-spacing: -0.02em;
+}
+
+.logo-subtitle {
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  margin-top: 3px;
+}
+
+.sidebar-toggle {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+  padding: 0;
+}
+
+.sidebar-toggle:hover {
+  background: var(--color-nav-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-accent);
+}
+
+.toggle-icon {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+  /* shift slightly right when showing › to keep optical center */
+  margin-left: 1px;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+  gap: 2px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.nav-item:hover {
+  background: var(--color-nav-hover);
+  color: var(--color-text-primary);
+}
+
+.nav-item.active {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.nav-icon {
+  font-size: 0.9375rem;
+  width: 1.125rem;
+  text-align: center;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.nav-item.active .nav-icon {
+  opacity: 1;
+}
+
+.sidebar.collapsed .nav-item {
+  justify-content: center;
+  padding: 0.5rem;
+}
+
+.sidebar.collapsed .nav-icon {
+  width: auto;
+  font-size: 1.125rem;
+  opacity: 0.7;
+}
+
+.sidebar.collapsed .nav-item.active .nav-icon {
+  opacity: 1;
+}
+
+.sidebar-spacer {
+  flex: 1;
+}
+
+.sidebar-footer {
+  padding: 0.875rem 0.75rem;
+  border-top: 1px solid var(--color-sidebar-border);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sidebar-footer.collapsed {
+  justify-content: center;
+  padding: 0.875rem 0;
+}
+
+.content-area {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--content-padding);
+  background: var(--color-bg);
 }
 </style>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -29,6 +29,11 @@
 
       <div :class="['sidebar-footer', { collapsed }]">
         <LanguageSwitcher v-show="!collapsed" />
+        <button
+          class="dark-mode-toggle"
+          @click="toggleDark"
+          :title="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+        >{{ isDark ? '☀' : '☾' }}</button>
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
@@ -70,6 +75,7 @@ import ProfileMenu from './components/ProfileMenu.vue'
 import ProfileDetailsModal from './components/ProfileDetailsModal.vue'
 import TasksModal from './components/TasksModal.vue'
 import LanguageSwitcher from './components/LanguageSwitcher.vue'
+import { useDarkMode } from './composables/useDarkMode'
 
 export default {
   name: 'App',
@@ -83,6 +89,7 @@ export default {
   setup() {
     const { currentUser } = useAuth()
     const { t } = useI18n()
+    const { isDark, toggleDark } = useDarkMode()
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
@@ -191,6 +198,8 @@ export default {
       toggleTask,
       collapsed,
       toggleSidebar,
+      isDark,
+      toggleDark,
     }
   }
 }
@@ -216,6 +225,20 @@ export default {
   --border-radius: 10px;
 }
 
+[data-theme="dark"] {
+  --color-bg: #0f172a;
+  --color-sidebar-bg: #1e293b;
+  --color-sidebar-border: #334155;
+  --color-surface: #1e293b;
+  --color-border: #334155;
+  --color-text-primary: #f1f5f9;
+  --color-text-muted: #94a3b8;
+  --color-accent: #60a5fa;
+  --color-accent-hover: #93c5fd;
+  --color-accent-subtle: rgba(96, 165, 250, 0.12);
+  --color-nav-hover: rgba(96, 165, 250, 0.08);
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -228,6 +251,7 @@ body {
   color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .page-header {
@@ -600,6 +624,23 @@ tbody tr:hover {
 .sidebar-footer.collapsed {
   justify-content: center;
   padding: 0.875rem 0;
+}
+
+.dark-mode-toggle {
+  background: none;
+  border: 1px solid var(--color-sidebar-border);
+  border-radius: 6px;
+  padding: 0.375rem 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  transition: all 0.15s ease;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.dark-mode-toggle:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .content-area {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,15 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async createRestockingOrder(items) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/orders`, { items })
+    return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/orders`)
+    return response.data
   }
 }

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -106,7 +106,7 @@ export default {
   border-bottom: 1px solid #e2e8f0;
   padding: 0.75rem 0;
   position: sticky;
-  top: 70px;
+  top: 0;
   z-index: 90;
 }
 

--- a/client/src/composables/useDarkMode.js
+++ b/client/src/composables/useDarkMode.js
@@ -1,0 +1,31 @@
+import { ref, watch } from 'vue'
+
+const isDark = ref(false)
+
+// Initialize from localStorage or system preference
+const stored = localStorage.getItem('theme')
+if (stored) {
+  isDark.value = stored === 'dark'
+} else {
+  isDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+// Apply to document root so CSS [data-theme="dark"] selectors work globally
+function applyTheme(dark) {
+  document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light')
+}
+
+applyTheme(isDark.value)
+
+watch(isDark, (val) => {
+  applyTheme(val)
+  localStorage.setItem('theme', val ? 'dark' : 'light')
+})
+
+export function useDarkMode() {
+  const toggleDark = () => {
+    isDark.value = !isDark.value
+  }
+
+  return { isDark, toggleDark }
+}

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,8 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
+    reports: 'Reports',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -185,6 +187,36 @@ export default {
       change: 'Change',
       trend: 'Trend',
       period: 'Period'
+    }
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking Planner',
+    description: 'Set your budget and place restocking orders based on demand forecasts',
+    budgetLabel: 'Available Budget',
+    recommendedItems: 'Recommended Items',
+    noItems: 'Increase the budget to see restocking recommendations',
+    itemsRecommended: 'Items Recommended',
+    estimatedSpend: 'Estimated Spend',
+    remainingBudget: 'Remaining Budget',
+    qtyToOrder: 'Qty to Order',
+    unitCost: 'Unit Cost',
+    lineTotal: 'Line Total',
+    placeOrder: 'Place Order',
+    orderPlaced: 'Order placed successfully',
+    submittedOrders: 'Submitted Restocking Orders',
+    expectedDelivery: 'Expected Delivery',
+    deliveryNote: '7-day lead time',
+    table: {
+      sku: 'SKU',
+      itemName: 'Item Name',
+      trend: 'Trend',
+      currentDemand: 'Current Demand',
+      forecastedDemand: 'Forecasted Demand',
+      qtyToOrder: 'Qty to Order',
+      unitCost: 'Unit Cost',
+      lineTotal: 'Line Total'
     }
   },
 

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,8 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充発注',
+    reports: 'レポート',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -185,6 +187,36 @@ export default {
       change: '変化',
       trend: 'トレンド',
       period: '期間'
+    }
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充計画',
+    description: '予算を設定し、需要予測に基づいて補充注文を行います',
+    budgetLabel: '利用可能予算',
+    recommendedItems: '推奨アイテム',
+    noItems: '予算を増やして補充の推奨事項を確認してください',
+    itemsRecommended: '推奨アイテム数',
+    estimatedSpend: '推定支出',
+    remainingBudget: '残余予算',
+    qtyToOrder: '発注数量',
+    unitCost: '単価',
+    lineTotal: '小計',
+    placeOrder: '発注する',
+    orderPlaced: '発注が完了しました',
+    submittedOrders: '提出済み補充注文',
+    expectedDelivery: '納期予定',
+    deliveryNote: '7日リードタイム',
+    table: {
+      sku: 'SKU',
+      itemName: '品目名',
+      trend: 'トレンド',
+      currentDemand: '現在の需要',
+      forecastedDemand: '予測需要',
+      qtyToOrder: '発注数量',
+      unitCost: '単価',
+      lineTotal: '小計'
     }
   },
 

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -27,6 +27,37 @@
         </div>
       </div>
 
+      <div v-if="restockingOrders.length > 0" class="card restocking-orders-card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.submittedOrders') }}</h3>
+          <span class="badge info">{{ restockingOrders.length }} {{ t('common.items') }}</span>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>{{ t('orders.table.orderNumber') }}</th>
+                <th>{{ t('orders.table.items') }}</th>
+                <th>{{ t('orders.table.totalValue') }}</th>
+                <th>{{ t('orders.table.orderDate') }}</th>
+                <th>{{ t('restocking.expectedDelivery') }}</th>
+                <th>{{ t('orders.table.status') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in restockingOrders" :key="order.order_number">
+                <td><strong>{{ order.order_number }}</strong></td>
+                <td>{{ formatRestockingItems(order.items) }}</td>
+                <td><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+                <td>{{ formatDate(order.order_date) }}</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td><span :class="['badge', getOrderStatusClass(order.status)]">{{ t(`status.${order.status.toLowerCase()}`) }}</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card">
         <div class="card-header">
           <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
@@ -95,6 +126,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -117,11 +149,26 @@ export default {
           const dateB = new Date(b.order_date)
           return dateA - dateB
         })
+        await loadRestockingOrders()
       } catch (err) {
         error.value = 'Failed to load orders: ' + err.message
       } finally {
         loading.value = false
       }
+    }
+
+    const loadRestockingOrders = async () => {
+      try {
+        restockingOrders.value = await api.getRestockingOrders()
+      } catch (err) {
+        // Non-critical: silently ignore if restocking endpoint fails
+        console.error('Failed to load restocking orders:', err)
+      }
+    }
+
+    const formatRestockingItems = (items) => {
+      if (items.length <= 2) return items.map(i => i.name).join(', ')
+      return items.slice(0, 2).map(i => i.name).join(', ') + ` +${items.length - 2} more`
     }
 
     // Watch for filter changes and reload data
@@ -165,13 +212,19 @@ export default {
       formatDate,
       currencySymbol,
       translateProductName,
-      translateCustomerName
+      translateCustomerName,
+      restockingOrders,
+      formatRestockingItems
     }
   }
 }
 </script>
 
 <style scoped>
+.restocking-orders-card {
+  border-left: 3px solid #2563eb;
+}
+
 /* Fixed table layout to prevent column shifting */
 .orders-table {
   table-layout: fixed;

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,296 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <div v-if="orderPlaced" class="success-banner">
+        <span class="checkmark">&#10003;</span>
+        {{ t('restocking.orderPlaced') }}
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.budgetLabel') }}</h3>
+          <span class="budget-display">{{ currencySymbol }}{{ budget.toLocaleString() }}</span>
+        </div>
+        <input
+          type="range"
+          v-model.number="budget"
+          :min="0"
+          :max="maxBudget"
+          :step="100"
+          class="budget-slider"
+        />
+        <div class="summary-pills">
+          <div class="pill">
+            <span class="pill-label">{{ t('restocking.itemsRecommended') }}</span>
+            <span class="pill-value">{{ recommendedItems.length }}</span>
+          </div>
+          <div class="pill">
+            <span class="pill-label">{{ t('restocking.estimatedSpend') }}</span>
+            <span class="pill-value">{{ currencySymbol }}{{ estimatedSpend.toLocaleString() }}</span>
+          </div>
+          <div class="pill">
+            <span class="pill-label">{{ t('restocking.remainingBudget') }}</span>
+            <span class="pill-value">{{ currencySymbol }}{{ remainingBudget.toLocaleString() }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="recommendedItems.length > 0" class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.recommendedItems') }}</h3>
+          <button
+            class="place-order-btn"
+            :disabled="recommendedItems.length === 0 || orderPlaced"
+            @click="placeOrder"
+          >
+            {{ t('restocking.placeOrder') }}
+          </button>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>{{ t('inventory.table.sku') }}</th>
+                <th>{{ t('inventory.table.name') }}</th>
+                <th>{{ t('demand.table.trend') }}</th>
+                <th>{{ t('demand.table.currentDemand') }}</th>
+                <th>{{ t('demand.table.forecastedDemand') }}</th>
+                <th>{{ t('restocking.qtyToOrder') }}</th>
+                <th>{{ t('restocking.unitCost') }}</th>
+                <th>{{ t('restocking.lineTotal') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendedItems" :key="item.id">
+                <td><strong>{{ item.item_sku }}</strong></td>
+                <td>{{ item.item_name }}</td>
+                <td><span :class="['badge', item.trend]">{{ item.trend }}</span></td>
+                <td>{{ item.current_demand.toLocaleString() }}</td>
+                <td>{{ item.forecasted_demand.toLocaleString() }}</td>
+                <td>{{ item.forecasted_demand.toLocaleString() }}</td>
+                <td>{{ currencySymbol }}{{ item.unit_cost.toLocaleString() }}</td>
+                <td><strong>{{ currencySymbol }}{{ (item.unit_cost * item.forecasted_demand).toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div v-else class="card">
+        <div class="empty-state">
+          {{ t('restocking.noItems') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency } = useI18n()
+
+    const forecasts = ref([])
+    const loading = ref(true)
+    const error = ref(null)
+    const budget = ref(0)
+    const orderPlaced = ref(false)
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? '¥' : '$'
+    })
+
+    const maxBudget = computed(() => {
+      return forecasts.value.reduce((sum, item) => {
+        return sum + item.unit_cost * item.forecasted_demand
+      }, 0)
+    })
+
+    const recommendedItems = computed(() => {
+      const sorted = [...forecasts.value].sort((a, b) => {
+        const trendOrder = { increasing: 0, stable: 1, decreasing: 2 }
+        const trendA = trendOrder[a.trend] ?? 1
+        const trendB = trendOrder[b.trend] ?? 1
+        if (trendA !== trendB) return trendA - trendB
+        const diffA = a.forecasted_demand - a.current_demand
+        const diffB = b.forecasted_demand - b.current_demand
+        return diffB - diffA
+      })
+
+      let running = 0
+      const included = []
+      for (const item of sorted) {
+        const lineTotal = item.unit_cost * item.forecasted_demand
+        if (running + lineTotal <= budget.value) {
+          running += lineTotal
+          included.push(item)
+        }
+      }
+      return included
+    })
+
+    const estimatedSpend = computed(() => {
+      return recommendedItems.value.reduce((sum, item) => {
+        return sum + item.unit_cost * item.forecasted_demand
+      }, 0)
+    })
+
+    const remainingBudget = computed(() => {
+      return budget.value - estimatedSpend.value
+    })
+
+    const placeOrder = async () => {
+      try {
+        const mappedItems = recommendedItems.value.map(item => ({
+          sku: item.item_sku,
+          name: item.item_name,
+          quantity: item.forecasted_demand,
+          unit_cost: item.unit_cost
+        }))
+        await api.createRestockingOrder(mappedItems)
+        orderPlaced.value = true
+      } catch (err) {
+        error.value = 'Failed to place order: ' + err.message
+        console.error(err)
+      }
+    }
+
+    watch(budget, () => {
+      orderPlaced.value = false
+    })
+
+    onMounted(async () => {
+      try {
+        loading.value = true
+        error.value = null
+        forecasts.value = await api.getDemandForecasts()
+        budget.value = Math.round(maxBudget.value * 0.5 / 100) * 100
+      } catch (err) {
+        error.value = 'Failed to load demand forecasts: ' + err.message
+        console.error(err)
+      } finally {
+        loading.value = false
+      }
+    })
+
+    return {
+      t,
+      forecasts,
+      loading,
+      error,
+      budget,
+      orderPlaced,
+      currencySymbol,
+      maxBudget,
+      recommendedItems,
+      estimatedSpend,
+      remainingBudget,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.restocking {
+  padding: 0;
+}
+
+.budget-slider {
+  width: 100%;
+  margin: 0.75rem 0 0;
+  accent-color: #2563eb;
+  height: 6px;
+  cursor: pointer;
+}
+
+.budget-display {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.summary-pills {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.pill {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pill-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.pill-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.place-order-btn {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.place-order-btn:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.place-order-btn:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.25rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkmark {
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+</style>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -6,7 +6,8 @@
     "current_demand": 300,
     "forecasted_demand": 450,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 45.00
   },
   {
     "id": "2",
@@ -15,7 +16,8 @@
     "current_demand": 150,
     "forecasted_demand": 152,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 28.50
   },
   {
     "id": "3",
@@ -24,7 +26,8 @@
     "current_demand": 500,
     "forecasted_demand": 600,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 12.75
   },
   {
     "id": "4",
@@ -33,7 +36,8 @@
     "current_demand": 50,
     "forecasted_demand": 35,
     "trend": "decreasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 185.00
   },
   {
     "id": "5",
@@ -42,7 +46,8 @@
     "current_demand": 800,
     "forecasted_demand": 950,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 8.99
   },
   {
     "id": "6",
@@ -51,7 +56,8 @@
     "current_demand": 120,
     "forecasted_demand": 121,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 67.50
   },
   {
     "id": "7",
@@ -60,7 +66,8 @@
     "current_demand": 250,
     "forecasted_demand": 252,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 45.99
   },
   {
     "id": "8",
@@ -69,7 +76,8 @@
     "current_demand": 180,
     "forecasted_demand": 182,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 22.50
   },
   {
     "id": "9",
@@ -78,6 +86,7 @@
     "current_demand": 95,
     "forecasted_demand": 96,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 89.00
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -89,6 +89,7 @@ class DemandForecast(BaseModel):
     forecasted_demand: int
     trend: str
     period: str
+    unit_cost: float
 
 class BacklogItem(BaseModel):
     id: str
@@ -119,6 +120,29 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+
+class RestockingOrder(BaseModel):
+    id: str
+    order_number: str
+    items: List[RestockingOrderItem]
+    total_value: float
+    status: str
+    order_date: str
+    expected_delivery: str
+    customer: str
+
+class CreateRestockingOrderRequest(BaseModel):
+    items: List[RestockingOrderItem]
+
+# In-memory store for restocking orders placed during this server session
+restocking_orders: List[dict] = []
+_restocking_counter: dict = {"n": 0}
 
 # API endpoints
 @app.get("/")
@@ -303,6 +327,38 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.post("/api/restocking/orders", response_model=RestockingOrder)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Create a new restocking order from the recommended items."""
+    from datetime import date, timedelta
+
+    _restocking_counter["n"] += 1
+    order_number = f"RST-{_restocking_counter['n']:03d}"
+    today = date.today()
+    delivery = today + timedelta(days=7)
+
+    total_value = round(sum(item.quantity * item.unit_cost for item in request.items), 2)
+
+    order = {
+        "id": order_number,
+        "order_number": order_number,
+        "items": [item.model_dump() for item in request.items],
+        "total_value": total_value,
+        "status": "Processing",
+        "order_date": today.isoformat(),
+        "expected_delivery": delivery.isoformat(),
+        "customer": "Internal Restocking"
+    }
+    restocking_orders.append(order)
+    return order
+
+
+@app.get("/api/restocking/orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all restocking orders placed this session."""
+    return restocking_orders
+
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary

- **Restocking Planner** — new view with budget slider, greedy demand-based item recommendations (increasing → stable → decreasing trend priority), Place Order button, and order confirmation flow
- **SaaS sidebar redesign** — replaced top nav bar with a collapsible left sidebar (240px expanded / 56px icons-only); CSS Grid layout, design token system via CSS variables, auto-collapses below 1024px
- **Orders tab** — new "Submitted Restocking Orders" section showing RST-NNN order numbers, items, total value, and 7-day expected delivery
- **Backend** — `POST /api/restocking/orders` and `GET /api/restocking/orders` endpoints with in-memory store; `unit_cost` field added to demand forecasts
- **i18n** — EN + JA translation keys added for all new UI strings
- **Architecture page** — standalone `architecture.html` overview of the system

## Test plan

- [ ] Start backend (`cd server && uv run python main.py`) and frontend (`cd client && npm run dev`)
- [ ] Navigate to `/restocking` — verify budget slider loads with recommended items
- [ ] Move slider left/right — verify items are added/removed and summary bar updates
- [ ] Click "Place Order" — verify confirmation banner appears and button disables
- [ ] Navigate to `/orders` — verify "Submitted Restocking Orders" section appears with the new order
- [ ] Click sidebar toggle `‹` — verify collapse to 56px icons-only rail
- [ ] Click `›` — verify re-expansion to 240px with labels
- [ ] Resize viewport below 1024px — verify sidebar auto-collapses
- [ ] Verify all 7 nav tabs route correctly with active highlight
- [ ] Switch language to Japanese — verify all new strings translate

🤖 Generated with [Claude Code](https://claude.com/claude-code)