### PR TITLE
Add Restocking Planner, sidebar layout, i18n support, and API enhancements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,12 @@ Use the Task tool with these specialized subagents for appropriate tasks:
 - **ALWAYS use Playwright MCP tools** (`mcp__playwright__*`) for browser testing
   - Test against: `http://localhost:3000` (frontend), `http://localhost:8001` (API)
 
+## Code Guidelines
+- Always document non-obvious logic changes with comments
+  - Why it matters: Future maintainers (including future-you) need to understand intent behind non-obvious code
+  - What counts: Complex algorithms, surprising workarounds, non-standard patterns, subtle invariants
+  - What doesn't: Well-named functions/variables that speak for themselves
+
 ## Stack
 - **Frontend**: Vue 3 + Composition API + Vite (port 3000)
 - **Backend**: Python FastAPI (port 8001)

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,50 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
+    <aside class="sidebar">
+      <div class="sidebar-logo">
+        <h1>{{ t('nav.companyName') }}</h1>
+        <span class="sidebar-subtitle">{{ t('nav.subtitle') }}</span>
+      </div>
+
+      <nav class="sidebar-nav">
+        <router-link to="/" :class="{ active: $route.path === '/' }">
+          {{ t('nav.overview') }}
+        </router-link>
+        <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
+          {{ t('nav.inventory') }}
+        </router-link>
+        <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
+          {{ t('nav.orders') }}
+        </router-link>
+        <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
+          {{ t('nav.finance') }}
+        </router-link>
+        <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
+          {{ t('nav.demandForecast') }}
+        </router-link>
+        <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+          {{ t('nav.restocking') }}
+        </router-link>
+        <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
+          {{ t('nav.reports') }}
+        </router-link>
+      </nav>
+
+      <div class="sidebar-footer">
         <LanguageSwitcher />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    </aside>
+
+    <div class="content-area">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -162,6 +170,31 @@ export default {
 </script>
 
 <style>
+/* ============================================================
+   CSS Custom Properties
+   ============================================================ */
+:root {
+  --accent: #2563eb;
+  --accent-light: #eff6ff;
+  --accent-hover: #1d4ed8;
+  --sidebar-width: 220px;
+  --border: #e2e8f0;
+  --surface: #ffffff;
+  --bg: #f8fafc;
+  --text-primary: #0f172a;
+  --text-secondary: #64748b;
+  --text-muted: #94a3b8;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 12px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -1px rgba(0,0,0,0.04);
+  --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.08), 0 4px 6px -2px rgba(0,0,0,0.04);
+}
+
+/* ============================================================
+   Reset & Base
+   ============================================================ */
 * {
   margin: 0;
   padding: 0;
@@ -170,233 +203,297 @@ export default {
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
+  background: var(--bg);
+  color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ============================================================
+   App Layout
+   ============================================================ */
 .app {
   display: flex;
-  flex-direction: column;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+/* ============================================================
+   Sidebar
+   ============================================================ */
+.sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
   position: sticky;
   top: 0;
+  height: 100vh;
   z-index: 100;
 }
 
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
+.sidebar-logo {
+  padding: 1.5rem 1.25rem 1.25rem;
+  border-bottom: 1px solid var(--border);
 }
 
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
+.sidebar-logo h1 {
+  font-size: 1.125rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-primary);
   letter-spacing: -0.025em;
+  line-height: 1.2;
 }
 
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
+.sidebar-subtitle {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
   font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
+  margin-top: 0.25rem;
 }
 
-.nav-tabs {
+.sidebar-nav {
+  flex: 1;
   display: flex;
-  gap: 0.25rem;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 1rem 0.75rem;
+  overflow-y: auto;
 }
 
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
+.sidebar-nav a {
+  display: block;
+  padding: 0.625rem 0.75rem;
+  color: var(--text-secondary);
   text-decoration: none;
   font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
+  font-size: 0.875rem;
+  border-radius: var(--radius-sm);
   transition: all 0.2s ease;
-  position: relative;
 }
 
-.nav-tabs a:hover {
-  color: #0f172a;
+.sidebar-nav a:hover {
+  color: var(--text-primary);
   background: #f1f5f9;
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
+.sidebar-nav a.active {
+  color: var(--accent);
+  background: var(--accent-light);
 }
 
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+.sidebar-footer {
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* ============================================================
+   Content Area
+   ============================================================ */
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .main-content {
   flex: 1;
-  max-width: 1600px;
-  width: 100%;
-  margin: 0 auto;
   padding: 1.5rem 2rem;
 }
 
+/* ============================================================
+   Mobile: collapse sidebar to top strip
+   ============================================================ */
+@media (max-width: 768px) {
+  .app {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    height: auto;
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .sidebar-logo {
+    border-bottom: none;
+    border-right: 1px solid var(--border);
+    padding: 0.75rem 1rem;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    gap: 0.125rem;
+    overflow-y: visible;
+  }
+
+  .sidebar-footer {
+    border-top: none;
+    border-left: 1px solid var(--border);
+    padding: 0.75rem 1rem;
+  }
+}
+
+/* ============================================================
+   Filter Bar
+   ============================================================ */
+.filters-bar {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   Page Header
+   ============================================================ */
 .page-header {
   margin-bottom: 1.5rem;
 }
 
 .page-header h2 {
-  font-size: 1.875rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 0.375rem;
+  color: var(--text-primary);
   letter-spacing: -0.025em;
+  line-height: 1.2;
 }
 
 .page-header p {
-  color: #64748b;
-  font-size: 0.938rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
 }
 
+/* ============================================================
+   Stats Grid
+   ============================================================ */
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
   margin-bottom: 1.5rem;
 }
 
+/* ============================================================
+   Stat Card
+   ============================================================ */
 .stat-card {
-  background: white;
-  padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  transition: all 0.2s ease;
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--border);
+  border-top: 3px solid var(--accent);
 }
 
-.stat-card:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
-}
+.stat-card.success { border-top-color: #10b981; }
+.stat-card.warning { border-top-color: #f59e0b; }
+.stat-card.danger  { border-top-color: #ef4444; }
+.stat-card.info    { border-top-color: #3b82f6; }
 
 .stat-label {
-  color: #64748b;
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 0.625rem;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
 }
 
 .stat-value {
-  font-size: 2.25rem;
+  font-size: 1.875rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-primary);
+  line-height: 1.2;
+  margin-top: 0.375rem;
   letter-spacing: -0.025em;
 }
 
-.stat-card.warning .stat-value {
-  color: #ea580c;
-}
-
-.stat-card.success .stat-value {
-  color: #059669;
-}
-
-.stat-card.danger .stat-value {
-  color: #dc2626;
-}
-
-.stat-card.info .stat-value {
-  color: #2563eb;
-}
-
+/* ============================================================
+   Card
+   ============================================================ */
 .card {
-  background: white;
-  border-radius: 10px;
-  padding: 1.25rem;
-  border: 1px solid #e2e8f0;
-  margin-bottom: 1.25rem;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem;
+  border: 1px solid rgba(226, 232, 240, 0.6);
 }
 
 .card-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 0.875rem;
-  border-bottom: 1px solid #e2e8f0;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
 }
 
 .card-title {
-  font-size: 1.125rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
 }
 
+/* ============================================================
+   Section Title
+   ============================================================ */
+.section-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+/* ============================================================
+   Table System
+   ============================================================ */
 .table-container {
   overflow-x: auto;
+  border-radius: var(--radius-md);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
+  font-size: 0.875rem;
 }
 
-thead {
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-th {
+thead th {
+  padding: 0.75rem 1rem;
   text-align: left;
-  padding: 0.5rem 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 600;
-  color: #475569;
-  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
 }
 
-td {
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid #f1f5f9;
-  color: #334155;
-  font-size: 0.875rem;
+tbody td {
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.5);
+  color: var(--text-primary);
 }
 
 tbody tr {
@@ -404,83 +501,55 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background: #f8fafc;
+  background: var(--bg);
 }
 
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* ============================================================
+   Badge System
+   ============================================================ */
 .badge {
-  display: inline-block;
-  padding: 0.313rem 0.75rem;
-  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
+  letter-spacing: 0.02em;
 }
 
-.badge.success {
-  background: #d1fae5;
-  color: #065f46;
-}
+.badge.success    { background: #dcfce7; color: #16a34a; }
+.badge.info       { background: #dbeafe; color: #2563eb; }
+.badge.warning    { background: #fef9c3; color: #ca8a04; }
+.badge.danger     { background: #fee2e2; color: #dc2626; }
+.badge.increasing { background: #dcfce7; color: #16a34a; }
+.badge.stable     { background: #dbeafe; color: #2563eb; }
+.badge.decreasing { background: #fee2e2; color: #dc2626; }
+.badge.high       { background: #fee2e2; color: #dc2626; }
+.badge.medium     { background: #fef9c3; color: #ca8a04; }
+.badge.low        { background: #dbeafe; color: #2563eb; }
 
-.badge.warning {
-  background: #fed7aa;
-  color: #92400e;
-}
-
-.badge.danger {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.info {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
-.badge.increasing {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.badge.decreasing {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.stable {
-  background: #e0e7ff;
-  color: #3730a3;
-}
-
-.badge.high {
-  background: #fecaca;
-  color: #991b1b;
-}
-
-.badge.medium {
-  background: #fed7aa;
-  color: #92400e;
-}
-
-.badge.low {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
+/* ============================================================
+   Loading & Error States
+   ============================================================ */
 .loading {
-  text-align: center;
-  padding: 3rem;
-  color: #64748b;
-  font-size: 0.938rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
 }
 
 .error {
-  background: #fef2f2;
+  background: #fee2e2;
+  color: #dc2626;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
   border: 1px solid #fecaca;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
-  font-size: 0.938rem;
 }
 </style>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,15 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking-orders`)
+    return response.data
+  },
+
+  async createRestockingOrder(data) {
+    const response = await axios.post(`${API_BASE_URL}/restocking-orders`, data)
+    return response.data
   }
 }

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -106,13 +106,11 @@ export default {
   border-bottom: 1px solid #e2e8f0;
   padding: 0.75rem 0;
   position: sticky;
-  top: 70px;
+  top: 0;
   z-index: 90;
 }
 
 .filters-container {
-  max-width: 1600px;
-  margin: 0 auto;
   padding: 0 2rem;
   display: flex;
   align-items: center;

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,8 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
+    reports: 'Reports',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,8 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充',
+    reports: 'レポート',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -2,165 +2,145 @@
   <div class="dashboard">
     <div class="page-header">
       <h2>{{ t('dashboard.title') }}</h2>
+      <p>Factory performance overview</p>
     </div>
 
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <!-- Key Performance Indicators -->
-      <div class="kpi-section">
-        <h3 class="section-title">{{ t('dashboard.kpi.title') }}</h3>
-        <div class="kpi-grid">
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.inventoryTurnover') }}</span>
-            </div>
-            <div class="kpi-value">4.2</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 4.5 (-6.67%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress" style="width: 93.33%"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.ordersFulfilled') }}</span>
-            </div>
-            <div class="kpi-value">{{ ordersData.fulfilled }}</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ ordersData.goal }} ({{ calculatePercentage(ordersData.fulfilled, ordersData.goal) }}%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress" :style="{ width: calculatePercentage(ordersData.fulfilled, ordersData.goal) + '%' }"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.orderFillRate') }}</span>
-            </div>
-            <div class="kpi-value">{{ fillRate }}%</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 95% ({{ fillRate - 95 > 0 ? '+' : '' }}{{ (fillRate - 95).toFixed(2) }}%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress success" :style="{ width: (fillRate / 95 * 100) + '%' }"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t(selectedPeriod === 'all' ? 'dashboard.kpi.revenueYTD' : 'dashboard.kpi.revenueMTD') }}</span>
-            </div>
-            <div class="kpi-value">{{ formatCurrency(Math.round(summary.total_orders_value), selectedCurrency) }}</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ formatCurrency(revenueGoal, selectedCurrency) }} ({{ summary.total_orders_value > revenueGoal ? '+' : '' }}{{ ((summary.total_orders_value / revenueGoal - 1) * 100).toFixed(1) }}%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress" :style="{ width: Math.min((summary.total_orders_value / revenueGoal * 100), 100) + '%' }"></div>
-            </div>
-          </div>
-
-          <div class="kpi-card">
-            <div class="kpi-header">
-              <span class="kpi-label">{{ t('dashboard.kpi.avgProcessingTime') }}</span>
-            </div>
-            <div class="kpi-value">2.8</div>
-            <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 3.0 (-6.67%)</div>
-            <div class="kpi-progress-bar">
-              <div class="kpi-progress success" style="width: 93.33%"></div>
-            </div>
+      <div class="stats-grid">
+        <div class="stat-card success">
+          <div class="stat-label">{{ t('dashboard.kpi.inventoryTurnover') }}</div>
+          <div class="stat-value">4.2</div>
+          <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 4.5 (-6.67%)</div>
+          <div class="kpi-progress-bar">
+            <div class="kpi-progress" style="width: 93.33%"></div>
           </div>
         </div>
-      </div>
 
-      <!-- Summary Section -->
-      <div class="summary-section">
-        <h3 class="section-title">{{ t('dashboard.summary.title') }}</h3>
+        <div class="stat-card">
+          <div class="stat-label">{{ t('dashboard.kpi.ordersFulfilled') }}</div>
+          <div class="stat-value">{{ ordersData.fulfilled }}</div>
+          <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ ordersData.goal }} ({{ calculatePercentage(ordersData.fulfilled, ordersData.goal) }}%)</div>
+          <div class="kpi-progress-bar">
+            <div class="kpi-progress" :style="{ width: calculatePercentage(ordersData.fulfilled, ordersData.goal) + '%' }"></div>
+          </div>
+        </div>
+
+        <div class="stat-card success">
+          <div class="stat-label">{{ t('dashboard.kpi.orderFillRate') }}</div>
+          <div class="stat-value">{{ fillRate }}%</div>
+          <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 95% ({{ fillRate - 95 > 0 ? '+' : '' }}{{ (fillRate - 95).toFixed(2) }}%)</div>
+          <div class="kpi-progress-bar">
+            <div class="kpi-progress success" :style="{ width: (fillRate / 95 * 100) + '%' }"></div>
+          </div>
+        </div>
+
+        <div class="stat-card success">
+          <div class="stat-label">{{ t(selectedPeriod === 'all' ? 'dashboard.kpi.revenueYTD' : 'dashboard.kpi.revenueMTD') }}</div>
+          <div class="stat-value">{{ formatCurrency(Math.round(summary.total_orders_value), selectedCurrency) }}</div>
+          <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: {{ formatCurrency(revenueGoal, selectedCurrency) }} ({{ summary.total_orders_value > revenueGoal ? '+' : '' }}{{ ((summary.total_orders_value / revenueGoal - 1) * 100).toFixed(1) }}%)</div>
+          <div class="kpi-progress-bar">
+            <div class="kpi-progress" :style="{ width: Math.min((summary.total_orders_value / revenueGoal * 100), 100) + '%' }"></div>
+          </div>
+        </div>
+
+        <div class="stat-card warning">
+          <div class="stat-label">{{ t('dashboard.kpi.avgProcessingTime') }}</div>
+          <div class="stat-value">2.8</div>
+          <div class="kpi-goal">{{ t('dashboard.kpi.goal') }}: 3.0 (-6.67%)</div>
+          <div class="kpi-progress-bar">
+            <div class="kpi-progress success" style="width: 93.33%"></div>
+          </div>
+        </div>
       </div>
 
       <!-- Charts Grid -->
       <div class="charts-grid">
         <!-- Order Health Dashboard -->
-        <div class="card chart-card">
+        <div class="card">
           <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.orderHealth.title') }}</h3>
+            <span class="card-title">{{ t('dashboard.orderHealth.title') }}</span>
           </div>
-          <div class="chart-content">
-            <div class="order-health-container">
-              <!-- Left: Donut Chart -->
-              <div class="order-health-chart">
-                <svg viewBox="0 0 200 200" class="donut-svg-compact">
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#e2e8f0" stroke-width="25"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#10b981" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.delivered)} 408`"
-                    stroke-dashoffset="0" transform="rotate(-90 100 100)"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#3b82f6" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.shipped)} 408`"
-                    :stroke-dashoffset="`-${getCircleSegment(statusData.delivered)}`"
-                    transform="rotate(-90 100 100)"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#f59e0b" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.processing)} 408`"
-                    :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped)}`"
-                    transform="rotate(-90 100 100)"/>
-                  <circle cx="100" cy="100" r="65" fill="none" stroke="#ef4444" stroke-width="25"
-                    :stroke-dasharray="`${getCircleSegment(statusData.backordered)} 408`"
-                    :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped) + getCircleSegment(statusData.processing)}`"
-                    transform="rotate(-90 100 100)"/>
-                  <text x="100" y="90" text-anchor="middle" class="donut-center-label">{{ t('dashboard.orderHealth.total') }}</text>
-                  <text x="100" y="120" text-anchor="middle" class="donut-center-value">{{ orderHealthMetrics.totalOrders }}</text>
-                </svg>
-                <div class="donut-legend-compact">
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #10b981"></span>{{ t('status.delivered') }}</div>
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #3b82f6"></span>{{ t('status.shipped') }}</div>
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #f59e0b"></span>{{ t('status.processing') }}</div>
-                  <div class="legend-item-compact"><span class="legend-dot" style="background: #ef4444"></span>{{ t('status.backordered') }}</div>
+          <div class="order-health-container">
+            <!-- Left: Donut Chart -->
+            <div class="order-health-chart">
+              <svg viewBox="0 0 200 200" class="donut-svg-compact">
+                <circle cx="100" cy="100" r="65" fill="none" stroke="#e2e8f0" stroke-width="25"/>
+                <circle cx="100" cy="100" r="65" fill="none" stroke="#10b981" stroke-width="25"
+                  :stroke-dasharray="`${getCircleSegment(statusData.delivered)} 408`"
+                  stroke-dashoffset="0" transform="rotate(-90 100 100)"/>
+                <circle cx="100" cy="100" r="65" fill="none" stroke="#3b82f6" stroke-width="25"
+                  :stroke-dasharray="`${getCircleSegment(statusData.shipped)} 408`"
+                  :stroke-dashoffset="`-${getCircleSegment(statusData.delivered)}`"
+                  transform="rotate(-90 100 100)"/>
+                <circle cx="100" cy="100" r="65" fill="none" stroke="#f59e0b" stroke-width="25"
+                  :stroke-dasharray="`${getCircleSegment(statusData.processing)} 408`"
+                  :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped)}`"
+                  transform="rotate(-90 100 100)"/>
+                <circle cx="100" cy="100" r="65" fill="none" stroke="#ef4444" stroke-width="25"
+                  :stroke-dasharray="`${getCircleSegment(statusData.backordered)} 408`"
+                  :stroke-dashoffset="`-${getCircleSegment(statusData.delivered) + getCircleSegment(statusData.shipped) + getCircleSegment(statusData.processing)}`"
+                  transform="rotate(-90 100 100)"/>
+                <text x="100" y="90" text-anchor="middle" class="donut-center-label">{{ t('dashboard.orderHealth.total') }}</text>
+                <text x="100" y="120" text-anchor="middle" class="donut-center-value">{{ orderHealthMetrics.totalOrders }}</text>
+              </svg>
+              <div class="donut-legend-compact">
+                <div class="legend-item-compact"><span class="legend-dot" style="background: #10b981"></span>{{ t('status.delivered') }}</div>
+                <div class="legend-item-compact"><span class="legend-dot" style="background: #3b82f6"></span>{{ t('status.shipped') }}</div>
+                <div class="legend-item-compact"><span class="legend-dot" style="background: #f59e0b"></span>{{ t('status.processing') }}</div>
+                <div class="legend-item-compact"><span class="legend-dot" style="background: #ef4444"></span>{{ t('status.backordered') }}</div>
+              </div>
+            </div>
+
+            <!-- Right: Health Metrics -->
+            <div class="order-health-metrics">
+              <div class="health-metric">
+                <div class="health-metric-label">{{ t('dashboard.orderHealth.revenue') }}</div>
+                <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.totalValue, selectedCurrency) }}</div>
+              </div>
+              <div class="health-metric">
+                <div class="health-metric-label">{{ t('dashboard.orderHealth.avgOrderValue') }}</div>
+                <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.avgOrderValue, selectedCurrency) }}</div>
+              </div>
+              <div class="health-metric">
+                <div class="health-metric-label">{{ t('dashboard.orderHealth.onTimeRate') }}</div>
+                <div class="health-metric-value" :class="{ 'metric-good': orderHealthMetrics.onTimeRate >= 90, 'metric-warning': orderHealthMetrics.onTimeRate < 90 && orderHealthMetrics.onTimeRate >= 75, 'metric-bad': orderHealthMetrics.onTimeRate < 75 }">
+                  {{ orderHealthMetrics.onTimeRate.toFixed(1) }}%
                 </div>
               </div>
-
-              <!-- Right: Health Metrics -->
-              <div class="order-health-metrics">
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.revenue') }}</div>
-                  <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.totalValue, selectedCurrency) }}</div>
-                </div>
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.avgOrderValue') }}</div>
-                  <div class="health-metric-value">{{ formatCurrency(orderHealthMetrics.avgOrderValue, selectedCurrency) }}</div>
-                </div>
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.onTimeRate') }}</div>
-                  <div class="health-metric-value" :class="{ 'metric-good': orderHealthMetrics.onTimeRate >= 90, 'metric-warning': orderHealthMetrics.onTimeRate < 90 && orderHealthMetrics.onTimeRate >= 75, 'metric-bad': orderHealthMetrics.onTimeRate < 75 }">
-                    {{ orderHealthMetrics.onTimeRate.toFixed(1) }}%
-                  </div>
-                </div>
-                <div class="health-metric">
-                  <div class="health-metric-label">{{ t('dashboard.orderHealth.avgFulfillmentDays') }}</div>
-                  <div class="health-metric-value">{{ orderHealthMetrics.avgFulfillmentDays.toFixed(1) }}</div>
-                </div>
+              <div class="health-metric">
+                <div class="health-metric-label">{{ t('dashboard.orderHealth.avgFulfillmentDays') }}</div>
+                <div class="health-metric-value">{{ orderHealthMetrics.avgFulfillmentDays.toFixed(1) }}</div>
               </div>
             </div>
           </div>
         </div>
 
         <!-- Inventory by Category -->
-        <div class="card chart-card">
+        <div class="card">
           <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.inventoryValue.title') }}</h3>
+            <span class="card-title">{{ t('dashboard.inventoryValue.title') }}</span>
           </div>
-          <div class="chart-content">
-            <div class="horizontal-bar-chart" v-if="categoryData.length > 0">
-              <div v-for="cat in categoryData" :key="cat.name" class="h-bar-item">
-                <div class="h-bar-label">{{ translateCategory(cat.name) }}</div>
-                <div class="h-bar-container">
-                  <div class="h-bar" :style="{ width: (cat.value / maxCategoryValue * 100) + '%', background: cat.color }">
-                    <span class="h-bar-value">{{ selectedCurrency === 'JPY' ? formatCurrency(cat.value, selectedCurrency) : `$${(cat.value / 1000).toFixed(1)}K` }}</span>
-                  </div>
+          <div class="horizontal-bar-chart" v-if="categoryData.length > 0">
+            <div v-for="cat in categoryData" :key="cat.name" class="h-bar-item">
+              <div class="h-bar-label">{{ translateCategory(cat.name) }}</div>
+              <div class="h-bar-container">
+                <div class="h-bar" :style="{ width: (cat.value / maxCategoryValue * 100) + '%', background: cat.color }">
+                  <span class="h-bar-value">{{ selectedCurrency === 'JPY' ? formatCurrency(cat.value, selectedCurrency) : `$${(cat.value / 1000).toFixed(1)}K` }}</span>
                 </div>
               </div>
             </div>
-            <div v-else class="no-data">{{ t('dashboard.inventoryShortages.noData') }}</div>
           </div>
+          <div v-else class="no-data">{{ t('dashboard.inventoryShortages.noData') }}</div>
         </div>
 
         <!-- Inventory Shortages -->
-        <div class="card chart-card full-width">
+        <div class="card full-width">
           <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.inventoryShortages.title') }} ({{ backlogItems.length }})</h3>
+            <span class="card-title">{{ t('dashboard.inventoryShortages.title') }}</span>
+            <span class="badge danger">{{ backlogItems.length }}</span>
           </div>
           <div v-if="backlogItems.length === 0" class="no-backlog">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="success-icon">
@@ -231,9 +211,9 @@
         </div>
 
         <!-- Top Products Table -->
-        <div class="card chart-card full-width">
+        <div class="card full-width">
           <div class="card-header">
-            <h3 class="card-title">{{ t('dashboard.topProducts.title') }}</h3>
+            <span class="card-title">{{ t('dashboard.topProducts.title') }}</span>
           </div>
           <div class="table-container">
             <table>
@@ -727,73 +707,17 @@ export default {
 </script>
 
 <style scoped>
-.page-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.header-meta {
-  font-size: 0.813rem;
-  color: #64748b;
-}
-
-.kpi-section {
-  margin-bottom: 1.5rem;
-}
-
-.section-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #475569;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 1rem;
-}
-
-.kpi-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.kpi-card {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 1rem;
-}
-
-.kpi-header {
-  margin-bottom: 0.75rem;
-}
-
-.kpi-label {
-  font-size: 0.813rem;
-  font-weight: 600;
-  color: #64748b;
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-}
-
-.kpi-value {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 0.5rem;
-  letter-spacing: -0.025em;
-}
-
+/* KPI progress bar — sits inside .stat-card, not covered by global classes */
 .kpi-goal {
-  font-size: 0.813rem;
-  color: #64748b;
-  margin-bottom: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 0.375rem;
+  margin-bottom: 0.625rem;
 }
 
 .kpi-progress-bar {
   width: 100%;
-  height: 6px;
+  height: 5px;
   background: #f1f5f9;
   border-radius: 3px;
   overflow: hidden;
@@ -801,7 +725,7 @@ export default {
 
 .kpi-progress {
   height: 100%;
-  background: #3b82f6;
+  background: var(--accent);
   border-radius: 3px;
   transition: width 0.6s ease;
 }
@@ -810,60 +734,29 @@ export default {
   background: #10b981;
 }
 
+/* Charts layout */
 .charts-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1.5rem;
 }
 
-.chart-card.full-width {
+.full-width {
   grid-column: 1 / -1;
 }
 
-.chart-content {
-  padding: 1rem;
+@media (max-width: 900px) {
+  .charts-grid { grid-template-columns: 1fr; }
+  .full-width { grid-column: 1; }
 }
 
-.donut-chart {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 3rem;
-}
-
-.donut-svg {
-  width: 200px;
-  height: 200px;
-}
-
-.donut-legend {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.legend-item {
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-  font-size: 0.875rem;
-  color: #475569;
-}
-
-.legend-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-}
-
-/* Order Health Dashboard Styles */
+/* Order Health — two-column layout inside .card */
 .order-health-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1.5rem;
   align-items: center;
-  padding: 1rem;
   min-height: 240px;
 }
 
@@ -871,9 +764,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 1rem;
-  padding: 0 1rem;
 }
 
 .donut-svg-compact {
@@ -883,7 +774,7 @@ export default {
 
 .donut-center-label {
   font-size: 12px;
-  fill: #64748b;
+  fill: var(--text-secondary);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -891,14 +782,14 @@ export default {
 
 .donut-center-value {
   font-size: 36px;
-  fill: #0f172a;
+  fill: var(--text-primary);
   font-weight: 700;
 }
 
 .donut-legend-compact {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 0.625rem 1.25rem;
+  gap: 0.5rem 1.25rem;
 }
 
 .legend-item-compact {
@@ -906,8 +797,15 @@ export default {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: #475569;
+  color: var(--text-secondary);
   font-weight: 500;
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
 }
 
 .order-health-metrics {
@@ -921,14 +819,14 @@ export default {
 .health-metric {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.25rem;
   text-align: center;
   width: 100%;
 }
 
 .health-metric-label {
   font-size: 0.688rem;
-  color: #64748b;
+  color: var(--text-secondary);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -937,27 +835,19 @@ export default {
 .health-metric-value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-primary);
   letter-spacing: -0.025em;
 }
 
-.metric-good {
-  color: #10b981;
-}
+.metric-good  { color: #10b981; }
+.metric-warning { color: #f59e0b; }
+.metric-bad   { color: #ef4444; }
 
-.metric-warning {
-  color: #f59e0b;
-}
-
-.metric-bad {
-  color: #ef4444;
-}
-
+/* Horizontal bar chart */
 .horizontal-bar-chart {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 0 1rem;
+  gap: 1.25rem;
 }
 
 .h-bar-item {
@@ -971,14 +861,14 @@ export default {
   min-width: 120px;
   font-size: 0.875rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
 .h-bar-container {
   flex: 1;
   height: 32px;
-  background: #f8fafc;
+  background: var(--bg);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -990,6 +880,7 @@ export default {
   justify-content: flex-end;
   padding-right: 0.75rem;
   transition: width 0.6s ease;
+  min-width: 2rem;
 }
 
 .h-bar-value {
@@ -998,86 +889,11 @@ export default {
   color: white;
 }
 
-.line-chart {
-  display: flex;
-  gap: 1.5rem;
-  height: 280px;
-}
-
-.line-y-axis {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding-right: 1rem;
-  font-size: 0.75rem;
-  color: #94a3b8;
-  border-right: 1px solid #e2e8f0;
-}
-
-.line-chart-area {
-  flex: 1;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-around;
-  gap: 0.5rem;
-}
-
-.line-bar-group {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
-  max-width: 80px;
-  gap: 0.5rem;
-}
-
-.line-bar-wrapper {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-.line-bar {
-  width: 100%;
-  max-width: 60px;
-  min-height: 8px;
-  background: #3b82f6;
-  border-radius: 6px 6px 0 0;
-  transition: all 0.3s ease;
-  cursor: pointer;
-  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
-}
-
-.line-bar.empty-bar {
-  background: #e2e8f0;
-  box-shadow: none;
-  min-height: 4px;
-}
-
-.line-bar:hover {
-  background: #2563eb;
-  transform: scaleY(1.05);
-}
-
-.line-bar.empty-bar:hover {
-  background: #cbd5e1;
-  transform: none;
-}
-
-.line-bar-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #64748b;
-  white-space: nowrap;
-}
-
+/* Empty / success states */
 .no-data {
   padding: 2rem;
   text-align: center;
-  color: #94a3b8;
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
@@ -1103,141 +919,19 @@ export default {
   margin: 0;
 }
 
+/* Table interactions */
 .clickable-row {
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
 
 .clickable-row:hover {
-  background: #eff6ff !important;
+  background: var(--accent-light) !important;
 }
 
-/* Tasks Card Styles */
-.tasks-card {
-  margin-bottom: 2rem;
-}
-
-.tasks-content {
-  padding: 1.5rem;
-}
-
-.task-input-container {
-  display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.task-input {
-  flex: 1;
-  padding: 0.75rem;
-  border: 2px solid #e2e8f0;
-  border-radius: 8px;
-  font-size: 0.95rem;
-  transition: border-color 0.2s ease;
-}
-
-.task-input:focus {
-  outline: none;
-  border-color: #667eea;
-}
-
-.task-add-btn {
-  padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.task-add-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-}
-
-.task-add-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.no-tasks {
-  text-align: center;
-  padding: 2rem;
-  color: #64748b;
-  font-style: italic;
-}
-
-.tasks-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.task-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  background: #f8fafc;
-  border-radius: 8px;
-  border: 2px solid transparent;
-  transition: all 0.2s ease;
-}
-
-.task-item:hover {
-  border-color: #e2e8f0;
-  background: white;
-}
-
-.task-item.completed {
-  opacity: 0.6;
-}
-
-.task-item.completed .task-text {
-  text-decoration: line-through;
-  color: #94a3b8;
-}
-
-.task-checkbox {
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  accent-color: #667eea;
-}
-
-.task-text {
-  flex: 1;
-  cursor: pointer;
-  user-select: none;
-  color: #0f172a;
-  font-size: 0.95rem;
-}
-
-.task-delete-btn {
-  width: 28px;
-  height: 28px;
-  background: #ef4444;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 1.25rem;
-  line-height: 1;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-}
-
-.task-delete-btn:hover {
-  background: #dc2626;
-  transform: scale(1.1);
-}
-
+/* PO action buttons */
 .po-button {
-  padding: 0.5rem 1rem;
+  padding: 0.375rem 0.875rem;
   border: none;
   border-radius: 6px;
   font-size: 0.813rem;
@@ -1248,18 +942,18 @@ export default {
 }
 
 .po-button.create {
-  background: #3b82f6;
+  background: var(--accent);
   color: white;
 }
 
 .po-button.create:hover {
-  background: #2563eb;
+  background: var(--accent-hover);
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.3);
 }
 
 .po-button.view {
-  background: #64748b;
+  background: var(--text-secondary);
   color: white;
 }
 

--- a/client/src/views/Demand.vue
+++ b/client/src/views/Demand.vue
@@ -8,68 +8,55 @@
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
-      <div class="demand-trend-cards">
-        <div class="trend-card increasing-card">
-          <div class="trend-header">
-            <div class="trend-icon">↑</div>
-            <div>
-              <div class="trend-label">{{ t('demand.increasingDemand') }}</div>
-              <div class="trend-count">{{ t('demand.itemsCount', { count: getForecastsByTrend('increasing').length }) }}</div>
+      <!-- Trend summary cards -->
+      <div class="stats-grid">
+        <div class="stat-card success">
+          <div class="stat-label">{{ t('demand.increasingDemand') }}</div>
+          <div class="stat-value">{{ getForecastsByTrend('increasing').length }}</div>
+          <div class="trend-items-preview">
+            <div v-for="item in getForecastsByTrend('increasing').slice(0, 3)" :key="item.id" class="preview-row">
+              <span class="preview-name">{{ item.item_name }}</span>
+              <span class="preview-change positive">{{ getChangePercent(item) }}%</span>
             </div>
-          </div>
-          <div class="trend-items">
-            <div v-for="item in getForecastsByTrend('increasing').slice(0, 5)" :key="item.id" class="trend-item">
-              <span class="item-name">{{ item.item_name }}</span>
-              <span class="item-change">+{{ getChangePercent(item) }}%</span>
-            </div>
-            <div v-if="getForecastsByTrend('increasing').length > 5" class="more-items">
-              +{{ getForecastsByTrend('increasing').length - 5 }} {{ t('demand.more') }}
+            <div v-if="getForecastsByTrend('increasing').length > 3" class="preview-more">
+              +{{ getForecastsByTrend('increasing').length - 3 }} {{ t('demand.more') }}
             </div>
           </div>
         </div>
 
-        <div class="trend-card stable-card">
-          <div class="trend-header">
-            <div class="trend-icon">→</div>
-            <div>
-              <div class="trend-label">{{ t('demand.stableDemand') }}</div>
-              <div class="trend-count">{{ t('demand.itemsCount', { count: getForecastsByTrend('stable').length }) }}</div>
+        <div class="stat-card info">
+          <div class="stat-label">{{ t('demand.stableDemand') }}</div>
+          <div class="stat-value">{{ getForecastsByTrend('stable').length }}</div>
+          <div class="trend-items-preview">
+            <div v-for="item in getForecastsByTrend('stable').slice(0, 3)" :key="item.id" class="preview-row">
+              <span class="preview-name">{{ item.item_name }}</span>
+              <span class="preview-change neutral">{{ getChangePercent(item) }}%</span>
             </div>
-          </div>
-          <div class="trend-items">
-            <div v-for="item in getForecastsByTrend('stable').slice(0, 5)" :key="item.id" class="trend-item">
-              <span class="item-name">{{ item.item_name }}</span>
-              <span class="item-change neutral">{{ getChangePercent(item) }}%</span>
-            </div>
-            <div v-if="getForecastsByTrend('stable').length > 5" class="more-items">
-              +{{ getForecastsByTrend('stable').length - 5 }} {{ t('demand.more') }}
+            <div v-if="getForecastsByTrend('stable').length > 3" class="preview-more">
+              +{{ getForecastsByTrend('stable').length - 3 }} {{ t('demand.more') }}
             </div>
           </div>
         </div>
 
-        <div class="trend-card decreasing-card">
-          <div class="trend-header">
-            <div class="trend-icon">↓</div>
-            <div>
-              <div class="trend-label">{{ t('demand.decreasingDemand') }}</div>
-              <div class="trend-count">{{ t('demand.itemsCount', { count: getForecastsByTrend('decreasing').length }) }}</div>
+        <div class="stat-card danger">
+          <div class="stat-label">{{ t('demand.decreasingDemand') }}</div>
+          <div class="stat-value">{{ getForecastsByTrend('decreasing').length }}</div>
+          <div class="trend-items-preview">
+            <div v-for="item in getForecastsByTrend('decreasing').slice(0, 3)" :key="item.id" class="preview-row">
+              <span class="preview-name">{{ item.item_name }}</span>
+              <span class="preview-change negative">{{ getChangePercent(item) }}%</span>
             </div>
-          </div>
-          <div class="trend-items">
-            <div v-for="item in getForecastsByTrend('decreasing').slice(0, 5)" :key="item.id" class="trend-item">
-              <span class="item-name">{{ item.item_name }}</span>
-              <span class="item-change">{{ getChangePercent(item) }}%</span>
-            </div>
-            <div v-if="getForecastsByTrend('decreasing').length > 5" class="more-items">
-              +{{ getForecastsByTrend('decreasing').length - 5 }} {{ t('demand.more') }}
+            <div v-if="getForecastsByTrend('decreasing').length > 3" class="preview-more">
+              +{{ getForecastsByTrend('decreasing').length - 3 }} {{ t('demand.more') }}
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Demand Forecasts table -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('demand.demandForecasts') }}</h3>
+          <span class="card-title">{{ t('demand.demandForecasts') }}</span>
         </div>
         <div class="table-container">
           <table>
@@ -91,7 +78,7 @@
                 <td>{{ forecast.current_demand }}</td>
                 <td><strong>{{ forecast.forecasted_demand }}</strong></td>
                 <td>
-                  <span :style="{ color: getChangeColor(forecast) }">
+                  <span :style="{ color: getChangeColor(forecast) }" class="change-value">
                     {{ getChangePercent(forecast) }}%
                   </span>
                 </td>
@@ -100,7 +87,7 @@
                     {{ t(`trends.${forecast.trend}`) }}
                   </span>
                 </td>
-                <td>{{ translatePeriod(forecast.period) }}</td>
+                <td class="period-cell">{{ translatePeriod(forecast.period) }}</td>
               </tr>
             </tbody>
           </table>
@@ -224,146 +211,54 @@ export default {
 </script>
 
 <style scoped>
-.demand-trend-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 2rem;
-}
-
-.trend-card {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 1.5rem;
-  transition: all 0.2s ease;
-}
-
-.trend-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-}
-
-.increasing-card {
-  border-left: 4px solid #10b981;
-}
-
-.stable-card {
-  border-left: 4px solid #3b82f6;
-}
-
-.decreasing-card {
-  border-left: 4px solid #ef4444;
-}
-
-.trend-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid #f1f5f9;
-}
-
-.trend-icon {
-  width: 48px;
-  height: 48px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  font-size: 1.75rem;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-
-.increasing-card .trend-icon {
-  background: #d1fae5;
-  color: #059669;
-}
-
-.stable-card .trend-icon {
-  background: #dbeafe;
-  color: #2563eb;
-}
-
-.decreasing-card .trend-icon {
-  background: #fee2e2;
-  color: #dc2626;
-}
-
-.trend-label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #64748b;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.trend-count {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin-top: 0.25rem;
-}
-
-.trend-items {
+/* Stat card trend preview items */
+.trend-items-preview {
+  margin-top: 0.875rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.375rem;
 }
 
-.trend-item {
+.preview-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0.75rem;
-  background: #f8fafc;
-  border-radius: 6px;
-  transition: background 0.2s;
+  font-size: 0.8125rem;
 }
 
-.trend-item:hover {
-  background: #f1f5f9;
-}
-
-.item-name {
-  font-size: 0.875rem;
-  color: #0f172a;
-  font-weight: 500;
-  flex: 1;
+.preview-name {
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: 1rem;
+  flex: 1;
+  margin-right: 0.5rem;
 }
 
-.item-change {
-  font-size: 0.813rem;
-  font-weight: 700;
+.preview-change {
+  font-weight: 600;
   flex-shrink: 0;
+  font-size: 0.8125rem;
 }
 
-.increasing-card .item-change {
-  color: #059669;
-}
+.preview-change.positive { color: #059669; }
+.preview-change.negative { color: #dc2626; }
+.preview-change.neutral  { color: #3b82f6; }
 
-.stable-card .item-change {
-  color: #3b82f6;
-}
-
-.decreasing-card .item-change {
-  color: #dc2626;
-}
-
-.item-change.neutral {
-  color: #64748b;
-}
-
-.more-items {
-  font-size: 0.813rem;
-  color: #64748b;
+.preview-more {
+  font-size: 0.75rem;
+  color: var(--text-muted);
   font-style: italic;
-  text-align: center;
-  padding: 0.5rem;
+  margin-top: 0.125rem;
+}
+
+/* Table extras */
+.change-value {
+  font-weight: 600;
+}
+
+.period-cell {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
 }
 </style>

--- a/client/src/views/Inventory.vue
+++ b/client/src/views/Inventory.vue
@@ -225,35 +225,7 @@ export default {
 </script>
 
 <style scoped>
-.page-header {
-  margin-bottom: 1.5rem;
-}
-
-.page-header h2 {
-  margin-bottom: 0.25rem;
-}
-
-.page-header p {
-  color: #64748b;
-  font-size: 0.875rem;
-}
-
-.card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1.5rem;
-  padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.card-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #0f172a;
-  margin: 0;
-}
-
+/* Search box — page-specific layout not covered by global styles */
 .search-box {
   position: relative;
   display: flex;
@@ -266,30 +238,30 @@ export default {
   left: 0.75rem;
   width: 18px;
   height: 18px;
-  color: #94a3b8;
+  color: var(--text-muted);
   pointer-events: none;
 }
 
 .search-input {
   width: 100%;
   padding: 0.5rem 2.5rem 0.5rem 2.5rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   font-size: 0.875rem;
-  color: #0f172a;
-  background: #f8fafc;
+  color: var(--text-primary);
+  background: var(--bg);
   transition: all 0.2s;
 }
 
 .search-input:focus {
   outline: none;
-  border-color: #3b82f6;
-  background: white;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--accent);
+  background: var(--surface);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
 .search-input::placeholder {
-  color: #94a3b8;
+  color: var(--text-muted);
 }
 
 .clear-search {
@@ -301,15 +273,15 @@ export default {
   padding: 0.25rem;
   background: transparent;
   border: none;
-  border-radius: 4px;
-  color: #94a3b8;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .clear-search:hover {
-  background: #e2e8f0;
-  color: #64748b;
+  background: var(--border);
+  color: var(--text-secondary);
 }
 
 .clear-search svg {
@@ -317,23 +289,11 @@ export default {
   height: 18px;
 }
 
-.loading,
-.error {
-  padding: 2rem;
-  text-align: center;
-  color: #64748b;
-}
-
-.error {
-  color: #ef4444;
-}
-
 .clickable-row {
   cursor: pointer;
-  transition: background-color 0.15s ease;
 }
 
 .clickable-row:hover {
-  background: #eff6ff !important;
+  background: var(--accent-light) !important;
 }
 </style>

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -27,6 +27,52 @@
         </div>
       </div>
 
+      <div v-if="restockingOrders.length > 0" class="card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders ({{ restockingOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">Order ID</th>
+                <th class="col-items">Items</th>
+                <th class="col-value">Total Cost</th>
+                <th class="col-status">Status</th>
+                <th class="col-date">Submitted</th>
+                <th class="col-date">Expected Delivery</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in restockingOrders" :key="order.id">
+                <td class="col-order-number"><strong>RS-{{ order.id }}</strong></td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ order.items.length }} item{{ order.items.length !== 1 ? 's' : '' }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ item.item_name }} ({{ item.sku }})</span>
+                        <span class="item-meta">Qty: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_cost }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_cost.toLocaleString() }}</strong></td>
+                <td class="col-status">
+                  <span :class="['badge', getOrderStatusClass(order.status)]">
+                    {{ t(`status.${order.status.toLowerCase()}`) }}
+                  </span>
+                </td>
+                <td class="col-date">{{ formatDate(order.created_date) }}</td>
+                <td class="col-date">{{ formatDate(order.expected_delivery_date) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card">
         <div class="card-header">
           <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
@@ -95,6 +141,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -121,6 +168,14 @@ export default {
         error.value = 'Failed to load orders: ' + err.message
       } finally {
         loading.value = false
+      }
+    }
+
+    const loadRestockingOrders = async () => {
+      try {
+        restockingOrders.value = await api.getRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load restocking orders:', err)
       }
     }
 
@@ -153,13 +208,17 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    onMounted(() => {
+      loadOrders()
+      loadRestockingOrders()
+    })
 
     return {
       t,
       loading,
       error,
       orders,
+      restockingOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -8,13 +8,33 @@
     <div v-if="loading" class="loading">Loading reports...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
+      <!-- Summary Stats -->
+      <div class="stats-grid">
+        <div class="stat-card info">
+          <div class="stat-label">Total Revenue (YTD)</div>
+          <div class="stat-value">${{ formatNumber(totalRevenue) }}</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Avg Monthly Revenue</div>
+          <div class="stat-value">${{ formatNumber(avgMonthlyRevenue) }}</div>
+        </div>
+        <div class="stat-card success">
+          <div class="stat-label">Total Orders (YTD)</div>
+          <div class="stat-value">{{ totalOrders }}</div>
+        </div>
+        <div class="stat-card warning">
+          <div class="stat-label">Best Performing Quarter</div>
+          <div class="stat-value">{{ bestQuarter }}</div>
+        </div>
+      </div>
+
       <!-- Quarterly Performance -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Quarterly Performance</h3>
+          <span class="card-title">Quarterly Performance</span>
         </div>
         <div class="table-container">
-          <table class="reports-table">
+          <table>
             <thead>
               <tr>
                 <th>Quarter</th>
@@ -44,7 +64,7 @@
       <!-- Monthly Trends Chart -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Monthly Revenue Trend</h3>
+          <span class="card-title">Monthly Revenue Trend</span>
         </div>
         <div class="chart-container">
           <div class="bar-chart">
@@ -65,10 +85,10 @@
       <!-- Month-over-Month Comparison -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Month-over-Month Analysis</h3>
+          <span class="card-title">Month-over-Month Analysis</span>
         </div>
         <div class="table-container">
-          <table class="reports-table">
+          <table>
             <thead>
               <tr>
                 <th>Month</th>
@@ -98,26 +118,6 @@
               </tr>
             </tbody>
           </table>
-        </div>
-      </div>
-
-      <!-- Summary Stats -->
-      <div class="stats-grid">
-        <div class="stat-card">
-          <div class="stat-label">Total Revenue (YTD)</div>
-          <div class="stat-value">${{ formatNumber(totalRevenue) }}</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-label">Avg Monthly Revenue</div>
-          <div class="stat-value">${{ formatNumber(avgMonthlyRevenue) }}</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-label">Total Orders (YTD)</div>
-          <div class="stat-value">{{ totalOrders }}</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-label">Best Performing Quarter</div>
-          <div class="stat-value">{{ bestQuarter }}</div>
         </div>
       </div>
     </div>
@@ -317,55 +317,8 @@ export default {
 </script>
 
 <style scoped>
-.reports {
-  padding: 0;
-}
-
-.card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.card-header {
-  margin-bottom: 1.5rem;
-}
-
-.card-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #0f172a;
-  margin: 0;
-}
-
-.reports-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.reports-table th {
-  background: #f8fafc;
-  padding: 0.75rem;
-  text-align: left;
-  font-weight: 600;
-  color: #64748b;
-  border-bottom: 2px solid #e2e8f0;
-}
-
-.reports-table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.reports-table tr:hover {
-  background: #f8fafc;
-}
-
 .chart-container {
-  padding: 2rem 1rem;
-  min-height: 300px;
+  padding: 2rem 1rem 1rem;
 }
 
 .bar-chart {
@@ -393,73 +346,23 @@ export default {
 
 .bar {
   width: 100%;
-  background: linear-gradient(to top, #3b82f6, #60a5fa);
+  background: linear-gradient(to top, var(--accent, #2563eb), #60a5fa);
   border-radius: 4px 4px 0 0;
   transition: all 0.3s;
   cursor: pointer;
 }
 
 .bar:hover {
-  background: linear-gradient(to top, #2563eb, #3b82f6);
+  background: linear-gradient(to top, var(--accent-hover, #1d4ed8), var(--accent, #2563eb));
 }
 
 .bar-label {
-  margin-top: 0.5rem;
   font-size: 0.75rem;
-  color: #64748b;
+  color: var(--text-secondary);
   text-align: center;
   transform: rotate(-45deg);
   white-space: nowrap;
   margin-top: 1.5rem;
-}
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
-
-.stat-card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border-left: 4px solid #3b82f6;
-}
-
-.stat-label {
-  font-size: 0.875rem;
-  color: #64748b;
-  margin-bottom: 0.5rem;
-}
-
-.stat-value {
-  font-size: 1.875rem;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.badge {
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.badge.success {
-  background: #dcfce7;
-  color: #166534;
-}
-
-.badge.warning {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.badge.danger {
-  background: #fee2e2;
-  color: #991b1b;
 }
 
 .positive-change {
@@ -470,19 +373,5 @@ export default {
 .negative-change {
   color: #dc2626;
   font-weight: 600;
-}
-
-.loading {
-  text-align: center;
-  padding: 3rem;
-  color: #64748b;
-}
-
-.error {
-  background: #fee2e2;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,333 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking Planner</h2>
+      <p>Allocate your restocking budget across forecasted demand using priority-ranked recommendations.</p>
+    </div>
+
+    <div v-if="loading" class="loading">Loading...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <div v-if="showSuccess" class="success-banner" @click="showSuccess = false">
+        <div class="success-content">
+          <strong>Order placed!</strong>
+          Order ID: {{ lastOrder.id }} | Expected delivery: {{ lastOrder.expected_delivery }}
+        </div>
+        <button class="dismiss-btn" @click.stop="showSuccess = false">Dismiss</button>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">Budget Allocation</span>
+          <span class="budget-display">${{ budget.toLocaleString() }}</span>
+        </div>
+        <input
+          type="range"
+          v-model.number="budget"
+          :min="0"
+          :max="maxBudget"
+          :step="1000"
+        />
+        <div class="budget-meta">
+          Total budget utilized: ${{ totalCost.toLocaleString() }} / ${{ budget.toLocaleString() }}
+          <span class="utilization-pct" v-if="budget > 0">
+            ({{ Math.round((totalCost / budget) * 100) }}%)
+          </span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">Recommended Items</span>
+          <span class="badge info">{{ recommendedItems.length }} items</span>
+        </div>
+        <div v-if="recommendedItems.length === 0" class="empty-state">
+          No items fit within this budget
+        </div>
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Item Name</th>
+                <th>Trend</th>
+                <th>Forecasted Qty</th>
+                <th>Unit Cost</th>
+                <th>Total Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendedItems" :key="item.item_sku">
+                <td><strong>{{ item.item_sku }}</strong></td>
+                <td>{{ item.item_name }}</td>
+                <td>
+                  <span :class="['badge', trendBadgeClass(item.trend)]">
+                    {{ item.trend }}
+                  </span>
+                </td>
+                <td>{{ item.forecasted_demand.toLocaleString() }}</td>
+                <td>${{ getUnitCost(item.item_sku).toLocaleString() }}</td>
+                <td><strong>${{ getItemCost(item).toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="card order-summary">
+        <div class="order-summary-row">
+          <div class="order-summary-meta">
+            <span>Total items: {{ recommendedItems.length }}</span>
+            <span class="separator">|</span>
+            <span class="stat-value">${{ totalCost.toLocaleString() }}</span>
+          </div>
+          <button
+            class="btn-primary"
+            :disabled="recommendedItems.length === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? 'Placing Order...' : 'Place Order' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t } = useI18n()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const forecasts = ref([])
+    const inventoryBySku = ref({})
+    const budget = ref(50000)
+    const submitting = ref(false)
+    const lastOrder = ref(null)
+    const showSuccess = ref(false)
+
+    const maxBudget = computed(() => {
+      return forecasts.value.reduce((sum, item) => {
+        return sum + getItemCost(item)
+      }, 0)
+    })
+
+    const sortedForecasts = computed(() => {
+      const trendPriority = { increasing: 0, stable: 1, decreasing: 2 }
+      return [...forecasts.value].sort((a, b) => {
+        const trendDiff = (trendPriority[a.trend] ?? 1) - (trendPriority[b.trend] ?? 1)
+        if (trendDiff !== 0) return trendDiff
+        return b.forecasted_demand - a.forecasted_demand
+      })
+    })
+
+    const recommendedItems = computed(() => {
+      let remaining = budget.value
+      const result = []
+      for (const item of sortedForecasts.value) {
+        const cost = getItemCost(item)
+        if (cost <= remaining) {
+          result.push(item)
+          remaining -= cost
+        }
+      }
+      return result
+    })
+
+    const totalCost = computed(() => {
+      return recommendedItems.value.reduce((sum, item) => sum + getItemCost(item), 0)
+    })
+
+    const getUnitCost = (sku) => {
+      return inventoryBySku.value[sku]?.unit_cost ?? 0
+    }
+
+    const getItemCost = (item) => {
+      const unitCost = inventoryBySku.value[item.item_sku]?.unit_cost ?? 0
+      return item.forecasted_demand * unitCost
+    }
+
+    const trendBadgeClass = (trend) => {
+      const map = { increasing: 'increasing', stable: 'stable', decreasing: 'decreasing' }
+      return map[trend] ?? 'info'
+    }
+
+    const loadData = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        const [forecastsData, inventoryData] = await Promise.all([
+          api.getDemandForecasts(),
+          api.getInventory({})
+        ])
+        forecasts.value = forecastsData
+        const bySkuMap = {}
+        for (const inv of inventoryData) {
+          bySkuMap[inv.sku] = inv
+        }
+        inventoryBySku.value = bySkuMap
+      } catch (err) {
+        error.value = 'Failed to load data: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      submitting.value = true
+      try {
+        const payload = {
+          items: recommendedItems.value.map(item => ({
+            sku: item.item_sku,
+            item_name: item.item_name,
+            quantity: item.forecasted_demand,
+            unit_cost: inventoryBySku.value[item.item_sku]?.unit_cost ?? 0
+          })),
+          notes: `Auto-generated restocking order. Budget: $${budget.value}`
+        }
+        const order = await api.createRestockingOrder(payload)
+        lastOrder.value = order
+        showSuccess.value = true
+        setTimeout(() => { showSuccess.value = false }, 5000)
+      } catch (err) {
+        error.value = 'Failed to place order: ' + err.message
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    onMounted(loadData)
+
+    return {
+      t,
+      loading,
+      error,
+      budget,
+      maxBudget,
+      recommendedItems,
+      totalCost,
+      submitting,
+      lastOrder,
+      showSuccess,
+      getUnitCost,
+      getItemCost,
+      trendBadgeClass,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+  margin: 0.75rem 0;
+}
+
+.budget-display {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.budget-meta {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.utilization-pct {
+  font-weight: 600;
+  color: var(--accent);
+  margin-left: 0.25rem;
+}
+
+.empty-state {
+  padding: 2.5rem;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.938rem;
+}
+
+.order-summary .order-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.order-summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.938rem;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.separator {
+  color: var(--border);
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.625rem 1.25rem;
+  border-radius: var(--radius-sm, 6px);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover, #1d4ed8);
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.success-banner {
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  color: #16a34a;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md, 8px);
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.success-content {
+  font-size: 0.938rem;
+}
+
+.dismiss-btn {
+  background: none;
+  border: 1px solid #059669;
+  color: #065f46;
+  border-radius: 5px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.813rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.dismiss-btn:hover {
+  background: #a7f3d0;
+}
+</style>

--- a/client/src/views/Spending.vue
+++ b/client/src/views/Spending.vue
@@ -9,21 +9,21 @@
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <!-- Revenue & Financial KPIs -->
-      <div class="stats-grid-finance">
-        <div class="stat-card revenue-card">
+      <div class="stats-grid">
+        <div class="stat-card success">
           <div class="stat-label">{{ t('finance.totalRevenue') }}</div>
           <div class="stat-value">{{ formatCurrency(revenueMetrics.totalRevenue) }}</div>
           <div class="stat-change positive">
-            <span class="change-icon">↑</span>
+            <span class="change-icon">&#8593;</span>
             {{ t('finance.fromOrders', { count: revenueMetrics.orderCount }) }}
           </div>
         </div>
-        <div class="stat-card cost-card">
+        <div class="stat-card danger">
           <div class="stat-label">{{ t('finance.totalCosts') }}</div>
           <div class="stat-value">{{ formatCurrency(totalCosts) }}</div>
           <div class="stat-meta">{{ t('finance.costBreakdown') }}</div>
         </div>
-        <div class="stat-card profit-card">
+        <div class="stat-card info">
           <div class="stat-label">{{ t('finance.netProfit') }}</div>
           <div class="stat-value">{{ formatCurrency(netProfit) }}</div>
           <div class="stat-meta">{{ profitMargin }}% {{ t('finance.margin') }}</div>
@@ -38,7 +38,7 @@
       <!-- Monthly Revenue vs Cost Chart -->
       <div class="card chart-card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('finance.revenueVsCosts.title') }}</h3>
+          <span class="card-title">{{ t('finance.revenueVsCosts.title') }}</span>
           <div class="chart-legend">
             <span class="legend-item"><span class="legend-dot revenue-color"></span>{{ t('finance.revenueVsCosts.revenue') }}</span>
             <span class="legend-item"><span class="legend-dot cost-color"></span>{{ t('finance.revenueVsCosts.costs') }}</span>
@@ -69,7 +69,7 @@
       <!-- Monthly Cost Flow Chart -->
       <div class="card chart-card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('finance.monthlyCostFlow.title') }}</h3>
+          <span class="card-title">{{ t('finance.monthlyCostFlow.title') }}</span>
           <div class="chart-legend">
             <span class="legend-item"><span class="legend-dot procurement"></span>{{ t('finance.monthlyCostFlow.procurement') }}</span>
             <span class="legend-item"><span class="legend-dot operational"></span>{{ t('finance.monthlyCostFlow.operational') }}</span>
@@ -102,11 +102,11 @@
         </div>
       </div>
 
-      <div class="two-column-grid">
+      <div class="charts-grid">
         <!-- Category Spending Breakdown -->
         <div class="card">
           <div class="card-header">
-            <h3 class="card-title">{{ t('finance.categorySpending.title') }}</h3>
+            <span class="card-title">{{ t('finance.categorySpending.title') }}</span>
           </div>
           <div class="category-list">
             <div v-for="category in categorySpending" :key="category.category" class="category-item">
@@ -128,12 +128,12 @@
         </div>
 
         <!-- Recent Transactions -->
-        <div class="card transactions-card">
+        <div class="card">
           <div class="card-header">
-            <h3 class="card-title">{{ t('finance.transactions.title') }}</h3>
+            <span class="card-title">{{ t('finance.transactions.title') }}</span>
           </div>
-          <div class="transactions-table-container">
-            <table class="transactions-table">
+          <div class="table-container transactions-scroll">
+            <table>
               <thead>
                 <tr>
                   <th>{{ t('finance.transactions.id') }}</th>
@@ -151,10 +151,10 @@
                   @click="handleTransactionClick(transaction)"
                 >
                   <td class="transaction-id">{{ transaction.id.toString().padStart(3, '0') }}</td>
-                  <td class="transaction-description">{{ transaction.description }}</td>
-                  <td class="transaction-vendor">{{ transaction.vendor }}</td>
-                  <td class="transaction-date">{{ formatDateShort(transaction.date) }}</td>
-                  <td class="transaction-amount text-right">{{ currencySymbol }}{{ transaction.amount.toLocaleString() }}</td>
+                  <td>{{ transaction.description }}</td>
+                  <td class="text-secondary">{{ transaction.vendor }}</td>
+                  <td class="text-secondary">{{ formatDateShort(transaction.date) }}</td>
+                  <td class="text-right amount-cell">{{ currencySymbol }}{{ transaction.amount.toLocaleString() }}</td>
                 </tr>
               </tbody>
             </table>
@@ -513,8 +513,15 @@ export default {
   font-size: 1rem;
 }
 
+.stat-meta {
+  margin-top: 0.5rem;
+  font-size: 0.813rem;
+  color: var(--text-secondary);
+}
+
+/* Chart cards */
 .chart-card {
-  margin-bottom: 1.75rem;
+  margin-bottom: 1.5rem;
 }
 
 .chart-legend {
@@ -527,47 +534,55 @@ export default {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #64748b;
+  color: var(--text-secondary);
 }
 
 .legend-dot {
   width: 12px;
   height: 12px;
   border-radius: 3px;
+  flex-shrink: 0;
 }
 
-.legend-dot.procurement { background: #3b82f6; }
-.legend-dot.operational { background: #8b5cf6; }
-.legend-dot.labor { background: #10b981; }
-.legend-dot.overhead { background: #f59e0b; }
+.legend-dot.procurement  { background: #3b82f6; }
+.legend-dot.operational  { background: #8b5cf6; }
+.legend-dot.labor        { background: #10b981; }
+.legend-dot.overhead     { background: #f59e0b; }
 .legend-dot.revenue-color { background: #0f172a; }
-.legend-dot.cost-color { background: #ef4444; }
+.legend-dot.cost-color   { background: #ef4444; }
 
-.stats-grid-finance {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+/* Bar chart shared layout */
+.chart-container {
+  padding: 1rem 0;
+}
+
+.bar-chart {
+  display: flex;
   gap: 1.5rem;
-  margin-bottom: 2rem;
+  height: 320px;
 }
 
-.revenue-card {
-  border-left: 4px solid #0f172a;
+.y-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-right: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  border-right: 1px solid var(--border);
+  min-width: 48px;
+  text-align: right;
 }
 
-.cost-card {
-  border-left: 4px solid #ef4444;
+.chart-area {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-around;
+  gap: 0.5rem;
 }
 
-.profit-card {
-  border-left: 4px solid #3b82f6;
-}
-
-.stat-meta {
-  margin-top: 0.5rem;
-  font-size: 0.813rem;
-  color: #64748b;
-}
-
+/* Revenue vs Cost bars */
 .bar-group-revenue {
   display: flex;
   flex-direction: column;
@@ -587,56 +602,25 @@ export default {
   padding-bottom: 2rem;
 }
 
-.revenue-bar, .cost-bar {
+.revenue-bar,
+.cost-bar {
   width: 50%;
   max-width: 30px;
   border-radius: 6px 6px 0 0;
-  transition: all 0.3s ease;
+  transition: opacity 0.2s ease;
   cursor: pointer;
   min-height: 4px;
 }
 
-.revenue-bar {
-  background: #0f172a;
+.revenue-bar { background: #0f172a; }
+.cost-bar    { background: #ef4444; }
+
+.revenue-bar:hover,
+.cost-bar:hover {
+  opacity: 0.75;
 }
 
-.cost-bar {
-  background: #ef4444;
-}
-
-.revenue-bar:hover, .cost-bar:hover {
-  opacity: 0.8;
-  transform: scaleY(1.05);
-}
-
-.chart-container {
-  padding: 1.5rem 0;
-}
-
-.bar-chart {
-  display: flex;
-  gap: 1.5rem;
-  height: 350px;
-}
-
-.y-axis {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding-right: 1rem;
-  font-size: 0.75rem;
-  color: #94a3b8;
-  border-right: 1px solid #e2e8f0;
-}
-
-.chart-area {
-  flex: 1;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-around;
-  gap: 0.5rem;
-}
-
+/* Stacked cost bars */
 .bar-group {
   display: flex;
   flex-direction: column;
@@ -663,51 +647,49 @@ export default {
 
 .bar-segment {
   width: 100%;
-  transition: all 0.3s ease;
-  cursor: pointer;
+  transition: opacity 0.2s ease;
   display: block;
 }
 
-.bar-segment:first-child {
-  border-radius: 0 0 6px 6px;
-}
-
-.bar-segment:last-child {
-  border-radius: 6px 6px 0 0;
-}
+.bar-segment:first-child { border-radius: 0 0 6px 6px; }
+.bar-segment:last-child  { border-radius: 6px 6px 0 0; }
 
 .bar-segment.procurement { background: #3b82f6; }
 .bar-segment.operational { background: #8b5cf6; }
-.bar-segment.labor { background: #10b981; }
-.bar-segment.overhead { background: #f59e0b; }
-
-.bar-segment:hover {
-  opacity: 0.8;
-}
+.bar-segment.labor       { background: #10b981; }
+.bar-segment.overhead    { background: #f59e0b; }
 
 .bar-label {
   margin-top: 0.5rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-secondary);
 }
 
-.two-column-grid {
+/* Two-column bottom grid */
+.charts-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
-  gap: 1.75rem;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
 }
 
+@media (max-width: 900px) {
+  .charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Category breakdown */
 .category-list {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .category-item {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .category-info {
@@ -718,135 +700,80 @@ export default {
 
 .category-name {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-primary);
+  font-size: 0.875rem;
 }
 
 .category-amount {
   font-weight: 700;
-  color: #2563eb;
-  font-size: 1.125rem;
+  color: var(--accent);
+  font-size: 1rem;
 }
 
 .category-bar-container {
   width: 100%;
-  height: 8px;
+  height: 6px;
   background: #f1f5f9;
-  border-radius: 4px;
+  border-radius: 3px;
   overflow: hidden;
 }
 
 .category-bar {
   height: 100%;
-  background: linear-gradient(90deg, #3b82f6 0%, #2563eb 100%);
-  border-radius: 4px;
-  transition: width 0.6s ease;
+  background: linear-gradient(90deg, #3b82f6 0%, var(--accent) 100%);
+  border-radius: 3px;
+  transition: width 0.5s ease;
 }
 
 .category-meta {
   display: flex;
   justify-content: space-between;
-  font-size: 0.813rem;
+  font-size: 0.8125rem;
 }
 
 .percentage {
-  color: #64748b;
+  color: var(--text-secondary);
 }
 
 .change {
   font-weight: 600;
 }
 
-.change.positive {
-  color: #059669;
-}
+.change.positive { color: #059669; }
+.change.negative { color: #dc2626; }
 
-.change.negative {
-  color: #dc2626;
-}
-
-.transactions-card {
-  display: flex;
-  flex-direction: column;
-}
-
-.transactions-table-container {
+/* Transactions table */
+.transactions-scroll {
+  max-height: 380px;
   overflow-y: auto;
-  max-height: 400px;
-}
-
-.transactions-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.transactions-table thead {
-  position: sticky;
-  top: 0;
-  background: #f8fafc;
-  z-index: 1;
-}
-
-.transactions-table th {
-  text-align: left;
-  padding: 0.625rem 0.75rem;
-  font-weight: 600;
-  color: #475569;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.transactions-table th.text-right {
-  text-align: right;
-}
-
-.transactions-table td {
-  padding: 0.75rem 0.75rem;
-  border-bottom: 1px solid #f1f5f9;
-  font-size: 0.875rem;
-}
-
-.transactions-table tbody tr {
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-
-.transactions-table tbody tr:hover {
-  background: #f8fafc;
-}
-
-.transactions-table tbody tr.clickable-row:hover {
-  background: #eff6ff;
 }
 
 .transaction-id {
-  color: #64748b;
+  color: var(--text-secondary);
   font-weight: 500;
   font-family: 'Monaco', 'Courier New', monospace;
-  font-size: 0.813rem;
+  font-size: 0.8125rem;
 }
 
-.transaction-description {
-  color: #0f172a;
-  font-weight: 500;
-}
-
-.transaction-vendor {
-  color: #64748b;
-}
-
-.transaction-date {
-  color: #64748b;
-  font-size: 0.813rem;
-}
-
-.transaction-amount {
-  font-weight: 700;
-  color: #0f172a;
+.text-secondary {
+  color: var(--text-secondary);
 }
 
 .text-right {
   text-align: right;
+}
+
+.amount-cell {
+  font-weight: 700;
+  color: var(--text-primary);
+  text-align: right;
+}
+
+.clickable-row {
+  cursor: pointer;
+}
+
+.clickable-row:hover {
+  background: #eff6ff !important;
 }
 </style>

--- a/server/main.py
+++ b/server/main.py
@@ -2,9 +2,13 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
+
+# In-memory restocking orders storage
+restocking_orders: list = []
 
 # Quarter mapping for date filtering
 QUARTER_MAP = {
@@ -118,6 +122,25 @@ class CreatePurchaseOrderRequest(BaseModel):
     quantity: int
     unit_cost: float
     expected_delivery_date: str
+    notes: Optional[str] = None
+
+class RestockingItem(BaseModel):
+    sku: str
+    item_name: str
+    quantity: int
+    unit_cost: float
+
+class RestockingOrder(BaseModel):
+    id: str
+    items: List[RestockingItem]
+    total_cost: float
+    status: str
+    created_date: str
+    expected_delivery_date: str
+    notes: Optional[str] = None
+
+class CreateRestockingOrderRequest(BaseModel):
+    items: List[RestockingItem]
     notes: Optional[str] = None
 
 # API endpoints
@@ -303,6 +326,27 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking-orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all restocking orders"""
+    return restocking_orders
+
+@app.post("/api/restocking-orders", response_model=RestockingOrder)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Create a new restocking order"""
+    now = datetime.utcnow()
+    order = {
+        "id": str(len(restocking_orders) + 1),
+        "items": [item.dict() for item in request.items],
+        "total_cost": sum(item.quantity * item.unit_cost for item in request.items),
+        "status": "Processing",
+        "created_date": now.isoformat(),
+        "expected_delivery_date": (now + timedelta(days=14)).isoformat(),
+        "notes": request.notes,
+    }
+    restocking_orders.append(order)
+    return order
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- Add **Restocking Planner** view with budget slider and demand-based recommendations
- Refactor navigation to **sidebar layout** for improved UX
- Add **i18n support** (English/Japanese) via vue-i18n
- Enhance FastAPI backend with spending, demand, and restocking endpoints
- Update all views for improved data display and filter integration

## Test plan
- [ ] Dashboard loads with KPI cards, order health chart, and inventory shortages table
- [ ] Inventory page shows all 32 SKUs with correct stock status badges
- [ ] Orders page displays status summary cards and full orders table
- [ ] Finance page shows revenue/cost charts and transactions list
- [ ] Demand Forecast page shows trend cards and forecast table
- [ ] Restocking Planner: budget slider updates total cost correctly; Place Order submits
- [ ] Reports page shows quarterly performance table and monthly revenue chart
- [ ] Language toggle switches UI between English and Japanese
- [ ] All 4 filters (Time Period, Location, Category, Order Status) apply across views

🤖 Generated with [Claude Code](https://claude.com/claude-code)