### PR TITLE
Add budget-based restocking feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,9 @@ npm install && npm run dev
 **Data Flow**: Vue filters → `client/src/api.js` → FastAPI → In-memory filtering → Pydantic validation → Computed properties
 **Reactivity**: Raw data in refs (`allOrders`, `inventoryItems`), derived data in computed properties
 
+## Code Style
+- Always document non-obvious logic changes with comments
+
 ## API Endpoints
 - `GET /api/inventory` - Filters: warehouse, category
 - `GET /api/orders` - Filters: warehouse, category, status, month

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,6 +22,9 @@
           <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
             {{ t('nav.demandForecast') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,10 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async createRestockOrder(payload) {
+    const response = await axios.post(`${API_BASE_URL}/orders`, payload)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -106,11 +107,13 @@ export default {
     title: 'Orders',
     description: 'View and manage customer orders',
     allOrders: 'All Orders',
+    submittedOrders: 'Submitted Orders',
     totalOrders: 'Total Orders',
     totalRevenue: 'Total Revenue',
     avgOrderValue: 'Avg Order Value',
     onTimeDelivery: 'On-Time Delivery',
     itemsCount: '{count} items',
+    leadTimeDays: '{days} days',
     quantity: 'Qty',
     table: {
       orderNumber: 'Order Number',
@@ -125,7 +128,33 @@ export default {
       totalValue: 'Total Value',
       status: 'Status',
       expectedDelivery: 'Expected Delivery',
-      actualDelivery: 'Actual Delivery'
+      actualDelivery: 'Actual Delivery',
+      leadTime: 'Lead Time'
+    }
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Set a budget and order recommended restock quantities from the demand forecast',
+    budgetLabel: 'Available Budget',
+    recommendationsTitle: 'Recommended Restock',
+    noRecommendations: 'No items fit within this budget. Increase the budget to see recommendations.',
+    totalCost: 'Total Cost',
+    remaining: 'Remaining Budget',
+    placeOrder: 'Place Order',
+    placingOrder: 'Placing order...',
+    orderPlaced: 'Restocking order {orderNumber} submitted successfully.',
+    viewInOrders: 'View in Orders',
+    table: {
+      sku: 'SKU',
+      itemName: 'Item Name',
+      currentDemand: 'Current Demand',
+      forecastedDemand: 'Forecasted Demand',
+      recommendedQty: 'Recommended Qty',
+      unitCost: 'Unit Cost',
+      lineTotal: 'Line Total',
+      trend: 'Trend'
     }
   },
 
@@ -204,6 +233,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    submitted: 'Submitted',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '在庫補充',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -106,11 +107,13 @@ export default {
     title: '注文',
     description: '顧客注文の表示と管理',
     allOrders: 'すべての注文',
+    submittedOrders: '提出済み注文',
     totalOrders: '総注文数',
     totalRevenue: '総収益',
     avgOrderValue: '平均注文額',
     onTimeDelivery: '定時配達',
     itemsCount: '{count}件',
+    leadTimeDays: '{days}日',
     quantity: '数量',
     table: {
       orderNumber: '注文番号',
@@ -125,7 +128,33 @@ export default {
       totalValue: '合計金額',
       status: 'ステータス',
       expectedDelivery: '予定配達日',
-      actualDelivery: '実際の配達日'
+      actualDelivery: '実際の配達日',
+      leadTime: 'リードタイム'
+    }
+  },
+
+  // Restocking
+  restocking: {
+    title: '在庫補充',
+    description: '予算を設定し、需要予測から推奨される補充数量を発注します',
+    budgetLabel: '利用可能な予算',
+    recommendationsTitle: '推奨補充',
+    noRecommendations: 'この予算に収まる品目がありません。予算を増やすと推奨が表示されます。',
+    totalCost: '合計コスト',
+    remaining: '残り予算',
+    placeOrder: '発注する',
+    placingOrder: '発注中...',
+    orderPlaced: '在庫補充注文 {orderNumber} が正常に提出されました。',
+    viewInOrders: '注文で表示',
+    table: {
+      sku: 'SKU',
+      itemName: '品目名',
+      currentDemand: '現在の需要',
+      forecastedDemand: '予測需要',
+      recommendedQty: '推奨数量',
+      unitCost: '単価',
+      lineTotal: '小計',
+      trend: 'トレンド'
     }
   },
 
@@ -204,6 +233,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    submitted: '提出済み',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,6 +5,7 @@ import Dashboard from './views/Dashboard.vue'
 import Inventory from './views/Inventory.vue'
 import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
+import Restocking from './views/Restocking.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
 
@@ -15,6 +16,7 @@ const router = createRouter({
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
+    { path: '/restocking', component: Restocking },
     { path: '/spending', component: Spending },
     { path: '/reports', component: Reports }
   ]

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -29,7 +29,7 @@
 
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
+          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ activeOrders.length }})</h3>
         </div>
         <div class="table-container">
           <table class="orders-table">
@@ -45,7 +45,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="order in orders" :key="order.id">
+              <tr v-for="order in activeOrders" :key="order.id">
                 <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
                 <td class="col-customer">{{ translateCustomerName(order.customer) }}</td>
                 <td class="col-items">
@@ -69,6 +69,48 @@
                 <td class="col-date">{{ formatDate(order.order_date) }}</td>
                 <td class="col-date">{{ formatDate(order.expected_delivery) }}</td>
                 <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div v-if="submittedOrders.length > 0" class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('orders.submittedOrders') }} ({{ submittedOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-items">{{ t('orders.table.items') }}</th>
+                <th class="col-value">{{ t('orders.table.totalValue') }}</th>
+                <th class="col-date">{{ t('orders.table.orderDate') }}</th>
+                <th class="col-date">{{ t('orders.table.expectedDelivery') }}</th>
+                <th class="col-lead-time">{{ t('orders.table.leadTime') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_price }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+                <td class="col-date">{{ formatDate(order.order_date) }}</td>
+                <td class="col-date">{{ formatDate(order.expected_delivery) }}</td>
+                <td class="col-lead-time">{{ t('orders.leadTimeDays', { days: getLeadTimeDays(order) }) }}</td>
               </tr>
             </tbody>
           </table>
@@ -129,6 +171,17 @@ export default {
       loadOrders()
     })
 
+    // Orders shown in the main "All Orders" table — submitted restock orders
+    // are broken out into their own section below.
+    const activeOrders = computed(() => {
+      return orders.value.filter(order => order.status !== 'Submitted')
+    })
+
+    // Submitted restock orders, rendered in a dedicated card.
+    const submittedOrders = computed(() => {
+      return orders.value.filter(order => order.status === 'Submitted')
+    })
+
     const getOrdersByStatus = (status) => {
       return orders.value.filter(order => order.status === status)
     }
@@ -138,9 +191,18 @@ export default {
         'Delivered': 'success',
         'Shipped': 'info',
         'Processing': 'warning',
-        'Backordered': 'danger'
+        'Backordered': 'danger',
+        'Submitted': 'submitted'
       }
       return statusMap[status] || 'info'
+    }
+
+    // Lead time in whole days between order placement and expected delivery.
+    // 86400000 ms = 1 day; Math.round smooths any DST/partial-day drift.
+    const getLeadTimeDays = (order) => {
+      return Math.round(
+        (new Date(order.expected_delivery) - new Date(order.order_date)) / 86400000
+      )
     }
 
     const formatDate = (dateString) => {
@@ -160,8 +222,11 @@ export default {
       loading,
       error,
       orders,
+      activeOrders,
+      submittedOrders,
       getOrdersByStatus,
       getOrderStatusClass,
+      getLeadTimeDays,
       formatDate,
       currencySymbol,
       translateProductName,
@@ -201,6 +266,16 @@ export default {
 
 .col-value {
   width: 120px;
+}
+
+.col-lead-time {
+  width: 120px;
+}
+
+/* Submitted restock orders badge */
+.badge.submitted {
+  background: #e0e7ff;
+  color: #3730a3;
 }
 
 /* Items details styling */

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,364 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.budgetLabel') }}</h3>
+          <div class="budget-value">{{ currencySymbol }}{{ budget.toLocaleString() }}</div>
+        </div>
+        <input
+          type="range"
+          class="budget-slider"
+          min="0"
+          :max="sliderMax"
+          :step="sliderStep"
+          v-model.number="budget"
+        />
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.recommendationsTitle') }}</h3>
+        </div>
+
+        <div v-if="recommendations.length === 0" class="no-recommendations">
+          {{ t('restocking.noRecommendations') }}
+        </div>
+
+        <div v-else>
+          <div class="table-container">
+            <table>
+              <thead>
+                <tr>
+                  <th>{{ t('restocking.table.sku') }}</th>
+                  <th>{{ t('restocking.table.itemName') }}</th>
+                  <th>{{ t('restocking.table.recommendedQty') }}</th>
+                  <th>{{ t('restocking.table.unitCost') }}</th>
+                  <th>{{ t('restocking.table.lineTotal') }}</th>
+                  <th>{{ t('restocking.table.trend') }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="rec in recommendations" :key="rec.sku">
+                  <td><strong>{{ rec.sku }}</strong></td>
+                  <td>{{ translateProductName(rec.name) }}</td>
+                  <td>{{ rec.quantity }}</td>
+                  <td>{{ currencySymbol }}{{ rec.unit_cost.toLocaleString() }}</td>
+                  <td><strong>{{ currencySymbol }}{{ rec.lineTotal.toLocaleString() }}</strong></td>
+                  <td>
+                    <span :class="['badge', rec.trend]">
+                      {{ t(`trends.${rec.trend}`) }}
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="totals">
+            <div class="total-row">
+              <span class="total-label">{{ t('restocking.totalCost') }}</span>
+              <span class="total-amount">{{ currencySymbol }}{{ totalCost.toLocaleString() }}</span>
+            </div>
+            <div class="total-row">
+              <span class="total-label">{{ t('restocking.remaining') }}</span>
+              <span class="total-amount">{{ currencySymbol }}{{ remaining.toLocaleString() }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <button
+          class="place-order-btn"
+          :disabled="recommendations.length === 0 || totalCost === 0 || submitting || !!placedOrderNumber"
+          @click="placeOrder"
+        >
+          {{ submitting ? t('restocking.placingOrder') : t('restocking.placeOrder') }}
+        </button>
+
+        <div v-if="placedOrderNumber" class="order-success">
+          {{ t('restocking.orderPlaced', { orderNumber: placedOrderNumber }) }}
+          <router-link to="/orders" class="view-orders-link">
+            {{ t('restocking.viewInOrders') }}
+          </router-link>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, computed, watch } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency, translateProductName } = useI18n()
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? '¥' : '$'
+    })
+
+    const loading = ref(true)
+    const error = ref(null)
+    const forecasts = ref([])
+
+    // User-controlled restock budget (drives the recommendations below)
+    const budget = ref(100000)
+
+    const submitting = ref(false)
+    const placedOrderNumber = ref(null)
+
+    const loadForecasts = async () => {
+      try {
+        loading.value = true
+        error.value = null
+        forecasts.value = await api.getDemandForecasts()
+        // Start the budget at the slider ceiling so every eligible item is funded
+        // up front; the user drags down to trim. sliderMax derives from the data
+        // just loaded, so reading it here reflects the fresh forecasts.
+        budget.value = sliderMax.value
+      } catch (err) {
+        error.value = 'Failed to load demand forecasts: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    // Eligible restock candidates: rising-demand items that are actually short
+    // on stock and have a positive unit cost (so the budget math can't divide by
+    // zero). shortfall = extra units needed to cover forecasted demand. Sorted so
+    // the budget covers the biggest shortfalls first.
+    const eligibleItems = computed(() => {
+      return forecasts.value
+        .filter(f => f.trend === 'increasing' && f.unit_cost > 0)
+        .map(f => ({
+          ...f,
+          shortfall: Math.max(f.forecasted_demand - f.current_demand, 0)
+        }))
+        .filter(f => f.shortfall > 0)
+        .sort((a, b) => b.shortfall - a.shortfall)
+    })
+
+    // Budget needed to fully fund every eligible item.
+    const maxEligibleCost = computed(() => {
+      return eligibleItems.value.reduce((sum, i) => sum + i.shortfall * i.unit_cost, 0)
+    })
+
+    // Scale the slider to the data: cap it just above the cost of funding
+    // everything (rounded up to a clean increment) so dragging the budget
+    // meaningfully adds/removes items across the whole range instead of sitting
+    // far past the point where all items are already funded.
+    const sliderMax = computed(() => Math.max(1000, Math.ceil(maxEligibleCost.value / 500) * 500))
+    const sliderStep = computed(() => Math.max(1, Math.round(sliderMax.value / 100)))
+
+    // Greedy budget-constrained restock recommendations.
+    // Recomputes automatically whenever the budget or forecasts change.
+    const recommendations = computed(() => {
+      const result = []
+      let remainingBudget = budget.value
+
+      for (const item of eligibleItems.value) {
+        const fullCost = item.shortfall * item.unit_cost
+
+        if (fullCost <= remainingBudget) {
+          // Whole shortfall fits within the remaining budget: take it all.
+          remainingBudget -= fullCost
+          result.push({
+            sku: item.item_sku,
+            name: item.item_name,
+            quantity: item.shortfall,
+            unit_cost: item.unit_cost,
+            lineTotal: fullCost,
+            trend: item.trend
+          })
+        } else {
+          // Not enough budget for the full shortfall: take as many whole units
+          // as the leftover budget allows. This exhausts the budget, so stop.
+          const affordableQty = Math.floor(remainingBudget / item.unit_cost)
+          if (affordableQty >= 1) {
+            const lineTotal = affordableQty * item.unit_cost
+            remainingBudget -= lineTotal
+            result.push({
+              sku: item.item_sku,
+              name: item.item_name,
+              quantity: affordableQty,
+              unit_cost: item.unit_cost,
+              lineTotal,
+              trend: item.trend
+            })
+          }
+          // Budget can't fund even a single unit (or has just been exhausted) —
+          // remaining lower-priority items are skipped.
+          break
+        }
+      }
+
+      return result
+    })
+
+    const totalCost = computed(() => {
+      return recommendations.value.reduce((sum, rec) => sum + rec.lineTotal, 0)
+    })
+
+    const remaining = computed(() => {
+      return budget.value - totalCost.value
+    })
+
+    const placeOrder = async () => {
+      try {
+        submitting.value = true
+        error.value = null
+        placedOrderNumber.value = null
+
+        const payload = {
+          items: recommendations.value.map(rec => ({
+            sku: rec.sku,
+            name: rec.name,
+            quantity: rec.quantity,
+            unit_price: rec.unit_cost
+          }))
+        }
+
+        const order = await api.createRestockOrder(payload)
+        placedOrderNumber.value = order.order_number
+      } catch (err) {
+        error.value = 'Failed to place restock order: ' + err.message
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    // Clear the "order placed" state when the budget changes so the user can
+    // submit a fresh order; this also prevents double-submitting the same set.
+    watch(budget, () => {
+      placedOrderNumber.value = null
+    })
+
+    onMounted(loadForecasts)
+
+    return {
+      t,
+      loading,
+      error,
+      budget,
+      sliderMax,
+      sliderStep,
+      currencySymbol,
+      recommendations,
+      totalCost,
+      remaining,
+      submitting,
+      placedOrderNumber,
+      placeOrder,
+      translateProductName
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.budget-slider {
+  width: 100%;
+  accent-color: #3b82f6;
+  cursor: pointer;
+}
+
+.no-recommendations {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+.totals {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.total-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 320px;
+  margin-left: auto;
+}
+
+.total-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.total-amount {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.place-order-btn {
+  background: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.938rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.place-order-btn:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.place-order-btn:disabled {
+  background: #cbd5e1;
+  cursor: not-allowed;
+}
+
+.order-success {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  color: #0f172a;
+  font-size: 0.938rem;
+}
+
+.view-orders-link {
+  margin-left: 0.5rem;
+  color: #3b82f6;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.view-orders-link:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,470 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Factory Inventory Management — System Architecture</title>
+<style>
+  :root {
+    --ink: #0f172a;
+    --muted: #64748b;
+    --line: #e2e8f0;
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --accent: #2563eb;
+    --green: #16a34a;
+    --amber: #d97706;
+    --violet: #7c3aed;
+    --radius: 10px;
+    --shadow: 0 1px 2px rgba(15,23,42,.06), 0 4px 12px rgba(15,23,42,.05);
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+  header.hero {
+    background: var(--ink);
+    color: #fff;
+    padding: 56px 0 48px;
+    border-bottom: 4px solid var(--accent);
+  }
+  header.hero .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: .14em;
+    font-size: 12px;
+    font-weight: 600;
+    color: #93c5fd;
+    margin: 0 0 10px;
+  }
+  header.hero h1 { margin: 0 0 12px; font-size: 34px; font-weight: 700; letter-spacing: -.02em; }
+  header.hero p { margin: 0; max-width: 720px; color: #cbd5e1; font-size: 16px; }
+  .badges { margin-top: 22px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .badge {
+    background: rgba(255,255,255,.10);
+    border: 1px solid rgba(255,255,255,.18);
+    color: #e2e8f0;
+    padding: 5px 12px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  nav.toc {
+    position: sticky; top: 0; z-index: 10;
+    background: rgba(255,255,255,.92);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--line);
+  }
+  nav.toc .wrap { display: flex; gap: 4px; flex-wrap: wrap; padding-top: 10px; padding-bottom: 10px; }
+  nav.toc a {
+    color: var(--muted); text-decoration: none; font-size: 13px; font-weight: 600;
+    padding: 6px 12px; border-radius: 6px;
+  }
+  nav.toc a:hover { color: var(--ink); background: var(--bg); }
+
+  section { padding: 44px 0; border-bottom: 1px solid var(--line); }
+  section h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: .12em;
+    color: var(--accent); margin: 0 0 6px; font-weight: 700;
+  }
+  section h2 + .lead { margin: 0 0 26px; font-size: 22px; font-weight: 600; letter-spacing: -.01em; }
+  .desc { color: var(--muted); max-width: 760px; margin: 0 0 26px; }
+
+  /* ---- Architecture diagram ---- */
+  .diagram { display: flex; flex-direction: column; gap: 0; align-items: center; }
+  .tier {
+    width: 100%; background: var(--card); border: 1px solid var(--line);
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 20px 22px;
+  }
+  .tier-head { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; }
+  .dot { width: 10px; height: 10px; border-radius: 50%; flex: none; }
+  .tier-head h3 { margin: 0; font-size: 16px; }
+  .tier-head .tag { margin-left: auto; font-size: 12px; color: var(--muted); font-weight: 600; }
+  .nodes { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+  .node {
+    border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px;
+    background: var(--bg); font-size: 13px;
+  }
+  .node strong { display: block; font-size: 13px; }
+  .node span { color: var(--muted); font-size: 12px; }
+  .arrow {
+    color: var(--muted); font-size: 13px; padding: 12px 0; display: flex; flex-direction: column;
+    align-items: center; gap: 2px; font-weight: 600;
+  }
+  .arrow .glyph { font-size: 20px; line-height: 1; }
+  .arrow .lbl { font-size: 12px; color: var(--muted); font-weight: 500; }
+
+  /* ---- Tech stack grid ---- */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    box-shadow: var(--shadow); padding: 20px;
+  }
+  .card .ic { width: 34px; height: 34px; border-radius: 8px; display: grid; place-items: center;
+    font-weight: 700; color: #fff; font-size: 14px; margin-bottom: 12px; }
+  .card h4 { margin: 0 0 4px; font-size: 15px; }
+  .card .meta { color: var(--muted); font-size: 12px; margin-bottom: 12px; font-weight: 600; }
+  .card ul { margin: 0; padding-left: 18px; color: var(--muted); font-size: 13px; }
+  .card ul li { margin: 3px 0; }
+
+  /* ---- Data flow steps ---- */
+  .steps { counter-reset: step; display: grid; gap: 14px; }
+  .step {
+    display: grid; grid-template-columns: 40px 1fr; gap: 16px; align-items: start;
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    box-shadow: var(--shadow); padding: 16px 18px;
+  }
+  .step .num {
+    counter-increment: step; width: 32px; height: 32px; border-radius: 50%;
+    background: var(--accent); color: #fff; font-weight: 700; display: grid; place-items: center;
+    font-size: 14px;
+  }
+  .step .num::before { content: counter(step); }
+  .step h4 { margin: 0 0 3px; font-size: 15px; }
+  .step p { margin: 0; color: var(--muted); font-size: 13px; }
+  .step code { background: var(--bg); border: 1px solid var(--line); border-radius: 4px;
+    padding: 1px 6px; font-size: 12px; color: var(--ink); }
+
+  /* ---- Endpoint table ---- */
+  table { width: 100%; border-collapse: collapse; background: var(--card);
+    border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); }
+  th, td { text-align: left; padding: 11px 16px; font-size: 13px; border-bottom: 1px solid var(--line); }
+  th { background: var(--bg); color: var(--muted); text-transform: uppercase; letter-spacing: .06em; font-size: 11px; }
+  tr:last-child td { border-bottom: none; }
+  td code { font-size: 12px; color: var(--accent); font-weight: 600; }
+  .pill { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
+  .get { background: #dcfce7; color: #166534; }
+  .post { background: #dbeafe; color: #1e40af; }
+  .planned { background: #fef3c7; color: #92400e; }
+
+  /* ---- File tree ---- */
+  .tree {
+    background: var(--ink); color: #e2e8f0; border-radius: var(--radius); padding: 22px 24px;
+    font-family: "SF Mono", "Cascadia Code", Consolas, monospace; font-size: 13px; line-height: 1.7;
+    overflow-x: auto;
+  }
+  .tree .d { color: #93c5fd; }
+  .tree .c { color: #64748b; }
+
+  .callout {
+    background: #fffbeb; border: 1px solid #fde68a; border-left: 4px solid var(--amber);
+    border-radius: 8px; padding: 14px 18px; color: #78350f; font-size: 13px; margin-top: 22px;
+  }
+  .callout strong { color: #92400e; }
+
+  footer { padding: 30px 0 50px; color: var(--muted); font-size: 13px; text-align: center; }
+
+  @media (max-width: 640px) {
+    header.hero h1 { font-size: 26px; }
+    .step { grid-template-columns: 32px 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <p class="eyebrow">System Architecture</p>
+    <h1>Factory Inventory Management System</h1>
+    <p>A full-stack demo application for inventory tracking, order management, demand forecasting,
+       and spending analytics. Single-page Vue 3 frontend, FastAPI backend, and file-based mock
+       data — no database.</p>
+    <div class="badges">
+      <span class="badge">Vue 3 + Vite</span>
+      <span class="badge">Python · FastAPI</span>
+      <span class="badge">Pydantic</span>
+      <span class="badge">Axios</span>
+      <span class="badge">In-memory JSON data</span>
+      <span class="badge">REST API</span>
+    </div>
+  </div>
+</header>
+
+<nav class="toc">
+  <div class="wrap">
+    <a href="#overview">Overview</a>
+    <a href="#stack">Tech Stack</a>
+    <a href="#architecture">Architecture</a>
+    <a href="#dataflow">Data Flow</a>
+    <a href="#api">API Surface</a>
+    <a href="#structure">Project Structure</a>
+  </div>
+</nav>
+
+<main class="wrap">
+
+  <!-- OVERVIEW -->
+  <section id="overview">
+    <h2>Overview</h2>
+    <div class="lead">A two-tier web app with a clear client / server split</div>
+    <p class="desc">
+      The system is organized into a <strong>Vue 3 single-page application</strong> (port 3000) that
+      renders all UI and charts, and a <strong>FastAPI service</strong> (port 8001) that exposes a
+      read-focused REST API over sample data. There is no database — the backend loads JSON files
+      from disk into memory at startup and serves them through validated, filterable endpoints.
+      Communication is one direction at runtime: the browser calls the API over HTTP/JSON via Axios.
+    </p>
+    <div class="grid">
+      <div class="card">
+        <div class="ic" style="background:var(--green)">UI</div>
+        <h4>Presentation</h4>
+        <div class="meta">client/ · Vue 3 SPA</div>
+        <ul><li>7 routed views</li><li>9 reusable components</li><li>Custom SVG charts, i18n (EN/JA)</li></ul>
+      </div>
+      <div class="card">
+        <div class="ic" style="background:var(--accent)">API</div>
+        <h4>Application</h4>
+        <div class="meta">server/ · FastAPI</div>
+        <ul><li>REST endpoints + filtering</li><li>Pydantic validation</li><li>CORS for the dev frontend</li></ul>
+      </div>
+      <div class="card">
+        <div class="ic" style="background:var(--violet)">DATA</div>
+        <h4>Data</h4>
+        <div class="meta">server/data/ · JSON</div>
+        <ul><li>7 JSON datasets</li><li>Loaded once at startup</li><li>In-memory, read-only</li></ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- TECH STACK -->
+  <section id="stack">
+    <h2>Tech Stack</h2>
+    <div class="lead">What each layer is built with</div>
+    <div class="grid">
+      <div class="card">
+        <div class="ic" style="background:var(--green)">F</div>
+        <h4>Frontend</h4>
+        <div class="meta">client/</div>
+        <ul>
+          <li>Vue 3 (Composition API)</li>
+          <li>Vite 5 dev server &amp; build</li>
+          <li>vue-router 4 (history mode)</li>
+          <li>Axios HTTP client</li>
+          <li>Composables: filters, auth, i18n</li>
+          <li>Hand-rolled SVG charts</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="ic" style="background:var(--accent)">B</div>
+        <h4>Backend</h4>
+        <div class="meta">server/</div>
+        <ul>
+          <li>Python ≥ 3.11</li>
+          <li>FastAPI web framework</li>
+          <li>Uvicorn ASGI server</li>
+          <li>Pydantic v2 models</li>
+          <li>CORS middleware</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="ic" style="background:var(--violet)">D</div>
+        <h4>Data</h4>
+        <div class="meta">server/data/</div>
+        <ul>
+          <li>inventory.json</li>
+          <li>orders.json</li>
+          <li>demand_forecasts.json</li>
+          <li>backlog_items.json</li>
+          <li>purchase_orders.json</li>
+          <li>spending.json · transactions.json</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="ic" style="background:var(--muted)">T</div>
+        <h4>Tooling</h4>
+        <div class="meta">repo-wide</div>
+        <ul>
+          <li>uv (Python env &amp; deps)</li>
+          <li>npm (frontend deps)</li>
+          <li>pytest + FastAPI TestClient</li>
+          <li>.claude/ agents, commands, hooks</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ARCHITECTURE DIAGRAM -->
+  <section id="architecture">
+    <h2>Architecture</h2>
+    <div class="lead">How the tiers connect</div>
+    <p class="desc">Each box is a real layer in the codebase. Data is loaded bottom-up at startup,
+      and requests flow top-down at runtime.</p>
+
+    <div class="diagram">
+
+      <div class="tier">
+        <div class="tier-head">
+          <span class="dot" style="background:var(--green)"></span>
+          <h3>Browser — Vue 3 SPA</h3>
+          <span class="tag">localhost:3000</span>
+        </div>
+        <div class="nodes">
+          <div class="node"><strong>App.vue</strong><span>Layout, nav, FilterBar, ProfileMenu</span></div>
+          <div class="node"><strong>Views (7)</strong><span>Dashboard, Inventory, Orders, Demand, Spending, Reports, Backlog</span></div>
+          <div class="node"><strong>Components (9)</strong><span>Detail modals, filters, language switcher</span></div>
+          <div class="node"><strong>Composables</strong><span>useFilters · useAuth · useI18n</span></div>
+        </div>
+      </div>
+
+      <div class="arrow">
+        <span class="glyph">&#8595;</span>
+        <span class="lbl">api.js (Axios) — HTTP GET/POST with filter query params</span>
+      </div>
+
+      <div class="tier">
+        <div class="tier-head">
+          <span class="dot" style="background:var(--accent)"></span>
+          <h3>FastAPI Service</h3>
+          <span class="tag">localhost:8001</span>
+        </div>
+        <div class="nodes">
+          <div class="node"><strong>Route handlers</strong><span>main.py — /api/* endpoints</span></div>
+          <div class="node"><strong>Filter helpers</strong><span>apply_filters() · filter_by_month()</span></div>
+          <div class="node"><strong>Pydantic models</strong><span>Validate &amp; shape responses</span></div>
+          <div class="node"><strong>CORS middleware</strong><span>Allows the dev frontend origin</span></div>
+        </div>
+      </div>
+
+      <div class="arrow">
+        <span class="glyph">&#8595;</span>
+        <span class="lbl">mock_data.py — imports in-memory Python lists/dicts</span>
+      </div>
+
+      <div class="tier">
+        <div class="tier-head">
+          <span class="dot" style="background:var(--violet)"></span>
+          <h3>Data Layer — JSON files</h3>
+          <span class="tag">server/data/ · read-only</span>
+        </div>
+        <div class="nodes">
+          <div class="node"><strong>load_json_file()</strong><span>Reads each dataset once at import time</span></div>
+          <div class="node"><strong>7 datasets</strong><span>inventory, orders, demand, backlog, POs, spending, transactions</span></div>
+          <div class="node"><strong>No persistence</strong><span>Changes don't survive restart</span></div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- DATA FLOW -->
+  <section id="dataflow">
+    <h2>Data Flow</h2>
+    <div class="lead">A filtered request, end to end</div>
+    <p class="desc">The four global filters — Time Period, Warehouse, Category, Order Status — live in a
+      shared <code>useFilters</code> composable and drive every data fetch. Here is the round trip when a
+      user changes a filter on the Dashboard.</p>
+    <div class="steps">
+      <div class="step">
+        <div class="num"></div>
+        <div><h4>User changes a filter</h4>
+          <p>The <code>FilterBar</code> updates shared refs in <code>useFilters.js</code>
+             (<code>selectedPeriod</code>, <code>selectedLocation</code>, <code>selectedCategory</code>,
+             <code>selectedStatus</code>).</p></div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div><h4>View reacts &amp; requests data</h4>
+          <p>The active view calls <code>getCurrentFilters()</code> and passes the result to a method on
+             <code>api.js</code>, e.g. <code>api.getDashboardSummary(filters)</code>.</p></div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div><h4>Axios builds the HTTP request</h4>
+          <p>Non-<code>"all"</code> filters become query params and Axios issues
+             <code>GET http://localhost:8001/api/dashboard/summary?warehouse=&hellip;&amp;month=&hellip;</code>.</p></div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div><h4>FastAPI filters in memory</h4>
+          <p>The route handler runs <code>apply_filters()</code> (warehouse / category / status) and
+             <code>filter_by_month()</code> (month or quarter) over the in-memory lists.</p></div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div><h4>Pydantic validates the response</h4>
+          <p>Results are shaped/validated against models (<code>InventoryItem</code>, <code>Order</code>,
+             &hellip;) and serialized to JSON.</p></div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div><h4>Vue renders</h4>
+          <p>The view stores raw data in refs; <strong>computed properties</strong> derive metrics and
+             chart inputs, and the SVG charts &amp; tables re-render reactively.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- API SURFACE -->
+  <section id="api">
+    <h2>API Surface</h2>
+    <div class="lead">Endpoints exposed by the backend</div>
+    <p class="desc">All filtering is done via optional query params: <code>warehouse</code>,
+      <code>category</code>, <code>status</code>, <code>month</code>. Inventory has no time dimension, so
+      it ignores <code>status</code>/<code>month</code>.</p>
+    <table>
+      <thead><tr><th>Method</th><th>Path</th><th>Purpose</th><th>Filters</th></tr></thead>
+      <tbody>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/inventory</code></td><td>Inventory items</td><td>warehouse, category</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/inventory/{id}</code></td><td>Single item (404 if missing)</td><td>—</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/orders</code></td><td>Orders</td><td>warehouse, category, status, month</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/orders/{id}</code></td><td>Single order</td><td>—</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/demand</code></td><td>Demand forecasts</td><td>—</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/backlog</code></td><td>Backlog + has_purchase_order flag</td><td>—</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/dashboard/summary</code></td><td>Aggregate KPIs</td><td>all four</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/spending/*</code></td><td>summary · monthly · categories · transactions</td><td>—</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/reports/quarterly</code></td><td>Quarterly performance</td><td>—</td></tr>
+        <tr><td><span class="pill get">GET</span></td><td><code>/api/reports/monthly-trends</code></td><td>Month-over-month trends</td><td>—</td></tr>
+        <tr><td><span class="pill planned">PLANNED</span></td><td><code>/api/tasks</code>, <code>/api/purchase-orders</code></td><td>Client (api.js) already calls these; backend routes not yet implemented</td><td>—</td></tr>
+      </tbody>
+    </table>
+    <div class="callout">
+      <strong>Note:</strong> the frontend's <code>api.js</code> defines methods for Tasks and
+      Purchase-Order endpoints (and a <code>CreatePurchaseOrderRequest</code> model exists in
+      <code>main.py</code>), but the matching backend routes are not yet wired up — the client is
+      slightly ahead of the server here.
+    </div>
+  </section>
+
+  <!-- STRUCTURE -->
+  <section id="structure">
+    <h2>Project Structure</h2>
+    <div class="lead">Where things live</div>
+    <div class="tree">
+inventory-management/
+├── <span class="d">client/</span>                  <span class="c"># Vue 3 + Vite frontend</span>
+│   └── src/
+│       ├── App.vue            <span class="c"># Root layout + global styles</span>
+│       ├── main.js            <span class="c"># App + vue-router setup</span>
+│       ├── api.js             <span class="c"># Axios API client (single source of HTTP calls)</span>
+│       ├── <span class="d">views/</span>             <span class="c"># 7 routed pages</span>
+│       ├── <span class="d">components/</span>        <span class="c"># 9 reusable UI components / modals</span>
+│       ├── <span class="d">composables/</span>       <span class="c"># useFilters, useAuth, useI18n</span>
+│       ├── <span class="d">locales/</span>           <span class="c"># en.js, ja.js</span>
+│       └── <span class="d">utils/</span>             <span class="c"># currency formatting</span>
+├── <span class="d">server/</span>                  <span class="c"># FastAPI backend</span>
+│   ├── main.py                <span class="c"># Endpoints, models, filtering</span>
+│   ├── mock_data.py           <span class="c"># Loads JSON into memory</span>
+│   └── <span class="d">data/</span>               <span class="c"># 7 JSON datasets</span>
+├── <span class="d">tests/</span>                   <span class="c"># pytest backend tests</span>
+├── <span class="d">scripts/</span>                 <span class="c"># start.sh / stop.sh (macOS/Linux)</span>
+└── <span class="d">.claude/</span>                 <span class="c"># agents, commands, hooks, skills, MCP</span>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  Generated architecture overview · Factory Inventory Management System ·
+  Frontend :3000 &nbsp;•&nbsp; Backend :8001 &nbsp;•&nbsp; API docs at /docs
+</footer>
+
+</body>
+</html>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -6,7 +6,8 @@
     "current_demand": 300,
     "forecasted_demand": 450,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 12.50
   },
   {
     "id": "2",
@@ -15,7 +16,8 @@
     "current_demand": 150,
     "forecasted_demand": 152,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 34.75
   },
   {
     "id": "3",
@@ -24,7 +26,8 @@
     "current_demand": 500,
     "forecasted_demand": 600,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 8.25
   },
   {
     "id": "4",
@@ -33,7 +36,8 @@
     "current_demand": 50,
     "forecasted_demand": 35,
     "trend": "decreasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 245.00
   },
   {
     "id": "5",
@@ -42,7 +46,8 @@
     "current_demand": 800,
     "forecasted_demand": 950,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 15.99
   },
   {
     "id": "6",
@@ -51,7 +56,8 @@
     "current_demand": 120,
     "forecasted_demand": 121,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 62.50
   },
   {
     "id": "7",
@@ -60,7 +66,8 @@
     "current_demand": 250,
     "forecasted_demand": 252,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 18.99
   },
   {
     "id": "8",
@@ -69,7 +76,8 @@
     "current_demand": 180,
     "forecasted_demand": 182,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 89.50
   },
   {
     "id": "9",
@@ -78,6 +86,7 @@
     "current_demand": 95,
     "forecasted_demand": 96,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 47.00
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,9 +2,13 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
+
+# Fixed delivery lead time (in days) applied to submitted restocking orders
+LEAD_TIME_DAYS = 14
 
 # Quarter mapping for date filtering
 QUARTER_MAP = {
@@ -89,6 +93,7 @@ class DemandForecast(BaseModel):
     forecasted_demand: int
     trend: str
     period: str
+    unit_cost: float
 
 class BacklogItem(BaseModel):
     id: str
@@ -119,6 +124,16 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_price: float
+
+class CreateRestockOrderRequest(BaseModel):
+    items: List[RestockOrderItem]
+    warehouse: Optional[str] = None
 
 # API endpoints
 @app.get("/")
@@ -161,6 +176,43 @@ def get_order(order_id: str):
         raise HTTPException(status_code=404, detail="Order not found")
     return order
 
+@app.post("/api/orders", response_model=Order, status_code=201)
+def create_restock_order(request: CreateRestockOrderRequest):
+    """Submit a restocking order.
+
+    Builds a new order with the "Submitted" status, appends it to the in-memory
+    orders list (so GET /api/orders immediately reflects it), and returns it.
+    Note: data is in-memory only and resets when the server restarts.
+    """
+    now = datetime.now()
+
+    # Derive the next numeric id from existing orders, then format a restock-specific
+    # order number (RST- prefix distinguishes these from customer orders).
+    next_id = max((int(o["id"]) for o in orders), default=0) + 1
+    new_id = str(next_id)
+    order_number = f"RST-2025-{next_id:04d}"
+
+    items = [item.model_dump() for item in request.items]
+    total_value = round(sum(i["quantity"] * i["unit_price"] for i in items), 2)
+
+    new_order = {
+        "id": new_id,
+        "order_number": order_number,
+        "customer": "Internal Restock",
+        "items": items,
+        "status": "Submitted",
+        "order_date": now.isoformat(timespec="seconds"),
+        # Fixed lead time: expected delivery is LEAD_TIME_DAYS after the order date
+        "expected_delivery": (now + timedelta(days=LEAD_TIME_DAYS)).isoformat(timespec="seconds"),
+        "total_value": total_value,
+        "actual_delivery": None,
+        "warehouse": request.warehouse,
+        "category": None,
+    }
+
+    orders.append(new_order)
+    return new_order
+
 @app.get("/api/demand", response_model=List[DemandForecast])
 def get_demand_forecasts():
     """Get demand forecasts"""
@@ -194,9 +246,13 @@ def get_dashboard_summary(
     filtered_orders = apply_filters(orders, warehouse, category, status)
     filtered_orders = filter_by_month(filtered_orders, month)
 
+    # Submitted restocking orders are internal procurement, not customer orders,
+    # so they are excluded from the customer-facing dashboard metrics below.
+    customer_orders = [order for order in filtered_orders if order["status"] != "Submitted"]
+
     total_inventory_value = sum(item["quantity_on_hand"] * item["unit_cost"] for item in filtered_inventory)
     low_stock_items = len([item for item in filtered_inventory if item["quantity_on_hand"] <= item["reorder_point"]])
-    pending_orders = len([order for order in filtered_orders if order["status"] in ["Processing", "Backordered"]])
+    pending_orders = len([order for order in customer_orders if order["status"] in ["Processing", "Backordered"]])
     total_backlog_items = len(backlog_items)
 
     return {
@@ -204,7 +260,7 @@ def get_dashboard_summary(
         "low_stock_items": low_stock_items,
         "pending_orders": pending_orders,
         "total_backlog_items": total_backlog_items,
-        "total_orders_value": sum(order["total_value"] for order in filtered_orders)
+        "total_orders_value": sum(order["total_value"] for order in customer_orders)
     }
 
 @app.get("/api/spending/summary")

--- a/tests/backend/test_orders.py
+++ b/tests/backend/test_orders.py
@@ -1,0 +1,92 @@
+"""
+Tests for order endpoints, including the restocking POST /api/orders endpoint.
+"""
+from datetime import datetime
+
+
+class TestDemandUnitCost:
+    """Demand forecasts must expose a unit_cost so restocking can budget against them."""
+
+    def test_demand_items_have_unit_cost(self, client):
+        """Every demand forecast item includes a non-negative numeric unit_cost."""
+        response = client.get("/api/demand")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 0
+
+        for forecast in data:
+            assert "unit_cost" in forecast, f"{forecast['item_sku']} missing unit_cost"
+            assert isinstance(forecast["unit_cost"], (int, float))
+            assert forecast["unit_cost"] >= 0
+
+
+class TestCreateRestockOrder:
+    """Test suite for submitting restocking orders via POST /api/orders."""
+
+    def _payload(self):
+        return {
+            "items": [
+                {"sku": "WDG-001", "name": "Industrial Widget Type A", "quantity": 150, "unit_price": 12.50},
+                {"sku": "GSK-203", "name": "High-Temperature Gasket", "quantity": 100, "unit_price": 8.25}
+            ]
+        }
+
+    def test_create_restock_order_returns_201(self, client):
+        """Submitting a restock order returns 201 with a Submitted order."""
+        response = client.post("/api/orders", json=self._payload())
+        assert response.status_code == 201
+
+        order = response.json()
+        assert order["status"] == "Submitted"
+        assert order["customer"] == "Internal Restock"
+        assert order["order_number"].startswith("RST-")
+        assert len(order["items"]) == 2
+
+    def test_total_value_is_calculated(self, client):
+        """total_value equals the sum of quantity * unit_price across items."""
+        response = client.post("/api/orders", json=self._payload())
+        order = response.json()
+
+        expected_total = round(150 * 12.50 + 100 * 8.25, 2)
+        assert order["total_value"] == expected_total
+
+    def test_lead_time_is_14_days(self, client):
+        """expected_delivery is exactly 14 days after order_date."""
+        response = client.post("/api/orders", json=self._payload())
+        order = response.json()
+
+        order_date = datetime.fromisoformat(order["order_date"])
+        expected_delivery = datetime.fromisoformat(order["expected_delivery"])
+        assert (expected_delivery - order_date).days == 14
+
+    def test_submitted_order_appears_in_get_orders(self, client):
+        """A submitted order is returned by GET /api/orders."""
+        created = client.post("/api/orders", json=self._payload()).json()
+
+        response = client.get("/api/orders")
+        assert response.status_code == 200
+
+        orders = response.json()
+        assert any(o["id"] == created["id"] for o in orders), \
+            "Submitted restock order should appear in GET /api/orders"
+
+    def test_submitted_order_filterable_by_status(self, client):
+        """The submitted order is returned when filtering orders by status=Submitted."""
+        client.post("/api/orders", json=self._payload())
+
+        response = client.get("/api/orders", params={"status": "Submitted"})
+        assert response.status_code == 200
+
+        submitted = response.json()
+        assert len(submitted) > 0
+        assert all(o["status"] == "Submitted" for o in submitted)
+
+    def test_submitted_order_excluded_from_dashboard_value(self, client):
+        """Internal restock orders must not inflate the dashboard's order value."""
+        before = client.get("/api/dashboard/summary").json()["total_orders_value"]
+
+        client.post("/api/orders", json=self._payload())
+
+        after = client.get("/api/dashboard/summary").json()["total_orders_value"]
+        assert after == before, "Submitted restock order should not change total_orders_value"


### PR DESCRIPTION
## Summary
Adds a **Restocking** page that recommends restock quantities from the demand
forecast within a user-set budget and submits them as orders.

## Changes
- **Server**: `POST /api/orders` creates a "Submitted" restock order with a fixed
  14-day lead time; demand forecasts now carry `unit_cost`; submitted orders are
  excluded from customer-facing dashboard metrics.
- **Client**: new Restocking view + route/nav entry; Orders page splits submitted
  restock orders into their own section with a lead-time column.
- **i18n**: English and Japanese strings for restocking and submitted orders.
- **Tests**: backend coverage for `unit_cost` and the restock order endpoint.
- **Docs**: `docs/architecture.html`.

## Testing
- Backend tests added in `tests/backend/test_orders.py` (not run in this
  environment — Python wasn't on PATH; please run `pytest` locally/CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
