### PR TITLE
Add Restocking view with budget optimizer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ npm install && npm run dev
 - Data: `server/data/*.json`
 - Styles: `client/src/App.vue`
 
+## Code Style
+- Always document non-obvious logic changes with comments
+
 ## Design System
 - Colors: Slate/gray (#0f172a, #64748b, #e2e8f0)
 - Status: green/blue/yellow/red

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,6 +25,9 @@
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
         </nav>
         <LanguageSwitcher />
         <ProfileMenu

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,10 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async createRestockingOrder(data) {
+    const response = await axios.post(`${API_BASE_URL}/restocking-orders`, data)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -204,6 +205,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    submitted: 'Submitted',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充発注',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -204,6 +205,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    submitted: '発注済み',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -74,6 +74,49 @@
           </table>
         </div>
       </div>
+
+      <div v-if="submittedOrders.length > 0" class="card submitted-orders-card">
+        <div class="card-header">
+          <span class="card-title">Submitted Restocking Orders</span>
+          <span class="submitted-count">{{ submittedOrders.length }} order{{ submittedOrders.length !== 1 ? 's' : '' }}</span>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Order #</th>
+                <th>Items</th>
+                <th>Order Date</th>
+                <th>Est. Delivery</th>
+                <th>Lead Time</th>
+                <th>Total Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td><span class="order-number">{{ order.order_number }}</span></td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_price }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td>{{ formatDate(order.order_date) }}</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td><span class="lead-time-badge">14 days</span></td>
+                <td>{{ formatCurrency(order.total_value) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -129,6 +172,12 @@ export default {
       loadOrders()
     })
 
+    const submittedOrders = computed(() => orders.value.filter(o => o.status === 'Submitted'))
+
+    const formatCurrency = (value) => {
+      return currencySymbol.value + value.toLocaleString()
+    }
+
     const getOrdersByStatus = (status) => {
       return orders.value.filter(order => order.status === status)
     }
@@ -138,7 +187,8 @@ export default {
         'Delivered': 'success',
         'Shipped': 'info',
         'Processing': 'warning',
-        'Backordered': 'danger'
+        'Backordered': 'danger',
+        'Submitted': 'stable'
       }
       return statusMap[status] || 'info'
     }
@@ -160,9 +210,11 @@ export default {
       loading,
       error,
       orders,
+      submittedOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,
+      formatCurrency,
       currencySymbol,
       translateProductName,
       translateCustomerName
@@ -275,5 +327,30 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+.submitted-orders-card {
+  margin-top: 1.5rem;
+}
+
+.submitted-count {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.lead-time-badge {
+  background: #e0e7ff;
+  color: #3730a3;
+  padding: 0.25rem 0.625rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.order-number {
+  font-family: monospace;
+  font-size: 0.875rem;
+  color: #0f172a;
+  font-weight: 600;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,412 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>Recommend items to restock based on demand forecasts and your available budget.</p>
+    </div>
+
+    <div class="card budget-card">
+      <div class="card-header">
+        <span class="card-title">Budget</span>
+      </div>
+      <div class="budget-body">
+        <div class="slider-row">
+          <label class="slider-label">Available Budget</label>
+          <span class="budget-value">{{ formatCurrency(budget) }}</span>
+        </div>
+        <input
+          v-model.number="budget"
+          type="range"
+          min="10000"
+          max="500000"
+          step="5000"
+          class="budget-slider"
+        />
+        <div class="slider-bounds">
+          <span>{{ formatCurrency(10000) }}</span>
+          <span>{{ formatCurrency(500000) }}</span>
+        </div>
+        <div class="remaining-row">
+          <span class="remaining-label">Remaining Budget</span>
+          <span :class="['remaining-value', remainingBudget >= 0 ? 'positive' : 'negative']">
+            {{ formatCurrency(remainingBudget) }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="successMessage" class="success-banner">
+      {{ successMessage }}
+    </div>
+
+    <div v-if="submitError" class="error submit-error">
+      {{ submitError }}
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">Recommended Items</span>
+        <span class="selection-summary">
+          {{ selectedItems.length }} item{{ selectedItems.length !== 1 ? 's' : '' }} selected
+          &nbsp;&middot;&nbsp;
+          Est. total: {{ formatCurrency(totalCost) }}
+        </span>
+      </div>
+
+      <div v-if="loading" class="loading">Loading...</div>
+      <div v-else-if="error" class="error">{{ error }}</div>
+      <div v-else-if="restockItems.length === 0" class="empty-state">
+        No restocking recommendations available.
+      </div>
+      <div v-else>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th class="col-checkbox"></th>
+                <th>SKU</th>
+                <th>Item Name</th>
+                <th>Current Demand</th>
+                <th>Forecasted Demand</th>
+                <th>Unit Cost</th>
+                <th>Est. Order Cost</th>
+                <th>Trend</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in restockItems" :key="item.sku">
+                <td class="col-checkbox">
+                  <input
+                    type="checkbox"
+                    :checked="item.selected"
+                    @change="toggleItem(item)"
+                  />
+                </td>
+                <td><strong>{{ item.sku }}</strong></td>
+                <td>{{ item.name }}</td>
+                <td>{{ item.current_demand.toLocaleString() }}</td>
+                <td>{{ item.forecasted_demand.toLocaleString() }}</td>
+                <td>{{ formatCurrency(item.unit_cost) }}</td>
+                <td>{{ formatCurrency(item.est_cost) }}</td>
+                <td>
+                  <span :class="['badge', item.trend]">{{ item.trend }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="actions-row">
+          <button
+            class="place-order-btn"
+            :disabled="selectedItems.length === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? 'Placing Order...' : 'Place Order' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { currentCurrency } = useI18n()
+    const { selectedLocation, selectedCategory } = useFilters()
+
+    const loading = ref(false)
+    const error = ref(null)
+    const restockItems = ref([])
+    const budget = ref(100000)
+    const submitting = ref(false)
+    const successMessage = ref(null)
+    const submitError = ref(null)
+
+    const formatCurrency = (value) => {
+      return value.toLocaleString('en-US', { style: 'currency', currency: currentCurrency.value })
+    }
+
+    const selectedItems = computed(() => restockItems.value.filter(i => i.selected))
+    const totalCost = computed(() => selectedItems.value.reduce((sum, i) => sum + i.est_cost, 0))
+    const remainingBudget = computed(() => budget.value - totalCost.value)
+
+    const runGreedy = () => {
+      const sorted = restockItems.value.slice().sort((a, b) => {
+        return (b.forecasted_demand - b.current_demand) - (a.forecasted_demand - a.current_demand)
+      })
+
+      let running = 0
+      const selectedSkus = new Set()
+      for (const item of sorted) {
+        if (running + item.est_cost <= budget.value) {
+          running += item.est_cost
+          selectedSkus.add(item.sku)
+        }
+      }
+
+      restockItems.value = restockItems.value.map(item => ({
+        ...item,
+        selected: selectedSkus.has(item.sku)
+      }))
+    }
+
+    const toggleItem = (item) => {
+      restockItems.value = restockItems.value.map(i =>
+        i.sku === item.sku ? { ...i, selected: !i.selected } : i
+      )
+    }
+
+    const loadData = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        const [forecasts, inventoryItems] = await Promise.all([
+          api.getDemandForecasts(),
+          api.getInventory({
+            warehouse: selectedLocation.value,
+            category: selectedCategory.value
+          })
+        ])
+
+        const inventoryMap = {}
+        for (const inv of inventoryItems) {
+          inventoryMap[inv.sku] = inv
+        }
+
+        restockItems.value = forecasts
+          .filter(f => inventoryMap[f.item_sku] != null)
+          .map(f => ({
+            sku: f.item_sku,
+            name: f.item_name,
+            current_demand: f.current_demand,
+            forecasted_demand: f.forecasted_demand,
+            trend: f.trend,
+            period: f.period,
+            unit_cost: inventoryMap[f.item_sku].unit_cost,
+            est_cost: f.forecasted_demand * inventoryMap[f.item_sku].unit_cost,
+            selected: false
+          }))
+
+        runGreedy()
+      } catch (err) {
+        error.value = 'Failed to load restocking data'
+        console.error(err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    watch(budget, runGreedy, { immediate: false })
+    watch([selectedLocation, selectedCategory], loadData)
+
+    const placeOrder = async () => {
+      submitting.value = true
+      submitError.value = null
+      successMessage.value = null
+      try {
+        const order = await api.createRestockingOrder({
+          items: selectedItems.value.map(i => ({
+            sku: i.sku,
+            name: i.name,
+            quantity: i.forecasted_demand,
+            unit_cost: i.unit_cost
+          })),
+          budget: budget.value
+        })
+        successMessage.value = `Order ${order.order_number} placed successfully.`
+        runGreedy()
+      } catch (err) {
+        submitError.value = 'Failed to place order. Please try again.'
+        console.error(err)
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    onMounted(loadData)
+
+    return {
+      loading,
+      error,
+      restockItems,
+      budget,
+      submitting,
+      successMessage,
+      submitError,
+      selectedItems,
+      totalCost,
+      remainingBudget,
+      formatCurrency,
+      toggleItem,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.page-header {
+  margin-bottom: 1.5rem;
+}
+
+.page-header h2 {
+  margin-bottom: 0.25rem;
+}
+
+.page-header p {
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.budget-card {
+  margin-bottom: 1.5rem;
+}
+
+.budget-body {
+  padding: 1.25rem 1.5rem;
+}
+
+.slider-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.slider-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.budget-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.budget-slider {
+  width: 100%;
+  accent-color: #2563eb;
+  cursor: pointer;
+}
+
+.slider-bounds {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin-top: 0.25rem;
+}
+
+.remaining-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.remaining-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.remaining-value {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.remaining-value.positive {
+  color: #16a34a;
+}
+
+.remaining-value.negative {
+  color: #dc2626;
+}
+
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 0.875rem 1.25rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.submit-error {
+  margin-bottom: 1.5rem;
+  padding: 0.875rem 1.25rem;
+  border-radius: 8px;
+}
+
+.loading,
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.error {
+  color: #ef4444;
+  font-size: 0.875rem;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.selection-summary {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.col-checkbox {
+  width: 2.5rem;
+  text-align: center;
+}
+
+.actions-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.place-order-btn {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.625rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.place-order-btn:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.place-order-btn:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,629 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Architecture — Factory Inventory Management</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    /* ── Header ── */
+    header {
+      background: #1e293b;
+      border-bottom: 1px solid #334155;
+      padding: 28px 48px;
+    }
+    header h1 { font-size: 1.5rem; font-weight: 700; color: #f8fafc; letter-spacing: -0.02em; }
+    header p  { font-size: 0.85rem; color: #64748b; margin-top: 4px; }
+
+    /* ── Layout ── */
+    main { max-width: 1200px; margin: 0 auto; padding: 48px 48px 80px; }
+
+    section { margin-bottom: 56px; }
+    section h2 {
+      font-size: 0.7rem; font-weight: 600; letter-spacing: 0.1em;
+      text-transform: uppercase; color: #64748b;
+      margin-bottom: 20px; padding-bottom: 8px;
+      border-bottom: 1px solid #1e293b;
+    }
+
+    /* ── Cards ── */
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 24px 28px;
+    }
+    .card h3 { font-size: 0.95rem; font-weight: 600; color: #f1f5f9; margin-bottom: 4px; }
+    .card .sub { font-size: 0.78rem; color: #64748b; margin-bottom: 14px; }
+
+    /* ── Stack Grid ── */
+    .stack-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+    }
+    .stack-card { background: #1e293b; border: 1px solid #334155; border-radius: 10px; padding: 20px 22px; }
+    .stack-card .layer-label {
+      font-size: 0.65rem; font-weight: 700; letter-spacing: 0.12em;
+      text-transform: uppercase; margin-bottom: 12px;
+    }
+    .stack-card.frontend .layer-label { color: #38bdf8; }
+    .stack-card.backend  .layer-label { color: #a78bfa; }
+    .stack-card.data     .layer-label { color: #34d399; }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.72rem; font-weight: 500;
+      padding: 3px 9px; border-radius: 4px;
+      margin: 3px 3px 3px 0;
+    }
+    .badge.blue   { background: #0c4a6e; color: #7dd3fc; }
+    .badge.purple { background: #2e1065; color: #c4b5fd; }
+    .badge.green  { background: #064e3b; color: #6ee7b7; }
+    .badge.slate  { background: #1e293b; color: #94a3b8; border: 1px solid #334155; }
+    .badge.amber  { background: #451a03; color: #fcd34d; }
+
+    .stack-detail { font-size: 0.78rem; color: #94a3b8; margin-top: 10px; }
+    .stack-detail li { margin: 4px 0 4px 14px; }
+
+    /* ── Data Flow ── */
+    .flow-wrapper {
+      display: flex;
+      align-items: stretch;
+      gap: 0;
+    }
+    .flow-step {
+      flex: 1;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 18px 16px;
+      position: relative;
+    }
+    .flow-step .step-num {
+      font-size: 0.65rem; font-weight: 700; color: #475569;
+      margin-bottom: 6px; display: block;
+    }
+    .flow-step .step-title {
+      font-size: 0.82rem; font-weight: 600; color: #f1f5f9;
+      margin-bottom: 6px;
+    }
+    .flow-step .step-desc {
+      font-size: 0.73rem; color: #64748b; line-height: 1.5;
+    }
+    .flow-arrow {
+      display: flex; align-items: center; padding: 0 6px;
+      color: #475569; font-size: 1.1rem; flex-shrink: 0;
+    }
+
+    /* ── API Endpoints ── */
+    .endpoint-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 10px;
+    }
+    .endpoint {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 12px 16px;
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+    }
+    .method {
+      font-size: 0.65rem; font-weight: 700; letter-spacing: 0.05em;
+      padding: 2px 7px; border-radius: 4px; flex-shrink: 0; margin-top: 1px;
+    }
+    .method.get  { background: #1d4ed8; color: #bfdbfe; }
+    .method.post { background: #065f46; color: #6ee7b7; }
+    .endpoint-path { font-size: 0.8rem; font-family: "SF Mono", "Fira Code", monospace; color: #e2e8f0; }
+    .endpoint-desc { font-size: 0.72rem; color: #64748b; margin-top: 2px; }
+    .endpoint-filters { margin-top: 4px; }
+
+    /* ── Component Tree ── */
+    .component-tree {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+    .tree-group { background: #1e293b; border: 1px solid #334155; border-radius: 10px; padding: 18px 20px; }
+    .tree-group h4 { font-size: 0.72rem; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 12px; }
+    .tree-item { font-size: 0.8rem; color: #94a3b8; padding: 4px 0; display: flex; align-items: center; gap: 8px; }
+    .tree-item .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+    .dot-blue   { background: #38bdf8; }
+    .dot-purple { background: #a78bfa; }
+    .dot-green  { background: #34d399; }
+    .dot-amber  { background: #fbbf24; }
+    .tree-item strong { color: #e2e8f0; font-weight: 500; }
+
+    /* ── Filter Flow ── */
+    .filter-flow {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 24px 28px;
+    }
+    .filter-path {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-bottom: 20px;
+    }
+    .filter-node {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 6px 12px;
+      font-size: 0.78rem;
+      color: #94a3b8;
+      font-family: "SF Mono", "Fira Code", monospace;
+    }
+    .filter-node.highlight { border-color: #38bdf8; color: #7dd3fc; }
+    .filter-arrow { color: #334155; font-size: 0.9rem; }
+    .filter-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+    .filter-table th { text-align: left; color: #475569; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; padding: 6px 12px; border-bottom: 1px solid #1e293b; }
+    .filter-table td { padding: 8px 12px; border-bottom: 1px solid #0f172a; color: #94a3b8; vertical-align: top; }
+    .filter-table td:first-child { color: #e2e8f0; font-weight: 500; }
+    .check { color: #34d399; } .dash { color: #475569; }
+
+    /* ── Data Models ── */
+    .model-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+    .model-card { background: #1e293b; border: 1px solid #334155; border-radius: 8px; padding: 16px 18px; }
+    .model-card h4 { font-size: 0.82rem; font-weight: 600; color: #f1f5f9; margin-bottom: 10px; }
+    .field { font-size: 0.72rem; color: #64748b; padding: 2px 0; display: flex; gap: 8px; }
+    .field-name { color: #94a3b8; font-family: "SF Mono", "Fira Code", monospace; flex-shrink: 0; }
+    .field-type { color: #475569; }
+    .field-opt  { color: #854d0e; font-size: 0.65rem; align-self: center; }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Factory Inventory Management — System Architecture</h1>
+  <p>Full-stack demo &nbsp;·&nbsp; Vue 3 + FastAPI + In-memory JSON &nbsp;·&nbsp; 3 warehouses &nbsp;·&nbsp; 7 data domains</p>
+</header>
+
+<main>
+
+  <!-- ── Tech Stack ── -->
+  <section>
+    <h2>Tech Stack</h2>
+    <div class="stack-grid">
+      <div class="stack-card frontend">
+        <div class="layer-label">Frontend &nbsp;·&nbsp; Port 3000</div>
+        <span class="badge blue">Vue 3</span>
+        <span class="badge blue">Composition API</span>
+        <span class="badge blue">Vite</span>
+        <span class="badge blue">Axios</span>
+        <ul class="stack-detail">
+          <li>7 page views, 9 reusable components</li>
+          <li>3 composables for shared logic</li>
+          <li>Custom SVG charts (no chart library)</li>
+          <li>EN / JA internationalization</li>
+          <li>Singleton filter state (useFilters)</li>
+        </ul>
+      </div>
+
+      <div class="stack-card backend">
+        <div class="layer-label">Backend &nbsp;·&nbsp; Port 8001</div>
+        <span class="badge purple">Python</span>
+        <span class="badge purple">FastAPI</span>
+        <span class="badge purple">Pydantic v2</span>
+        <span class="badge purple">uv</span>
+        <ul class="stack-detail">
+          <li>17 REST endpoints across 6 resource groups</li>
+          <li>8 Pydantic response models</li>
+          <li>CORS open for local development</li>
+          <li>Auto-generated OpenAPI docs at /docs</li>
+          <li>Pure filter functions (no mutations)</li>
+        </ul>
+      </div>
+
+      <div class="stack-card data">
+        <div class="layer-label">Data Layer &nbsp;·&nbsp; In-memory</div>
+        <span class="badge green">JSON files</span>
+        <span class="badge green">In-memory</span>
+        <span class="badge green">No DB</span>
+        <ul class="stack-detail">
+          <li>7 JSON files loaded at startup</li>
+          <li>Data resets on server restart</li>
+          <li>Warehouses: San Francisco, London, Tokyo</li>
+          <li>5 product categories</li>
+          <li>Months: Jan–Dec 2025</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Data Flow ── -->
+  <section>
+    <h2>Request Data Flow</h2>
+    <div class="flow-wrapper">
+      <div class="flow-step">
+        <span class="step-num">01</span>
+        <div class="step-title">User Interaction</div>
+        <div class="step-desc">User changes a filter dropdown or navigates to a view in the browser.</div>
+      </div>
+      <div class="flow-arrow">&#8594;</div>
+      <div class="flow-step">
+        <span class="step-num">02</span>
+        <div class="step-title">useFilters Composable</div>
+        <div class="step-desc">Singleton reactive refs update. Any watching component is notified.</div>
+      </div>
+      <div class="flow-arrow">&#8594;</div>
+      <div class="flow-step">
+        <span class="step-num">03</span>
+        <div class="step-title">View loadData()</div>
+        <div class="step-desc">watch() triggers loadData(). getCurrentFilters() maps UI state to API params.</div>
+      </div>
+      <div class="flow-arrow">&#8594;</div>
+      <div class="flow-step">
+        <span class="step-num">04</span>
+        <div class="step-title">api.js (Axios)</div>
+        <div class="step-desc">Builds URLSearchParams and sends GET to http://localhost:8001/api/&hellip;</div>
+      </div>
+      <div class="flow-arrow">&#8594;</div>
+      <div class="flow-step">
+        <span class="step-num">05</span>
+        <div class="step-title">FastAPI Endpoint</div>
+        <div class="step-desc">apply_filters() and filter_by_month() run on in-memory lists.</div>
+      </div>
+      <div class="flow-arrow">&#8594;</div>
+      <div class="flow-step">
+        <span class="step-num">06</span>
+        <div class="step-title">Pydantic Validation</div>
+        <div class="step-desc">Response serialized through Pydantic model; JSON returned.</div>
+      </div>
+      <div class="flow-arrow">&#8594;</div>
+      <div class="flow-step">
+        <span class="step-num">07</span>
+        <div class="step-title">Template Re-render</div>
+        <div class="step-desc">Reactive ref updated; Vue re-renders only affected DOM nodes.</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Component Tree ── -->
+  <section>
+    <h2>Frontend Component Structure</h2>
+    <div class="component-tree">
+      <div class="tree-group">
+        <h4>Views (Pages)</h4>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Dashboard.vue</strong> &nbsp;— KPI cards, order health chart, low stock</div>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Inventory.vue</strong> &nbsp;— Stock table, search, item modal</div>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Orders.vue</strong> &nbsp;&nbsp;&nbsp;&nbsp;— Order table, status breakdown</div>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Spending.vue</strong> &nbsp;&nbsp;— Cost analytics, monthly chart</div>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Reports.vue</strong> &nbsp;&nbsp;&nbsp;— Quarterly &amp; monthly trends</div>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Demand.vue</strong> &nbsp;&nbsp;&nbsp;&nbsp;— Forecast table per SKU</div>
+        <div class="tree-item"><span class="dot dot-blue"></span> <strong>Backlog.vue</strong> &nbsp;&nbsp;&nbsp;— Delayed orders, PO creation</div>
+      </div>
+
+      <div class="tree-group">
+        <h4>Components &amp; Composables</h4>
+        <div class="tree-item"><span class="dot dot-purple"></span> <strong>FilterBar.vue</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;— 4 dropdowns + reset (sticky)</div>
+        <div class="tree-item"><span class="dot dot-purple"></span> <strong>InventoryDetailModal</strong> &nbsp;— SKU detail overlay</div>
+        <div class="tree-item"><span class="dot dot-purple"></span> <strong>BacklogDetailModal</strong> &nbsp;&nbsp;&nbsp;— Backlog item detail</div>
+        <div class="tree-item"><span class="dot dot-purple"></span> <strong>TasksModal</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;— Task management</div>
+        <div class="tree-item"><span class="dot dot-purple"></span> <strong>ProfileMenu</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;— User menu + language toggle</div>
+        <div class="tree-item"><span class="dot dot-green"></span>  <strong>useFilters.js</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;— Singleton filter state</div>
+        <div class="tree-item"><span class="dot dot-green"></span>  <strong>useI18n.js</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;— EN/JA translations + currency</div>
+        <div class="tree-item"><span class="dot dot-green"></span>  <strong>useAuth.js</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;— Mock current user &amp; tasks</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Filter System ── -->
+  <section>
+    <h2>Filter System</h2>
+    <div class="filter-flow">
+      <div class="filter-path">
+        <span class="filter-node highlight">selectedPeriod</span>
+        <span class="filter-arrow">&#8594;</span>
+        <span class="filter-node">month=2025-01</span>
+        <span class="filter-arrow">&nbsp;&nbsp;</span>
+        <span class="filter-node highlight">selectedLocation</span>
+        <span class="filter-arrow">&#8594;</span>
+        <span class="filter-node">warehouse=Tokyo</span>
+        <span class="filter-arrow">&nbsp;&nbsp;</span>
+        <span class="filter-node highlight">selectedCategory</span>
+        <span class="filter-arrow">&#8594;</span>
+        <span class="filter-node">category=Sensors</span>
+        <span class="filter-arrow">&nbsp;&nbsp;</span>
+        <span class="filter-node highlight">selectedStatus</span>
+        <span class="filter-arrow">&#8594;</span>
+        <span class="filter-node">status=Delivered</span>
+      </div>
+
+      <table class="filter-table">
+        <thead>
+          <tr>
+            <th>View</th>
+            <th>Warehouse</th>
+            <th>Category</th>
+            <th>Status</th>
+            <th>Month / Period</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Dashboard</td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td>All 4 filters applied to summary stats</td>
+          </tr>
+          <tr>
+            <td>Inventory</td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td>Local text search applied on top</td>
+          </tr>
+          <tr>
+            <td>Orders</td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td><span class="check">&#10003;</span></td>
+            <td>Full filter support</td>
+          </tr>
+          <tr>
+            <td>Spending</td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td>Static aggregated data</td>
+          </tr>
+          <tr>
+            <td>Reports</td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td>Pre-aggregated quarterly/monthly</td>
+          </tr>
+          <tr>
+            <td>Demand</td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td>No filtering</td>
+          </tr>
+          <tr>
+            <td>Backlog</td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td><span class="dash">&mdash;</span></td>
+            <td>No filtering; PO creation available</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ── API Endpoints ── -->
+  <section>
+    <h2>API Endpoints</h2>
+    <div class="endpoint-grid">
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/dashboard/summary</div>
+          <div class="endpoint-desc">KPI totals: inventory value, low stock, pending orders</div>
+          <div class="endpoint-filters"><span class="badge slate">warehouse</span><span class="badge slate">category</span><span class="badge slate">status</span><span class="badge slate">month</span></div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/inventory</div>
+          <div class="endpoint-desc">Full inventory list with stock levels</div>
+          <div class="endpoint-filters"><span class="badge slate">warehouse</span><span class="badge slate">category</span></div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/inventory/{item_id}</div>
+          <div class="endpoint-desc">Single inventory item by ID</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/orders</div>
+          <div class="endpoint-desc">Order list with item details</div>
+          <div class="endpoint-filters"><span class="badge slate">warehouse</span><span class="badge slate">category</span><span class="badge slate">status</span><span class="badge slate">month</span></div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/demand</div>
+          <div class="endpoint-desc">Demand forecasts per SKU with trend direction</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/backlog</div>
+          <div class="endpoint-desc">Delayed orders with days delayed &amp; priority</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/spending/summary</div>
+          <div class="endpoint-desc">Procurement, operational, labor, overhead totals</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/spending/monthly</div>
+          <div class="endpoint-desc">Monthly cost breakdown by category</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/spending/categories</div>
+          <div class="endpoint-desc">Spending share per category with percentages</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/spending/transactions</div>
+          <div class="endpoint-desc">Individual transaction ledger</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/reports/quarterly</div>
+          <div class="endpoint-desc">Q1–Q4 aggregated KPIs: revenue, fulfillment rate</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/reports/monthly-trends</div>
+          <div class="endpoint-desc">Month-over-month order count &amp; revenue</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/tasks</div>
+          <div class="endpoint-desc">User task list</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method post">POST</span>
+        <div>
+          <div class="endpoint-path">/api/tasks</div>
+          <div class="endpoint-desc">Create a new task</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method post">POST</span>
+        <div>
+          <div class="endpoint-path">/api/purchase-orders</div>
+          <div class="endpoint-desc">Create purchase order for a backlog item</div>
+        </div>
+      </div>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <div>
+          <div class="endpoint-path">/api/purchase-orders</div>
+          <div class="endpoint-desc">List all purchase orders</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Data Models ── -->
+  <section>
+    <h2>Core Data Models (Pydantic)</h2>
+    <div class="model-grid">
+      <div class="model-card">
+        <h4>InventoryItem</h4>
+        <div class="field"><span class="field-name">id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">sku</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">category</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">warehouse</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">quantity_on_hand</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">reorder_point</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">unit_cost</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">location</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">last_updated</span><span class="field-type">str</span></div>
+      </div>
+
+      <div class="model-card">
+        <h4>Order</h4>
+        <div class="field"><span class="field-name">id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">order_number</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">customer</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">items</span><span class="field-type">List[dict]</span></div>
+        <div class="field"><span class="field-name">status</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">order_date</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">expected_delivery</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">total_value</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">actual_delivery</span><span class="field-type">str</span><span class="field-opt">opt</span></div>
+        <div class="field"><span class="field-name">warehouse</span><span class="field-type">str</span><span class="field-opt">opt</span></div>
+      </div>
+
+      <div class="model-card">
+        <h4>BacklogItem</h4>
+        <div class="field"><span class="field-name">id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">order_id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">item_sku</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">item_name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">quantity_needed</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">quantity_available</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">days_delayed</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">priority</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">has_purchase_order</span><span class="field-type">bool</span><span class="field-opt">opt</span></div>
+      </div>
+
+      <div class="model-card">
+        <h4>DemandForecast</h4>
+        <div class="field"><span class="field-name">id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">item_sku</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">item_name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">current_demand</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">forecasted_demand</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">trend</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">period</span><span class="field-type">str</span></div>
+      </div>
+
+      <div class="model-card">
+        <h4>PurchaseOrder</h4>
+        <div class="field"><span class="field-name">id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">backlog_item_id</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">supplier_name</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">quantity</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">unit_cost</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">expected_delivery_date</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">status</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">created_date</span><span class="field-type">str</span></div>
+        <div class="field"><span class="field-name">notes</span><span class="field-type">str</span><span class="field-opt">opt</span></div>
+      </div>
+
+      <div class="model-card">
+        <h4>DashboardSummary</h4>
+        <div class="field"><span class="field-name">total_inventory_value</span><span class="field-type">float</span></div>
+        <div class="field"><span class="field-name">low_stock_items</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">pending_orders</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">total_backlog_items</span><span class="field-type">int</span></div>
+        <div class="field"><span class="field-name">total_orders_value</span><span class="field-type">float</span></div>
+        <div style="margin-top:10px; font-size:0.7rem; color:#475569;">
+          Pending = Processing + Backordered<br>
+          Low stock = qty &le; reorder_point
+        </div>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -1,8 +1,8 @@
 [
   {
     "id": "1",
-    "item_sku": "WDG-001",
-    "item_name": "Industrial Widget Type A",
+    "item_sku": "PCB-001",
+    "item_name": "Single Layer PCB Assembly",
     "current_demand": 300,
     "forecasted_demand": 450,
     "trend": "increasing",
@@ -10,26 +10,26 @@
   },
   {
     "id": "2",
-    "item_sku": "BRG-102",
-    "item_name": "Steel Bearing Assembly",
+    "item_sku": "TMP-201",
+    "item_name": "Temperature Sensor Module",
     "current_demand": 150,
-    "forecasted_demand": 152,
-    "trend": "stable",
-    "period": "Next 30 days"
-  },
-  {
-    "id": "3",
-    "item_sku": "GSK-203",
-    "item_name": "High-Temperature Gasket",
-    "current_demand": 500,
-    "forecasted_demand": 600,
+    "forecasted_demand": 240,
     "trend": "increasing",
     "period": "Next 30 days"
   },
   {
+    "id": "3",
+    "item_sku": "HMD-202",
+    "item_name": "Humidity Sensor Module",
+    "current_demand": 500,
+    "forecasted_demand": 510,
+    "trend": "stable",
+    "period": "Next 30 days"
+  },
+  {
     "id": "4",
-    "item_sku": "MTR-304",
-    "item_name": "Electric Motor 5HP",
+    "item_sku": "SRV-301",
+    "item_name": "Micro Servo Motor",
     "current_demand": 50,
     "forecasted_demand": 35,
     "trend": "decreasing",
@@ -37,35 +37,35 @@
   },
   {
     "id": "5",
-    "item_sku": "FLT-405",
-    "item_name": "Oil Filter Cartridge",
+    "item_sku": "MCU-401",
+    "item_name": "32-bit ARM Microcontroller",
     "current_demand": 800,
-    "forecasted_demand": 950,
+    "forecasted_demand": 1100,
     "trend": "increasing",
     "period": "Next 30 days"
   },
   {
     "id": "6",
-    "item_sku": "VLV-506",
-    "item_name": "Pressure Relief Valve",
+    "item_sku": "PSU-501",
+    "item_name": "5V 10A Switching Power Supply",
     "current_demand": 120,
-    "forecasted_demand": 121,
+    "forecasted_demand": 122,
     "trend": "stable",
     "period": "Next 30 days"
   },
   {
     "id": "7",
-    "item_sku": "PSU-501",
-    "item_name": "5V 10A Switching Power Supply",
+    "item_sku": "PCB-003",
+    "item_name": "Multi Layer PCB Assembly",
     "current_demand": 250,
-    "forecasted_demand": 252,
-    "trend": "stable",
+    "forecasted_demand": 400,
+    "trend": "increasing",
     "period": "Next 30 days"
   },
   {
     "id": "8",
-    "item_sku": "SNR-420",
-    "item_name": "Temperature Sensor Module",
+    "item_sku": "PRX-204",
+    "item_name": "Proximity Sensor",
     "current_demand": 180,
     "forecasted_demand": 182,
     "trend": "stable",
@@ -73,11 +73,11 @@
   },
   {
     "id": "9",
-    "item_sku": "CTL-330",
-    "item_name": "Logic Controller Board",
+    "item_sku": "MCU-402",
+    "item_name": "8-bit AVR Microcontroller",
     "current_demand": 95,
-    "forecasted_demand": 96,
-    "trend": "stable",
+    "forecasted_demand": 65,
+    "trend": "decreasing",
     "period": "Next 30 days"
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
@@ -119,6 +120,17 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+
+class CreateRestockingOrderRequest(BaseModel):
+    items: List[RestockingOrderItem]
+    budget: float
+    warehouse: str = "San Francisco"
 
 # API endpoints
 @app.get("/")
@@ -303,6 +315,39 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.post("/api/restocking-orders", response_model=Order)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Create a restocking order from demand forecast recommendations"""
+    if not request.items:
+        raise HTTPException(status_code=400, detail="At least one item is required")
+
+    # Generate order number: RST-YYYY-NNNN (sequence based on existing RST orders)
+    rst_count = sum(1 for o in orders if o.get("order_number", "").startswith("RST-"))
+    year = datetime.now().year
+    order_number = f"RST-{year}-{str(rst_count + 1).zfill(4)}"
+
+    now = datetime.now()
+    total_value = sum(item.quantity * item.unit_cost for item in request.items)
+
+    new_order = {
+        "id": str(len(orders) + 1),
+        "order_number": order_number,
+        "customer": "Internal Restocking",
+        "items": [{"sku": i.sku, "name": i.name, "quantity": i.quantity, "unit_price": i.unit_cost} for i in request.items],
+        "status": "Submitted",
+        "order_date": now.isoformat(),
+        "expected_delivery": (now + timedelta(days=14)).isoformat(),
+        "total_value": round(total_value, 2),
+        "actual_delivery": None,
+        "warehouse": request.warehouse,
+        "category": None,
+    }
+
+    # Append to in-memory orders list so GET /api/orders immediately returns it
+    orders.append(new_order)
+    return new_order
+
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary

- New **Restocking** page with a budget slider and greedy algorithm that auto-selects items maximizing demand coverage within the available budget
- `POST /api/restocking-orders` backend endpoint that creates `RST-YYYY-NNNN` orders and appends them to the in-memory orders list
- **Orders** view gains a "Submitted Restocking Orders" section showing RST orders with expandable item detail rows
- Wired `/restocking` route, nav link (with i18n), and `createRestockingOrder` API call
- Updated `demand_forecasts.json` and added Playwright MCP config (token replaced with env-var placeholder)

## Test plan

- [ ] Start backend (`uv run python main.py`) and frontend (`npm run dev`)
- [ ] Navigate to Restocking page — items table loads with greedy pre-selection
- [ ] Move budget slider — selection updates automatically to stay within budget
- [ ] Toggle individual checkboxes — remaining budget updates in real time
- [ ] Click Place Order with items selected — success banner shows order number
- [ ] Navigate to Orders page — submitted RST order appears in the new section
- [ ] Verify warehouse/category filters reload the restocking table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)