### PR TITLE
Add Restocking tab with budget-driven recommendations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,6 @@ npm install && npm run dev
 - Status: green/blue/yellow/red
 - Charts: Custom SVG, CSS Grid for layouts
 - No emojis in UI
+
+## Code Style
+- Always document non-obvious logic changes with comments

--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,543 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Factory Inventory Management — Architecture</title>
+<style>
+  :root {
+    --bg: #f8fafc;
+    --surface: #ffffff;
+    --border: #e2e8f0;
+    --border-strong: #cbd5e1;
+    --text: #0f172a;
+    --text-muted: #64748b;
+    --text-subtle: #94a3b8;
+    --accent: #0f172a;
+    --green: #059669;
+    --green-bg: #d1fae5;
+    --blue: #2563eb;
+    --blue-bg: #dbeafe;
+    --yellow: #d97706;
+    --yellow-bg: #fef3c7;
+    --red: #dc2626;
+    --red-bg: #fee2e2;
+    --purple: #7c3aed;
+    --purple-bg: #ede9fe;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page { max-width: 1200px; margin: 0 auto; padding: 48px 32px 80px; }
+  header.hero {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 32px;
+    margin-bottom: 48px;
+  }
+  header.hero .eyebrow {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+  }
+  header.hero h1 {
+    font-size: 36px;
+    font-weight: 700;
+    color: var(--text);
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+  }
+  header.hero p {
+    font-size: 16px;
+    color: var(--text-muted);
+    max-width: 720px;
+  }
+  .meta-row {
+    display: flex;
+    gap: 16px;
+    margin-top: 20px;
+    flex-wrap: wrap;
+  }
+  .meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .meta .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--green);
+  }
+  section { margin-bottom: 56px; }
+  h2 {
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 8px;
+    letter-spacing: -0.01em;
+  }
+  .section-sub {
+    font-size: 14px;
+    color: var(--text-muted);
+    margin-bottom: 24px;
+  }
+
+  /* Tech Stack */
+  .stack-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  .stack-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 24px;
+  }
+  .stack-card .label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+  }
+  .stack-card h3 {
+    font-size: 17px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .stack-card .port {
+    font-size: 12px;
+    color: var(--text-subtle);
+    font-family: "SF Mono", Monaco, Consolas, monospace;
+    margin-bottom: 16px;
+  }
+  .stack-card ul { list-style: none; }
+  .stack-card li {
+    font-size: 13px;
+    color: var(--text);
+    padding: 6px 0;
+    border-top: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+  }
+  .stack-card li:first-child { border-top: none; }
+  .stack-card li span.v {
+    color: var(--text-subtle);
+    font-family: "SF Mono", Monaco, Consolas, monospace;
+    font-size: 12px;
+  }
+
+  /* Architecture diagram */
+  .diagram-wrap {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 32px;
+    overflow-x: auto;
+  }
+  svg.architecture { display: block; margin: 0 auto; max-width: 100%; height: auto; }
+
+  /* Data flow */
+  .flow {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+  .flow-step {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--blue);
+    border-radius: 8px;
+    padding: 16px 18px;
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+  }
+  .flow-step .num {
+    flex-shrink: 0;
+    width: 26px; height: 26px;
+    background: var(--text);
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .flow-step .body strong {
+    display: block;
+    font-size: 14px;
+    color: var(--text);
+    margin-bottom: 2px;
+  }
+  .flow-step .body span {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-family: "SF Mono", Monaco, Consolas, monospace;
+  }
+
+  /* Tables */
+  .table-wrap {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  thead th {
+    text-align: left;
+    padding: 12px 16px;
+    background: #f8fafc;
+    border-bottom: 1px solid var(--border);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  tbody td {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  td.method {
+    font-family: "SF Mono", Monaco, Consolas, monospace;
+    font-size: 11px;
+    font-weight: 600;
+  }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--green);
+    background: var(--green-bg);
+  }
+  td code, .mono {
+    font-family: "SF Mono", Monaco, Consolas, monospace;
+    font-size: 12px;
+    color: var(--text);
+  }
+
+  /* View grid */
+  .views-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  .view-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 18px 20px;
+  }
+  .view-card .route {
+    font-family: "SF Mono", Monaco, Consolas, monospace;
+    font-size: 12px;
+    color: var(--blue);
+    margin-bottom: 4px;
+  }
+  .view-card h4 {
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .view-card p {
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+
+  footer {
+    margin-top: 64px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-subtle);
+    text-align: center;
+  }
+
+  @media (max-width: 880px) {
+    .stack-grid, .views-grid { grid-template-columns: 1fr; }
+    .flow { grid-template-columns: 1fr; }
+    header.hero h1 { font-size: 28px; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header class="hero">
+    <div class="eyebrow">System Documentation</div>
+    <h1>Factory Inventory Management — Architecture</h1>
+    <p>A full-stack demo of a factory inventory management system. Vue 3 single-page client communicates with a FastAPI service over a small REST surface; data is mocked in JSON files and loaded into memory at startup.</p>
+    <div class="meta-row">
+      <div class="meta"><span class="dot"></span>Frontend &middot; localhost:3000</div>
+      <div class="meta"><span class="dot"></span>Backend &middot; localhost:8001</div>
+      <div class="meta">In-memory mock data &middot; no database</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>Tech Stack</h2>
+    <div class="section-sub">Three thin layers: a Vue SPA, a FastAPI service, and JSON files on disk.</div>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="label">Frontend</div>
+        <h3>Vue 3 SPA</h3>
+        <div class="port">client/ &middot; port 3000</div>
+        <ul>
+          <li>Vue 3 <span class="v">Composition API</span></li>
+          <li>Vue Router <span class="v">4.3</span></li>
+          <li>Axios <span class="v">1.6</span></li>
+          <li>Vite <span class="v">5.2</span></li>
+          <li>i18n <span class="v">en / ja</span></li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="label">Backend</div>
+        <h3>FastAPI Service</h3>
+        <div class="port">server/ &middot; port 8001</div>
+        <ul>
+          <li>FastAPI <span class="v">&ge; 0.110</span></li>
+          <li>Pydantic <span class="v">&ge; 2.5</span></li>
+          <li>Uvicorn <span class="v">&ge; 0.24</span></li>
+          <li>Python <span class="v">&ge; 3.11</span></li>
+          <li>CORS <span class="v">open (dev)</span></li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="label">Data</div>
+        <h3>JSON Mock Store</h3>
+        <div class="port">server/data/ &middot; in-memory</div>
+        <ul>
+          <li>inventory.json <span class="v">SKUs</span></li>
+          <li>orders.json <span class="v">2025</span></li>
+          <li>demand_forecasts.json <span class="v">trends</span></li>
+          <li>spending.json <span class="v">costs</span></li>
+          <li>backlog, transactions <span class="v">&hellip;</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>System Architecture</h2>
+    <div class="section-sub">Browser issues HTTP requests against the FastAPI service, which filters in-memory data loaded from JSON at startup.</div>
+    <div class="diagram-wrap">
+      <svg class="architecture" viewBox="0 0 980 460" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="System architecture diagram">
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+          </marker>
+        </defs>
+
+        <!-- Client column -->
+        <g>
+          <rect x="40" y="40" width="240" height="380" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+          <text x="60" y="68" font-family="-apple-system, sans-serif" font-size="11" font-weight="600" fill="#64748b" letter-spacing="1.5">CLIENT &middot; PORT 3000</text>
+
+          <rect x="60" y="88" width="200" height="50" rx="6" fill="#dbeafe" stroke="#2563eb" stroke-width="1"/>
+          <text x="160" y="111" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="13" font-weight="600" fill="#0f172a">Browser</text>
+          <text x="160" y="127" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="11" fill="#64748b">Vue 3 SPA &middot; Vite</text>
+
+          <rect x="60" y="156" width="200" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="160" y="182" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">Views (router-view)</text>
+
+          <rect x="60" y="208" width="200" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="160" y="234" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">Composables &middot; useFilters</text>
+
+          <rect x="60" y="260" width="200" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="160" y="286" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">api.js (Axios client)</text>
+
+          <text x="60" y="340" font-family="-apple-system, sans-serif" font-size="11" fill="#94a3b8">Routes</text>
+          <text x="60" y="358" font-family="SF Mono, monospace" font-size="11" fill="#64748b">/  /inventory  /orders</text>
+          <text x="60" y="374" font-family="SF Mono, monospace" font-size="11" fill="#64748b">/demand  /spending</text>
+          <text x="60" y="390" font-family="SF Mono, monospace" font-size="11" fill="#64748b">/reports</text>
+        </g>
+
+        <!-- Arrow client -> server -->
+        <line x1="290" y1="281" x2="370" y2="281" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+        <text x="330" y="272" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="11" fill="#64748b">HTTP</text>
+        <text x="330" y="298" text-anchor="middle" font-family="SF Mono, monospace" font-size="10" fill="#94a3b8">GET /api/*</text>
+
+        <!-- Arrow server -> client -->
+        <line x1="370" y1="200" x2="290" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+        <text x="330" y="192" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="11" fill="#64748b">JSON</text>
+
+        <!-- Server column -->
+        <g>
+          <rect x="380" y="40" width="280" height="380" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+          <text x="400" y="68" font-family="-apple-system, sans-serif" font-size="11" font-weight="600" fill="#64748b" letter-spacing="1.5">SERVER &middot; PORT 8001</text>
+
+          <rect x="400" y="88" width="240" height="50" rx="6" fill="#d1fae5" stroke="#059669" stroke-width="1"/>
+          <text x="520" y="111" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="13" font-weight="600" fill="#0f172a">FastAPI</text>
+          <text x="520" y="127" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="11" fill="#64748b">Uvicorn &middot; ASGI</text>
+
+          <rect x="400" y="156" width="240" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="520" y="182" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">main.py &middot; route handlers</text>
+
+          <rect x="400" y="208" width="240" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="520" y="234" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">apply_filters / filter_by_month</text>
+
+          <rect x="400" y="260" width="240" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="520" y="286" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">Pydantic models (validation)</text>
+
+          <rect x="400" y="312" width="240" height="42" rx="6" fill="#ffffff" stroke="#cbd5e1"/>
+          <text x="520" y="338" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="12" fill="#0f172a">mock_data.py (in-memory lists)</text>
+        </g>
+
+        <!-- Arrow server -> data -->
+        <line x1="670" y1="333" x2="750" y2="333" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+        <text x="710" y="324" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="11" fill="#64748b">load</text>
+        <text x="710" y="350" text-anchor="middle" font-family="SF Mono, monospace" font-size="10" fill="#94a3b8">at startup</text>
+
+        <!-- Data column -->
+        <g>
+          <rect x="760" y="40" width="180" height="380" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+          <text x="780" y="68" font-family="-apple-system, sans-serif" font-size="11" font-weight="600" fill="#64748b" letter-spacing="1.5">DATA</text>
+
+          <rect x="780" y="88" width="140" height="50" rx="6" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
+          <text x="850" y="111" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="13" font-weight="600" fill="#0f172a">JSON Files</text>
+          <text x="850" y="127" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="11" fill="#64748b">server/data/</text>
+
+          <text x="780" y="172" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">inventory.json</text>
+          <text x="780" y="194" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">orders.json</text>
+          <text x="780" y="216" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">demand_forecasts.json</text>
+          <text x="780" y="238" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">backlog_items.json</text>
+          <text x="780" y="260" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">spending.json</text>
+          <text x="780" y="282" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">transactions.json</text>
+          <text x="780" y="304" font-family="SF Mono, monospace" font-size="11" fill="#0f172a">purchase_orders.json</text>
+        </g>
+      </svg>
+    </div>
+  </section>
+
+  <section>
+    <h2>Data Flow</h2>
+    <div class="section-sub">End-to-end path for a typical filtered request — e.g. selecting "Q2-2025" on the Dashboard.</div>
+    <div class="flow">
+      <div class="flow-step"><div class="num">1</div><div class="body"><strong>User selects a filter</strong><span>FilterBar.vue &rarr; useFilters composable</span></div></div>
+      <div class="flow-step"><div class="num">2</div><div class="body"><strong>View reads current filters</strong><span>getCurrentFilters() returns { month, warehouse, category, status }</span></div></div>
+      <div class="flow-step"><div class="num">3</div><div class="body"><strong>API client builds request</strong><span>api.getOrders(filters) &rarr; URLSearchParams</span></div></div>
+      <div class="flow-step"><div class="num">4</div><div class="body"><strong>HTTP call to FastAPI</strong><span>GET /api/orders?month=Q2-2025</span></div></div>
+      <div class="flow-step"><div class="num">5</div><div class="body"><strong>Route handler runs</strong><span>main.py: get_orders() receives query params</span></div></div>
+      <div class="flow-step"><div class="num">6</div><div class="body"><strong>Filters applied in memory</strong><span>apply_filters() then filter_by_month()</span></div></div>
+      <div class="flow-step"><div class="num">7</div><div class="body"><strong>Pydantic validates response</strong><span>Order[] schema enforced before serialization</span></div></div>
+      <div class="flow-step"><div class="num">8</div><div class="body"><strong>JSON returned to client</strong><span>Axios resolves &rarr; ref() updated &rarr; computed re-runs</span></div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>API Endpoints</h2>
+    <div class="section-sub">All routes return JSON. Filter params are optional; "all" or omitted means no filter.</div>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr><th style="width:80px">Method</th><th>Endpoint</th><th>Purpose</th><th>Filters</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/inventory</code></td><td>List SKUs across warehouses</td><td><code>warehouse, category</code></td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/inventory/{id}</code></td><td>Single inventory item</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/orders</code></td><td>Customer orders</td><td><code>warehouse, category, status, month</code></td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/orders/{id}</code></td><td>Single order</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/demand</code></td><td>Demand forecasts</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/backlog</code></td><td>Unfulfilled items with PO status</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/dashboard/summary</code></td><td>Aggregated KPIs for landing page</td><td><code>all</code></td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/spending/summary</code></td><td>Total procurement, ops, labor, overhead</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/spending/monthly</code></td><td>Month-by-month cost breakdown</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/spending/categories</code></td><td>Cost distribution by category</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/spending/transactions</code></td><td>Recent transactions</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/reports/quarterly</code></td><td>Q1&ndash;Q4 2025 performance</td><td>&mdash;</td></tr>
+          <tr><td class="method"><span class="badge">GET</span></td><td><code>/api/reports/monthly-trends</code></td><td>Month-over-month trends</td><td>&mdash;</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>Views &amp; Routes</h2>
+    <div class="section-sub">Six top-level pages, each backed by a Composition-API view component.</div>
+    <div class="views-grid">
+      <div class="view-card">
+        <div class="route">/</div>
+        <h4>Dashboard</h4>
+        <p>KPIs, inventory overview, order metrics, revenue tracking.</p>
+      </div>
+      <div class="view-card">
+        <div class="route">/inventory</div>
+        <h4>Inventory</h4>
+        <p>Warehouse stock, SKU details, reorder points, locations.</p>
+      </div>
+      <div class="view-card">
+        <div class="route">/orders</div>
+        <h4>Orders</h4>
+        <p>Order status, customers, delivery tracking, date / status filters.</p>
+      </div>
+      <div class="view-card">
+        <div class="route">/demand</div>
+        <h4>Demand</h4>
+        <p>Forecasts, trend analysis, forecasted vs current demand per SKU.</p>
+      </div>
+      <div class="view-card">
+        <div class="route">/spending</div>
+        <h4>Spending</h4>
+        <p>Cost analytics, monthly and category breakdowns, transactions.</p>
+      </div>
+      <div class="view-card">
+        <div class="route">/reports</div>
+        <h4>Reports</h4>
+        <p>Quarterly performance summaries and monthly trend reports.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Key Design Choices</h2>
+    <div class="section-sub">Patterns worth knowing before making changes.</div>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="label">State</div>
+        <h3>No store library</h3>
+        <p style="font-size:13px;color:var(--text-muted);margin-top:6px;">Shared filter state lives in a singleton composable (useFilters). Each view manages its own loading / error / data refs. Derived data uses computed properties.</p>
+      </div>
+      <div class="stack-card">
+        <div class="label">Filtering</div>
+        <h3>Server-side, in-memory</h3>
+        <p style="font-size:13px;color:var(--text-muted);margin-top:6px;">FastAPI receives query params, filters Python lists with apply_filters / filter_by_month, and returns the trimmed result. Quarters (Q1&ndash;Q4) are mapped to month sets server-side.</p>
+      </div>
+      <div class="stack-card">
+        <div class="label">Validation</div>
+        <h3>Pydantic at the edge</h3>
+        <p style="font-size:13px;color:var(--text-muted);margin-top:6px;">Every endpoint declares a Pydantic response model. Changing a JSON field requires updating the model in main.py, otherwise responses fail validation.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    Architecture reference &middot; Factory Inventory Management Demo &middot; Vue 3 + FastAPI
+  </footer>
+
+</div>
+</body>
+</html>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,6 +22,9 @@
           <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
             {{ t('nav.demandForecast') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            Restocking
+          </router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,22 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingRecommendations(budget) {
+    const response = await axios.get(`${API_BASE_URL}/restocking/recommendations`, {
+      params: { budget }
+    })
+    return response.data
+  },
+
+  async submitRestockingOrder(payload) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/submit`, payload)
+    return response.data
+  },
+
+  async getSubmittedOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/submitted`)
+    return response.data
   }
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,6 +17,7 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
+    { path: '/restocking', component: Restocking },
     { path: '/reports', component: Reports }
   ]
 })

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -27,6 +27,48 @@
         </div>
       </div>
 
+      <div v-if="submittedOrders.length > 0" class="card submitted-orders-card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders ({{ submittedOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="submitted-table">
+            <thead>
+              <tr>
+                <th>Order #</th>
+                <th>Submitted</th>
+                <th>Items</th>
+                <th>Total Cost</th>
+                <th>Lead Time</th>
+                <th>Expected Delivery</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td><strong class="order-num">{{ order.order_number }}</strong></td>
+                <td>{{ formatDate(order.submitted_date) }}</td>
+                <td>
+                  <details class="items-details">
+                    <summary class="items-summary">{{ order.total_items }} item{{ order.total_items === 1 ? '' : 's' }}</summary>
+                    <div class="items-dropdown">
+                      <div v-for="item in order.items" :key="item.sku" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">Qty: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_cost }} · {{ item.lead_time_days }}d lead</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td><strong>{{ currencySymbol }}{{ order.total_cost.toLocaleString() }}</strong></td>
+                <td>{{ order.max_lead_time_days }} days</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td><span class="badge info">Submitted</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card">
         <div class="card-header">
           <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
@@ -95,6 +137,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const submittedOrders = ref([])
 
     // Use shared filters
     const {
@@ -153,7 +196,18 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    const loadSubmittedOrders = async () => {
+      try {
+        submittedOrders.value = await api.getSubmittedOrders()
+      } catch (err) {
+        console.error('Failed to load submitted orders:', err)
+      }
+    }
+
+    onMounted(() => {
+      loadOrders()
+      loadSubmittedOrders()
+    })
 
     return {
       t,
@@ -165,7 +219,8 @@ export default {
       formatDate,
       currencySymbol,
       translateProductName,
-      translateCustomerName
+      translateCustomerName,
+      submittedOrders
     }
   }
 }
@@ -275,5 +330,19 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+.submitted-orders-card {
+  border-left: 3px solid #2563eb;
+}
+
+.submitted-table {
+  width: 100%;
+}
+
+.submitted-table .order-num {
+  font-family: 'SF Mono', Monaco, Consolas, monospace;
+  font-size: 0.813rem;
+  color: #0f172a;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,390 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>Set your budget and we'll recommend items to restock — items below reorder point first, then those with increasing demand.</p>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Available Budget</h3>
+      </div>
+      <div class="budget-display">{{ formatCurrency(budget) }}</div>
+      <input
+        type="range"
+        min="0"
+        max="100000"
+        step="1000"
+        v-model.number="budget"
+        class="budget-slider"
+      />
+      <div class="slider-marks">
+        <span>$0</span>
+        <span>$100K</span>
+      </div>
+    </div>
+
+    <div v-if="!submitted">
+      <div v-if="loading && recommendations.length === 0" class="loading">Loading recommendations...</div>
+      <div v-else-if="error" class="error">{{ error }}</div>
+      <template v-else>
+        <div class="stats-grid">
+          <div class="stat-card info">
+            <div class="stat-label">Items to restock</div>
+            <div class="stat-value">{{ itemsCount }}</div>
+          </div>
+          <div class="stat-card warning">
+            <div class="stat-label">Total cost</div>
+            <div class="stat-value">{{ formatCurrency(totalCost) }}</div>
+          </div>
+          <div :class="['stat-card', budgetRemaining >= 0 ? 'success' : 'danger']">
+            <div class="stat-label">Budget remaining</div>
+            <div class="stat-value">{{ formatCurrency(budgetRemaining) }}</div>
+          </div>
+        </div>
+
+        <div :class="['card', { 'loading-overlay': loading && recommendations.length > 0 }]">
+          <div class="card-header">
+            <h3 class="card-title">Recommended Items ({{ recommendations.length }})</h3>
+          </div>
+          <div v-if="recommendations.length === 0" class="empty-state">
+            No items fit in this budget. Try increasing the budget.
+          </div>
+          <div v-else class="table-container">
+            <table class="restock-table">
+              <thead>
+                <tr>
+                  <th>SKU</th>
+                  <th>Product</th>
+                  <th>Category</th>
+                  <th>Warehouse</th>
+                  <th>Stock (curr / reorder)</th>
+                  <th>Qty to Order</th>
+                  <th>Unit Cost</th>
+                  <th>Line Cost</th>
+                  <th>Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in recommendations" :key="item.sku">
+                  <td class="sku-cell">{{ item.sku }}</td>
+                  <td>{{ translateProductName(item.name) }}</td>
+                  <td>{{ item.category }}</td>
+                  <td>{{ item.warehouse }}</td>
+                  <td class="stock-cell">
+                    <span :class="{ deficit: item.current_quantity < item.reorder_point }">{{ item.current_quantity }}</span>
+                    <span class="stock-sep"> / </span>
+                    <span>{{ item.reorder_point }}</span>
+                  </td>
+                  <td><strong>{{ item.quantity_to_order }}</strong></td>
+                  <td>{{ currencySymbol }}{{ item.unit_cost.toFixed(2) }}</td>
+                  <td><strong>{{ formatCurrency(item.line_cost) }}</strong></td>
+                  <td>
+                    <span :class="['badge', item.reason === 'below_reorder_point' ? 'danger' : 'info']">
+                      {{ item.reason === 'below_reorder_point' ? 'Below reorder' : 'Trend up' }}
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="place-order-bar">
+          <button
+            class="btn-primary"
+            :disabled="recommendations.length === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? 'Placing order...' : `Place Order (${formatCurrency(totalCost)})` }}
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <div v-else class="card success-card">
+      <div class="card-header">
+        <h3 class="card-title">Order placed</h3>
+      </div>
+      <div class="success-details">
+        <div class="success-row">
+          <span class="success-label">Order number</span>
+          <span class="success-value mono">{{ submittedOrder.order_number }}</span>
+        </div>
+        <div class="success-row">
+          <span class="success-label">Total cost</span>
+          <span class="success-value">{{ formatCurrency(submittedOrder.total_cost) }}</span>
+        </div>
+        <div class="success-row">
+          <span class="success-label">Items ordered</span>
+          <span class="success-value">{{ submittedOrder.total_items }}</span>
+        </div>
+        <div class="success-row">
+          <span class="success-label">Expected delivery</span>
+          <span class="success-value">{{ formatDate(submittedOrder.expected_delivery) }}</span>
+        </div>
+        <div class="success-row">
+          <span class="success-label">Lead time</span>
+          <span class="success-value">{{ submittedOrder.max_lead_time_days }} days</span>
+        </div>
+      </div>
+      <p class="success-hint">View it in the Orders tab under Submitted Restocking Orders.</p>
+      <div class="place-order-bar">
+        <button class="btn-outline" @click="resetAndReload">Plan another order</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency, translateProductName } = useI18n()
+
+    const currencySymbol = computed(() => currentCurrency.value === 'JPY' ? '¥' : '$')
+
+    const budget = ref(50000)
+    const loading = ref(false)
+    const error = ref(null)
+    const recommendations = ref([])
+    const itemsCount = ref(0)
+    const totalCost = ref(0)
+
+    const submitting = ref(false)
+    const submitted = ref(false)
+    const submittedOrder = ref(null)
+
+    const budgetRemaining = computed(() => budget.value - totalCost.value)
+
+    const formatCurrency = (value) =>
+      `${currencySymbol.value}${Number(value).toLocaleString('en-US', { maximumFractionDigits: 0 })}`
+
+    const formatDate = (dateString) => {
+      const d = new Date(dateString)
+      if (isNaN(d.getTime())) return dateString
+      return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    }
+
+    const loadRecommendations = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        const data = await api.getRestockingRecommendations(budget.value)
+        recommendations.value = data.recommendations
+        itemsCount.value = data.items_count
+        totalCost.value = data.total_cost
+      } catch (err) {
+        error.value = 'Failed to load recommendations. Please check that the backend is running.'
+        console.error(err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      submitting.value = true
+      error.value = null
+      try {
+        const items = recommendations.value.map(item => ({
+          sku: item.sku,
+          name: item.name,
+          category: item.category,
+          warehouse: item.warehouse,
+          unit_cost: item.unit_cost,
+          quantity: item.quantity_to_order
+        }))
+        const result = await api.submitRestockingOrder({ items, budget: budget.value })
+        submittedOrder.value = result
+        submitted.value = true
+      } catch (err) {
+        error.value = 'Failed to submit order. Please try again.'
+        console.error(err)
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    const resetAndReload = () => {
+      submitted.value = false
+      submittedOrder.value = null
+      loadRecommendations()
+    }
+
+    // Debounce slider changes to avoid hammering the API on every tick
+    let debounceTimer = null
+    watch(budget, () => {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(loadRecommendations, 300)
+    })
+
+    onMounted(() => loadRecommendations())
+
+    return {
+      t,
+      currencySymbol,
+      budget,
+      loading,
+      error,
+      recommendations,
+      itemsCount,
+      totalCost,
+      budgetRemaining,
+      submitting,
+      submitted,
+      submittedOrder,
+      formatCurrency,
+      formatDate,
+      placeOrder,
+      resetAndReload,
+      translateProductName
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-display {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+  margin-bottom: 1rem;
+}
+
+.budget-slider {
+  width: 100%;
+  accent-color: #2563eb;
+  height: 6px;
+}
+
+.slider-marks {
+  display: flex;
+  justify-content: space-between;
+  color: #64748b;
+  font-size: 0.813rem;
+  margin-top: 0.5rem;
+}
+
+.loading-overlay {
+  opacity: 0.6;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.sku-cell {
+  font-family: 'Courier New', Courier, monospace;
+  color: #475569;
+  font-size: 0.813rem;
+}
+
+.stock-cell .deficit {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.stock-sep {
+  color: #94a3b8;
+}
+
+.place-order-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.btn-primary {
+  padding: 0.875rem 1.75rem;
+  background: #0f172a;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.938rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1e293b;
+}
+
+.btn-primary:disabled {
+  background: #cbd5e1;
+  cursor: not-allowed;
+}
+
+.success-card {
+  border-left: 4px solid #059669;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+.success-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.success-row {
+  display: flex;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.success-label {
+  width: 160px;
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.success-value {
+  font-size: 0.938rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.success-value.mono {
+  font-family: 'Courier New', Courier, monospace;
+  color: #475569;
+}
+
+.success-hint {
+  font-size: 0.813rem;
+  color: #94a3b8;
+  margin-bottom: 1.25rem;
+}
+
+.btn-outline {
+  padding: 0.625rem 1.5rem;
+  background: white;
+  color: #0f172a;
+  border: 1.5px solid #0f172a;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.938rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-outline:hover {
+  background: #f1f5f9;
+}
+
+.restock-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+</style>

--- a/server/main.py
+++ b/server/main.py
@@ -1,8 +1,9 @@
+from datetime import datetime, timedelta
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
-from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders, submitted_orders
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -13,6 +14,18 @@ QUARTER_MAP = {
     'Q3-2025': ['2025-07', '2025-08', '2025-09'],
     'Q4-2025': ['2025-10', '2025-11', '2025-12']
 }
+
+# Delivery lead time per inventory category, in days. Used when computing the
+# expected delivery date for a submitted restocking order. Fallback below is
+# applied for any category not listed here.
+CATEGORY_LEAD_TIMES = {
+    "Circuit Boards": 14,
+    "Sensors": 7,
+    "Actuators": 10,
+    "Controllers": 12,
+    "Power Supplies": 9,
+}
+DEFAULT_LEAD_TIME_DAYS = 14
 
 def filter_by_month(items: list, month: Optional[str]) -> list:
     """Filter items by month/quarter based on order_date field"""
@@ -119,6 +132,58 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingRecommendation(BaseModel):
+    sku: str
+    name: str
+    category: str
+    warehouse: str
+    unit_cost: float
+    current_quantity: int
+    reorder_point: int
+    quantity_to_order: int
+    line_cost: float
+    reason: str  # 'below_reorder_point' | 'increasing_trend'
+    trend: Optional[str] = None
+
+class RestockingRecommendationsResponse(BaseModel):
+    budget: float
+    total_cost: float
+    items_count: int
+    recommendations: List[RestockingRecommendation]
+
+class SubmitOrderItemRequest(BaseModel):
+    sku: str
+    name: str
+    category: str
+    warehouse: str
+    unit_cost: float
+    quantity: int
+
+class SubmitOrderRequest(BaseModel):
+    items: List[SubmitOrderItemRequest]
+    budget: Optional[float] = None
+
+class SubmittedOrderItem(BaseModel):
+    sku: str
+    name: str
+    category: str
+    warehouse: str
+    unit_cost: float
+    quantity: int
+    line_cost: float
+    lead_time_days: int
+
+class SubmittedOrder(BaseModel):
+    id: str
+    order_number: str
+    submitted_date: str
+    total_cost: float
+    total_items: int
+    items: List[SubmittedOrderItem]
+    status: str
+    max_lead_time_days: int
+    expected_delivery: str
 
 # API endpoints
 @app.get("/")
@@ -303,6 +368,149 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking/recommendations", response_model=RestockingRecommendationsResponse)
+def get_restocking_recommendations(budget: float = 0.0):
+    """Recommend items to restock within a budget.
+
+    Priority 1: inventory items below their reorder_point — sorted by largest deficit.
+    Priority 2: items with an 'increasing' demand trend not already in P1.
+
+    Items are matched to demand forecasts by name (case-insensitive) because
+    demand_forecasts.json and inventory.json don't share SKU prefixes.
+    Greedy fill: line items are added in priority order while their line cost
+    fits in the remaining budget.
+    """
+    if budget < 0:
+        raise HTTPException(status_code=400, detail="Budget must be non-negative")
+
+    demand_by_name = {f["item_name"].lower(): f for f in demand_forecasts}
+
+    candidates = []
+
+    # Priority 1: below reorder point. Order enough to reach 2x reorder_point so the
+    # buffer is meaningful for the demo (a pure deficit refill could be a single unit).
+    for item in inventory_items:
+        if item["quantity_on_hand"] < item["reorder_point"]:
+            qty = (2 * item["reorder_point"]) - item["quantity_on_hand"]
+            forecast = demand_by_name.get(item["name"].lower())
+            candidates.append({
+                "sku": item["sku"],
+                "name": item["name"],
+                "category": item["category"],
+                "warehouse": item["warehouse"],
+                "unit_cost": item["unit_cost"],
+                "current_quantity": item["quantity_on_hand"],
+                "reorder_point": item["reorder_point"],
+                "quantity_to_order": qty,
+                "line_cost": round(qty * item["unit_cost"], 2),
+                "reason": "below_reorder_point",
+                "trend": forecast["trend"] if forecast else None,
+                "_priority": 1,
+                "_deficit": item["reorder_point"] - item["quantity_on_hand"],
+            })
+
+    p1_skus = {c["sku"] for c in candidates}
+
+    # Priority 2: trending up but not yet below reorder. Order ~30% of forecasted
+    # demand as a forward buffer.
+    for item in inventory_items:
+        if item["sku"] in p1_skus:
+            continue
+        forecast = demand_by_name.get(item["name"].lower())
+        if forecast and forecast["trend"] == "increasing":
+            qty = max(int(forecast["forecasted_demand"] * 0.3), 1)
+            candidates.append({
+                "sku": item["sku"],
+                "name": item["name"],
+                "category": item["category"],
+                "warehouse": item["warehouse"],
+                "unit_cost": item["unit_cost"],
+                "current_quantity": item["quantity_on_hand"],
+                "reorder_point": item["reorder_point"],
+                "quantity_to_order": qty,
+                "line_cost": round(qty * item["unit_cost"], 2),
+                "reason": "increasing_trend",
+                "trend": "increasing",
+                "_priority": 2,
+                "_deficit": 0,
+            })
+
+    candidates.sort(key=lambda c: (c["_priority"], -c["_deficit"], c["line_cost"]))
+
+    selected = []
+    total_cost = 0.0
+    for c in candidates:
+        if total_cost + c["line_cost"] <= budget:
+            c.pop("_priority", None)
+            c.pop("_deficit", None)
+            selected.append(c)
+            total_cost += c["line_cost"]
+
+    return {
+        "budget": budget,
+        "total_cost": round(total_cost, 2),
+        "items_count": len(selected),
+        "recommendations": selected,
+    }
+
+@app.post("/api/restocking/submit", response_model=SubmittedOrder)
+def submit_restocking_order(request: SubmitOrderRequest):
+    """Submit a restocking order. The order is stored in-memory (resets on
+    restart) and surfaces in /api/restocking/submitted.
+
+    Lead time is per-line based on category (CATEGORY_LEAD_TIMES). The order's
+    expected_delivery uses the longest line lead time so the whole order is
+    considered fulfilled once the slowest item arrives.
+    """
+    if not request.items:
+        raise HTTPException(status_code=400, detail="At least one item is required")
+
+    submitted_at = datetime.now()
+    order_number = f"RST-{submitted_at.strftime('%Y%m%d-%H%M%S')}"
+
+    order_items = []
+    total_cost = 0.0
+    max_lead = 0
+    for item in request.items:
+        if item.quantity <= 0:
+            raise HTTPException(status_code=400, detail=f"Quantity for {item.sku} must be positive")
+        lead = CATEGORY_LEAD_TIMES.get(item.category, DEFAULT_LEAD_TIME_DAYS)
+        line_cost = round(item.unit_cost * item.quantity, 2)
+        total_cost += line_cost
+        if lead > max_lead:
+            max_lead = lead
+        order_items.append({
+            "sku": item.sku,
+            "name": item.name,
+            "category": item.category,
+            "warehouse": item.warehouse,
+            "unit_cost": item.unit_cost,
+            "quantity": item.quantity,
+            "line_cost": line_cost,
+            "lead_time_days": lead,
+        })
+
+    expected_delivery = (submitted_at + timedelta(days=max_lead)).date().isoformat()
+
+    new_order = {
+        "id": f"sub-{len(submitted_orders) + 1}",
+        "order_number": order_number,
+        "submitted_date": submitted_at.isoformat(),
+        "total_cost": round(total_cost, 2),
+        "total_items": len(order_items),
+        "items": order_items,
+        "status": "Submitted",
+        "max_lead_time_days": max_lead,
+        "expected_delivery": expected_delivery,
+    }
+    submitted_orders.append(new_order)
+    return new_order
+
+@app.get("/api/restocking/submitted", response_model=List[SubmittedOrder])
+def get_submitted_orders():
+    """List submitted restocking orders, most recent first."""
+    return sorted(submitted_orders, key=lambda o: o["submitted_date"], reverse=True)
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/mock_data.py
+++ b/server/mock_data.py
@@ -35,5 +35,10 @@ recent_transactions = load_json_file('transactions.json')
 # Load purchase orders
 purchase_orders = load_json_file('purchase_orders.json')
 
+# In-memory list for restocking orders submitted via /api/restocking/submit.
+# Intentionally not persisted to disk — resets on server restart, matching the
+# rest of the mock-data model.
+submitted_orders = []
+
 # All data is now loaded from JSON files in the data/ directory
 # This allows for easier maintenance and updates of the sample data


### PR DESCRIPTION
## Summary

- New **Restocking** tab: budget slider drives recommendations from inventory + demand forecasts, with a Place Order button that submits an in-memory order.
- **Orders** tab gains a *Submitted Restocking Orders* section showing order number, items, lead time, and expected delivery.
- New `architecture.html` overview of the system, tech stack, and data flow.
- CLAUDE.md: added code-style rule to document non-obvious logic with comments.

## Commits

1. Add code style rule: document non-obvious logic with comments
2. Add architecture overview page
3. Add restocking backend: recommendations, submit, submitted list
4. Add restocking frontend: budget-driven recommendations and submission

## How it works

**Backend** — three new endpoints in `server/main.py`:

- `GET /api/restocking/recommendations?budget=N` — priority 1: items where `quantity_on_hand < reorder_point` (qty = `2 * reorder_point - on_hand`); priority 2: items with demand trend = increasing (qty = `forecasted_demand * 0.3`). Greedy-fills within the budget. Items are matched between inventory and demand forecasts by name (case-insensitive) because the two JSON files use different SKU schemes.
- `POST /api/restocking/submit` — stores order in `submitted_orders` (in-memory list in `server/mock_data.py`, resets on backend restart). Computes `expected_delivery` from the max per-category lead time (Circuit Boards 14d, Sensors 7d, Actuators 10d, Controllers 12d, Power Supplies 9d).
- `GET /api/restocking/submitted` — returns submitted orders, newest first.

**Frontend** — new `client/src/views/Restocking.vue`: $0–$100K budget slider, 300ms debounce, 3 summary cards (items / total cost / budget remaining), recommendations table with Below-reorder / Trend-up badges, then Place Order → success card with order number, expected delivery, and lead time. `Orders.vue` gains a "Submitted Restocking Orders" section above All Orders.

## Test plan

- [ ] Backend: start `server/` (`uv run python main.py`), hit `GET /api/restocking/recommendations?budget=100000` — expect 4 items (TMP-201, PSU-508, SRV-301, SRV-302) totaling ~$86,525.
- [ ] Backend: `POST /api/restocking/submit` with the recommendations — expect `RST-YYYYMMDD-HHMMSS` order number, `expected_delivery` = today + max line-item lead time.
- [ ] Backend: `GET /api/restocking/submitted` returns the submitted order.
- [ ] Frontend: `/restocking` page loads, slider changes update recommendations (debounced), Place Order shows success card.
- [ ] Frontend: `/orders` shows "Submitted Restocking Orders" section with the order; section is hidden when there are no submitted orders.
- [ ] Restart backend, refresh `/orders` — submitted list resets (in-memory only, expected for the demo).
