### PR TITLE
Add Restocking tab, architecture docs, and saas-redesign skill

### DIFF
--- a/.claude/skills/saas-redesign/SKILL.md
+++ b/.claude/skills/saas-redesign/SKILL.md
@@ -1,0 +1,653 @@
+---
+name: saas-redesign
+description: Redesigns a Vue 3 application's UI into a modern SaaS-style interface with a vertical navigation sidebar, consistent spacing, and a polished professional look. Use when the user asks to modernize, redesign, or make the app look like a SaaS product.
+---
+
+# SaaS Redesign Skill
+
+Transform this Vue 3 application's UI into a modern SaaS-style interface. This skill covers the full redesign: layout structure, design system, sidebar navigation, typography, spacing, and visual polish.
+
+---
+
+## Phase 1 — Audit the Current App
+
+Before writing any code, read these files to understand what exists:
+
+1. **`client/src/App.vue`** — current root layout, global CSS, nav structure
+2. **`client/src/main.js`** — router config and all route paths
+3. **`client/src/views/*.vue`** — all page components (skim for page-level classes and layout patterns)
+4. **`client/src/components/FilterBar.vue`** — to understand where it lives in the layout
+
+Map out:
+- All nav links and their routes
+- All global CSS class names used across views (`.card`, `.stat-card`, `.badge`, `.table-container`, etc.)
+- Any hardcoded colors or fonts in scoped styles that conflict with the new system
+
+---
+
+## Phase 2 — Design System
+
+Apply this token set consistently. Define CSS custom properties in `:root` inside `App.vue`'s global `<style>` block:
+
+```css
+:root {
+  /* Sidebar */
+  --sidebar-width: 240px;
+  --sidebar-bg: #0f172a;
+  --sidebar-text: #94a3b8;
+  --sidebar-text-active: #f8fafc;
+  --sidebar-accent: #3b82f6;
+  --sidebar-hover-bg: rgba(255,255,255,0.06);
+  --sidebar-active-bg: rgba(59,130,246,0.15);
+  --sidebar-border: rgba(255,255,255,0.08);
+
+  /* Surface */
+  --bg: #f1f5f9;
+  --surface: #ffffff;
+  --surface-2: #f8fafc;
+  --border: #e2e8f0;
+  --border-strong: #cbd5e1;
+
+  /* Text */
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+
+  /* Brand */
+  --accent: #3b82f6;
+  --accent-hover: #2563eb;
+
+  /* Status */
+  --success: #059669;
+  --success-bg: #d1fae5;
+  --warning: #d97706;
+  --warning-bg: #fef3c7;
+  --danger: #dc2626;
+  --danger-bg: #fee2e2;
+  --info: #2563eb;
+  --info-bg: #dbeafe;
+
+  /* Radius & shadow */
+  --radius-sm: 6px;
+  --radius: 10px;
+  --radius-lg: 14px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+  --shadow: 0 4px 12px rgba(0,0,0,0.08);
+  --shadow-lg: 0 10px 24px rgba(0,0,0,0.12);
+
+  /* Spacing */
+  --content-padding: 2rem;
+  --card-padding: 1.5rem;
+  --gap: 1.25rem;
+}
+```
+
+---
+
+## Phase 3 — Rewrite App.vue Layout
+
+Replace the top-nav layout with a sidebar + content shell. The new structure:
+
+```
+┌──────────────────────────────────────┐
+│  sidebar (fixed, full height)        │
+│  ┌────────┐  ┌─────────────────────┐ │
+│  │ 240px  │  │   main content      │ │
+│  │        │  │                     │ │
+│  │ logo   │  │  FilterBar (if any) │ │
+│  │ nav    │  │                     │ │
+│  │ items  │  │  <router-view />    │ │
+│  │        │  │                     │ │
+│  │ user   │  │                     │ │
+│  └────────┘  └─────────────────────┘ │
+└──────────────────────────────────────┘
+```
+
+### App.vue template skeleton
+
+```vue
+<template>
+  <div class="app-shell">
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <!-- Logo / brand -->
+      <div class="sidebar-brand">
+        <div class="brand-icon"><!-- initials or icon --></div>
+        <div class="brand-text">
+          <span class="brand-name">{{ t('nav.companyName') }}</span>
+          <span class="brand-sub">{{ t('nav.subtitle') }}</span>
+        </div>
+      </div>
+
+      <!-- Navigation -->
+      <nav class="sidebar-nav">
+        <router-link
+          v-for="item in navItems"
+          :key="item.path"
+          :to="item.path"
+          class="nav-item"
+          :class="{ active: isActive(item) }"
+        >
+          <!-- SVG icon slot -->
+          <span class="nav-icon" v-html="item.icon"></span>
+          <span class="nav-label">{{ t(item.labelKey) }}</span>
+        </router-link>
+      </nav>
+
+      <!-- Spacer pushes user section to bottom -->
+      <div class="sidebar-spacer"></div>
+
+      <!-- Bottom: language + user -->
+      <div class="sidebar-footer">
+        <LanguageSwitcher />
+        <ProfileMenu
+          @show-profile-details="showProfileDetails = true"
+          @show-tasks="showTasks = true"
+        />
+      </div>
+    </aside>
+
+    <!-- Main content area -->
+    <div class="content-area">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
+
+    <!-- Modals (unchanged) -->
+    <ProfileDetailsModal :is-open="showProfileDetails" @close="showProfileDetails = false" />
+    <TasksModal ... />
+  </div>
+</template>
+```
+
+### navItems array (define in setup())
+
+Build the nav from the router config. Each item:
+```js
+const navItems = [
+  { path: '/',           labelKey: 'nav.overview',       icon: '<svg>...</svg>' },
+  { path: '/inventory',  labelKey: 'nav.inventory',      icon: '<svg>...</svg>' },
+  { path: '/orders',     labelKey: 'nav.orders',         icon: '<svg>...</svg>' },
+  { path: '/spending',   labelKey: 'nav.finance',        icon: '<svg>...</svg>' },
+  { path: '/demand',     labelKey: 'nav.demandForecast', icon: '<svg>...</svg>' },
+  { path: '/reports',    labelKey: 'nav.reports',        icon: '<svg>...</svg>' },
+  { path: '/restocking', labelKey: 'nav.restocking',     icon: '<svg>...</svg>' },
+]
+```
+
+Use `useRoute()` from vue-router for active detection:
+```js
+import { useRoute } from 'vue-router'
+const route = useRoute()
+const isActive = (item) => {
+  if (item.path === '/') return route.path === '/'
+  return route.path.startsWith(item.path)
+}
+```
+
+### Icon set — use Heroicons outline SVGs (inline, no library needed)
+
+Suggested icon SVGs (24×24, `stroke="currentColor"`, `fill="none"`):
+- Overview/Dashboard: squares-2×2 or chart-bar
+- Inventory: archive-box or cube
+- Orders: clipboard-document-list
+- Finance/Spending: banknotes or currency-dollar
+- Demand Forecast: arrow-trending-up or chart-line
+- Reports: document-chart-bar
+- Restocking: arrow-path or shopping-cart
+
+Find the correct SVG path data at https://heroicons.com — use the **outline** variant. Each icon should be:
+```html
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="18" height="18">
+  <path stroke-linecap="round" stroke-linejoin="round" d="..." />
+</svg>
+```
+
+---
+
+## Phase 4 — App.vue Global CSS
+
+Replace ALL existing global styles with this new system. Keep class names compatible with what the views already use (`.card`, `.stat-card`, `.badge`, etc.) so views don't need changes.
+
+```css
+/* ── Shell layout ── */
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  background: var(--sidebar-bg);
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  z-index: 100;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1.25rem 1.25rem;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+.brand-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.brand-name {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--sidebar-text-active);
+  display: block;
+  line-height: 1.2;
+}
+
+.brand-sub {
+  font-size: 0.688rem;
+  color: var(--sidebar-text);
+  display: block;
+  margin-top: 2px;
+  line-height: 1.2;
+}
+
+/* ── Nav items ── */
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 1rem 0.75rem;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: var(--radius-sm);
+  color: var(--sidebar-text);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: background 0.15s ease, color 0.15s ease;
+  cursor: pointer;
+}
+
+.nav-item:hover {
+  background: var(--sidebar-hover-bg);
+  color: var(--sidebar-text-active);
+}
+
+.nav-item.active {
+  background: var(--sidebar-active-bg);
+  color: var(--sidebar-accent);
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.nav-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-spacer { flex: 1; }
+
+.sidebar-footer {
+  padding: 1rem 0.75rem;
+  border-top: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* ── Content area ── */
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0; /* prevents flex overflow */
+}
+
+.main-content {
+  flex: 1;
+  padding: var(--content-padding);
+  max-width: 1400px;
+  width: 100%;
+}
+
+/* ── Typography ── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Page header ── */
+.page-header {
+  margin-bottom: 1.75rem;
+}
+
+.page-header h2 {
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.025em;
+  margin-bottom: 0.25rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+/* ── Cards ── */
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: var(--card-padding);
+  margin-bottom: var(--gap);
+  box-shadow: var(--shadow-sm);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+/* ── Stat cards ── */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+}
+
+.stat-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 1.25rem var(--card-padding);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.stat-card:hover {
+  box-shadow: var(--shadow);
+  border-color: var(--border-strong);
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.625rem;
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+
+.stat-card.success .stat-value { color: var(--success); }
+.stat-card.warning .stat-value { color: var(--warning); }
+.stat-card.danger  .stat-value { color: var(--danger); }
+.stat-card.info    .stat-value { color: var(--info); }
+.stat-card.restocking .stat-value { color: #7c3aed; }
+
+/* ── Tables ── */
+.table-container { overflow-x: auto; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+th {
+  text-align: left;
+  padding: 0.625rem 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: 0.688rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+td {
+  padding: 0.625rem 0.875rem;
+  border-top: 1px solid #f1f5f9;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+tbody tr { transition: background 0.1s ease; }
+tbody tr:hover { background: var(--surface-2); }
+
+/* ── Badges ── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  font-size: 0.688rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.badge.success    { background: var(--success-bg); color: #065f46; }
+.badge.warning    { background: var(--warning-bg); color: #92400e; }
+.badge.danger     { background: var(--danger-bg);  color: #991b1b; }
+.badge.info       { background: var(--info-bg);    color: #1e40af; }
+.badge.increasing { background: var(--success-bg); color: #065f46; }
+.badge.decreasing { background: var(--danger-bg);  color: #991b1b; }
+.badge.stable     { background: #e0e7ff;           color: #3730a3; }
+.badge.high       { background: var(--danger-bg);  color: #991b1b; }
+.badge.medium     { background: var(--warning-bg); color: #92400e; }
+.badge.low        { background: var(--info-bg);    color: #1e40af; }
+.badge.restocking { background: #ede9fe;           color: #5b21b6; }
+
+/* ── Loading / error states ── */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+.error {
+  background: var(--danger-bg);
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  margin: 1rem 0;
+  font-size: 0.875rem;
+}
+```
+
+---
+
+## Phase 5 — FilterBar Integration
+
+The FilterBar sits between the sidebar and the view content. Style it as a sticky subheader inside `.content-area`, above `<main>`:
+
+```css
+/* In FilterBar.vue scoped styles — or in App.vue global */
+.filter-bar {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem var(--content-padding);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  box-shadow: var(--shadow-sm);
+}
+```
+
+---
+
+## Phase 6 — LanguageSwitcher and ProfileMenu in the Sidebar
+
+These components live in the sidebar footer. They may need style adjustments since they were designed for a top nav. Check their scoped styles and update colors/backgrounds to match the dark sidebar:
+
+- Buttons inside should use `color: var(--sidebar-text)` and `hover: var(--sidebar-hover-bg)`
+- Dropdowns/modals should still open in `var(--surface)` white — no change needed there
+- If either component uses hardcoded dark text that becomes invisible on the dark sidebar, add a scoped override in `App.vue`:
+
+```css
+/* Override for sidebar context */
+.sidebar-footer :deep(.language-switcher button),
+.sidebar-footer :deep(.profile-menu-trigger) {
+  color: var(--sidebar-text);
+  background: transparent;
+}
+.sidebar-footer :deep(.language-switcher button):hover,
+.sidebar-footer :deep(.profile-menu-trigger):hover {
+  background: var(--sidebar-hover-bg);
+  color: var(--sidebar-text-active);
+}
+```
+
+---
+
+## Phase 7 — View-Level Polish (optional but recommended)
+
+After the layout is working, scan each view for these quick wins:
+
+| Issue | Fix |
+|---|---|
+| `.page-header h2` font-size is too small | Already handled by global styles — verify |
+| Stat cards have hardcoded border colors | Remove scoped overrides, let global `.stat-card` handle |
+| Table `th` has excessive padding | Handled by global `th` — check for scoped overrides that fight it |
+| Empty state messages are unstyled | Wrap in `<div class="empty-state">` with centered text and muted color |
+| Buttons have no shared style | Add a `.btn`, `.btn-primary`, `.btn-secondary` global class |
+
+Suggested global button styles:
+```css
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.btn-primary {
+  background: var(--accent);
+  color: white;
+}
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-primary:disabled { background: var(--border-strong); color: var(--text-muted); cursor: not-allowed; }
+.btn-secondary {
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+.btn-secondary:hover { border-color: var(--border-strong); color: var(--text-primary); }
+```
+
+---
+
+## Phase 8 — Verification
+
+After writing all code, verify in the browser using Playwright MCP tools:
+
+1. **Navigate to each route** — sidebar active state highlights correctly, content renders
+2. **Sidebar** — logo, all nav links, language switcher, profile menu visible
+3. **FilterBar** — renders as sticky subheader, filters still function
+4. **Cards and tables** — spacing, borders, hover states look correct
+5. **Badges and stat cards** — colors match the design system
+6. **Modals** — ProfileDetails and Tasks modals still open correctly
+7. **Responsive check** — scroll horizontally if viewport is narrow; sidebar should not collapse (out of scope unless user requests)
+
+Use `mcp__playwright__browser_take_screenshot` at each major route to confirm the visual result. Fix any broken layout before reporting done.
+
+---
+
+## Implementation Order
+
+Execute in this order to minimize broken states:
+
+1. Read all files listed in Phase 1
+2. Rewrite `App.vue` — template + global CSS (Phases 3–4)
+3. Update `FilterBar.vue` scoped styles if needed (Phase 5)
+4. Fix `LanguageSwitcher` and `ProfileMenu` sidebar colors if needed (Phase 6)
+5. Quick view-level polish pass (Phase 7)
+6. Browser verification (Phase 8)
+
+**Delegate all `.vue` file writes to the `vue-expert` subagent** as required by CLAUDE.md. Pass the full context (current file content + exact changes needed) in the agent prompt.
+
+---
+
+## Common Pitfalls
+
+- **Sidebar width and `min-width`** — always set both on `.sidebar` or flex will shrink it
+- **`min-width: 0` on `.content-area`** — required to prevent flex children from overflowing
+- **`position: sticky; top: 0; height: 100vh`** on sidebar — keeps it in place while content scrolls
+- **Removing `max-width` from `main-content`** — old layout had `max-width: 1600px` centered; new layout fills the space right of the sidebar, so remove the `margin: 0 auto`
+- **Active route for root `/`** — use exact match `route.path === '/'` not `startsWith('/')` or every link will be active
+- **Dark sidebar + white dropdowns** — ProfileMenu and LanguageSwitcher dropdowns open in white, which is correct; only the trigger buttons need sidebar color overrides

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,6 +25,9 @@
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            {{ t('nav.restocking') }}
+          </router-link>
         </nav>
         <LanguageSwitcher />
         <ProfileMenu
@@ -465,6 +468,15 @@ tbody tr:hover {
 .badge.low {
   background: #dbeafe;
   color: #1e40af;
+}
+
+.badge.restocking {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.stat-card.restocking .stat-value {
+  color: #7c3aed;
 }
 
 .loading {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,15 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingCandidates() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/candidates`)
+    return response.data
+  },
+
+  async createOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/orders`, orderData)
+    return response.data
   }
 }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -204,6 +205,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    restocking: 'Restocking',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'
@@ -309,6 +311,40 @@ export default {
     english: 'English',
     japanese: 'Japanese',
     selectLanguage: 'Select Language'
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Set a budget and place restocking orders for low-stock items',
+    budget: {
+      label: 'Available Budget',
+      allocated: 'Allocated',
+      remaining: 'Remaining',
+      of: 'of'
+    },
+    items: {
+      title: 'Recommended Items',
+      empty: 'Increase your budget to see restocking recommendations',
+      summary: '{count} items selected'
+    },
+    table: {
+      sku: 'SKU',
+      name: 'Item',
+      category: 'Category',
+      warehouse: 'Warehouse',
+      onHand: 'On Hand',
+      reorderPoint: 'Reorder Point',
+      qtyToOrder: 'Qty to Order',
+      unitCost: 'Unit Cost',
+      totalCost: 'Total Cost'
+    },
+    placeOrder: 'Place Restocking Order',
+    orderPlaced: 'Order Placed',
+    success: 'Restocking order {orderNumber} submitted. Expected delivery: {date}.',
+    leadTime: '7-day lead time',
+    submittedOrders: 'Submitted Restocking Orders',
+    noItems: 'No low-stock items require restocking'
   },
 
   // Common

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充発注',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -204,6 +205,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    restocking: '補充発注',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'
@@ -309,6 +311,40 @@ export default {
     english: 'English',
     japanese: '日本語',
     selectLanguage: '言語を選択'
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充発注',
+    description: '予算を設定して在庫不足品目の補充注文を行います',
+    budget: {
+      label: '利用可能予算',
+      allocated: '割当済み',
+      remaining: '残額',
+      of: 'の'
+    },
+    items: {
+      title: '推奨品目',
+      empty: '予算を増やして補充推奨品目を確認してください',
+      summary: '{count}品目選択中'
+    },
+    table: {
+      sku: 'SKU',
+      name: '品目',
+      category: 'カテゴリ',
+      warehouse: '倉庫',
+      onHand: '手持在庫',
+      reorderPoint: '再注文点',
+      qtyToOrder: '注文数量',
+      unitCost: '単価',
+      totalCost: '合計金額'
+    },
+    placeOrder: '補充注文を発注',
+    orderPlaced: '注文完了',
+    success: '補充注文{orderNumber}が提出されました。予定配達日：{date}。',
+    leadTime: '7日間リードタイム',
+    submittedOrders: '提出済み補充注文',
+    noItems: '補充が必要な在庫不足品目はありません'
   },
 
   // Common

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -25,6 +25,44 @@
           <div class="stat-label">{{ t('status.backordered') }}</div>
           <div class="stat-value">{{ getOrdersByStatus('Backordered').length }}</div>
         </div>
+        <div class="stat-card restocking">
+          <div class="stat-label">{{ t('status.restocking') }}</div>
+          <div class="stat-value">{{ restockingOrders.length }}</div>
+        </div>
+      </div>
+
+      <div v-if="restockingOrders.length > 0" class="card restocking-section">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.submittedOrders') }} ({{ restockingOrders.length }})</h3>
+          <span class="lead-time-badge">{{ t('restocking.leadTime') }}</span>
+        </div>
+        <div class="table-container">
+          <table class="restocking-table">
+            <thead>
+              <tr>
+                <th>{{ t('orders.table.orderNumber') }}</th>
+                <th>{{ t('orders.table.items') }}</th>
+                <th>{{ t('orders.table.warehouse') }}</th>
+                <th>{{ t('orders.table.orderDate') }}</th>
+                <th>{{ t('orders.table.expectedDelivery') }}</th>
+                <th>{{ t('orders.table.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in restockingOrders" :key="order.id">
+                <td><strong>{{ order.order_number }}</strong></td>
+                <td>{{ order.items.length }} items</td>
+                <td>{{ order.warehouse || 'All' }}</td>
+                <td>{{ formatDate(order.order_date) }}</td>
+                <td>
+                  {{ formatDate(order.expected_delivery) }}
+                  <span class="delivery-lead-badge">+7 days</span>
+                </td>
+                <td><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div class="card">
@@ -129,6 +167,11 @@ export default {
       loadOrders()
     })
 
+    // Restocking orders are excluded from the main list and shown separately above
+    const restockingOrders = computed(() =>
+      orders.value.filter(o => o.status === 'Restocking')
+    )
+
     const getOrdersByStatus = (status) => {
       return orders.value.filter(order => order.status === status)
     }
@@ -138,7 +181,8 @@ export default {
         'Delivered': 'success',
         'Shipped': 'info',
         'Processing': 'warning',
-        'Backordered': 'danger'
+        'Backordered': 'danger',
+        'Restocking': 'restocking'
       }
       return statusMap[status] || 'info'
     }
@@ -160,6 +204,7 @@ export default {
       loading,
       error,
       orders,
+      restockingOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,
@@ -275,5 +320,33 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+/* Restocking section styles */
+.restocking-section .card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.lead-time-badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  background: #ede9fe;
+  color: #5b21b6;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.delivery-lead-badge {
+  display: inline-block;
+  margin-left: 0.375rem;
+  padding: 0.125rem 0.5rem;
+  background: #ede9fe;
+  color: #5b21b6;
+  border-radius: 4px;
+  font-size: 0.688rem;
+  font-weight: 600;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,629 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else-if="candidates.length === 0">
+      <div class="card empty-card">
+        <p class="empty-text">{{ t('restocking.noItems') }}</p>
+      </div>
+    </div>
+    <div v-else>
+      <!-- Budget card -->
+      <div class="card budget-card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.budget.label') }}</h3>
+          <span class="lead-time-badge">{{ t('restocking.leadTime') }}</span>
+        </div>
+
+        <div class="slider-row">
+          <input
+            v-model.number="budget"
+            type="range"
+            :min="0"
+            :max="maxBudget"
+            :step="1000"
+            class="budget-slider"
+            aria-label="Budget slider"
+          />
+        </div>
+
+        <div class="budget-pills">
+          <div class="budget-pill">
+            <span class="pill-label">{{ t('restocking.budget.label') }}</span>
+            <span class="pill-value">{{ currencySymbol }}{{ budget.toLocaleString() }}</span>
+          </div>
+          <div class="budget-pill allocated">
+            <span class="pill-label">{{ t('restocking.budget.allocated') }}</span>
+            <span class="pill-value">{{ currencySymbol }}{{ allocatedCost.toLocaleString() }}</span>
+          </div>
+          <div class="budget-pill remaining" :class="{ 'over-budget': remainingBudget < 0 }">
+            <span class="pill-label">{{ t('restocking.budget.remaining') }}</span>
+            <span class="pill-value">{{ currencySymbol }}{{ remainingBudget.toLocaleString() }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Recommended items card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">
+            {{ t('restocking.items.title') }}
+            <span class="item-count">({{ t('restocking.items.summary', { count: selectedCandidates.length }) }})</span>
+          </h3>
+        </div>
+
+        <div v-if="budget === 0 || selectedCandidates.length === 0" class="empty-state">
+          <p>{{ t('restocking.items.empty') }}</p>
+        </div>
+        <div v-else class="table-container">
+          <table class="restocking-table">
+            <thead>
+              <tr>
+                <th class="col-check"></th>
+                <th class="col-sku">{{ t('restocking.table.sku') }}</th>
+                <th class="col-name">{{ t('restocking.table.name') }}</th>
+                <th class="col-category">{{ t('restocking.table.category') }}</th>
+                <th class="col-warehouse">{{ t('restocking.table.warehouse') }}</th>
+                <th class="col-num">{{ t('restocking.table.onHand') }}</th>
+                <th class="col-num">{{ t('restocking.table.reorderPoint') }}</th>
+                <th class="col-num">{{ t('restocking.table.qtyToOrder') }}</th>
+                <th class="col-cost">{{ t('restocking.table.unitCost') }}</th>
+                <th class="col-cost">{{ t('restocking.table.totalCost') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!--
+                Render ALL candidates so deselected rows stay visible and can be re-checked.
+                selectedSkus drives :checked so unaffordable rows show unchecked correctly.
+                Rows outside budget that the user hasn't explicitly touched get a dimmer style.
+              -->
+              <tr
+                v-for="candidate in candidates"
+                :key="candidate.sku"
+                :class="{
+                  'row-deselected': deselected.has(candidate.sku),
+                  'row-unaffordable': !selectedSkus.has(candidate.sku) && !deselected.has(candidate.sku)
+                }"
+              >
+                <td class="col-check">
+                  <input
+                    type="checkbox"
+                    :checked="selectedSkus.has(candidate.sku)"
+                    @change="toggleItem(candidate.sku)"
+                    class="row-checkbox"
+                    :aria-label="`Select ${candidate.name}`"
+                  />
+                </td>
+                <td class="col-sku"><code class="sku-code">{{ candidate.sku }}</code></td>
+                <td class="col-name"><strong>{{ candidate.name }}</strong></td>
+                <td class="col-category">
+                  <span class="badge info">{{ candidate.category }}</span>
+                </td>
+                <td class="col-warehouse">{{ candidate.warehouse }}</td>
+                <td class="col-num">{{ candidate.quantity_on_hand }}</td>
+                <td class="col-num">{{ candidate.reorder_point }}</td>
+                <td class="col-num"><strong>{{ candidate.restock_quantity }}</strong></td>
+                <td class="col-cost">{{ currencySymbol }}{{ candidate.unit_cost.toLocaleString() }}</td>
+                <td class="col-cost"><strong>{{ currencySymbol }}{{ candidate.restock_cost.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr class="summary-row">
+                <td colspan="7" class="summary-label">Total Selected ({{ selectedCandidates.length }} items)</td>
+                <td class="col-num summary-qty">{{ totalRestockQty.toLocaleString() }}</td>
+                <td></td>
+                <td class="col-cost summary-total">{{ currencySymbol }}{{ allocatedCost.toLocaleString() }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+
+      <!-- Place order section -->
+      <div class="place-order-section">
+        <div v-if="orderPlaced" class="success-banner">
+          <div class="success-icon">
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+              <circle cx="10" cy="10" r="10" fill="#059669" />
+              <path d="M6 10l3 3 5-5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </div>
+          <div class="success-text">
+            <strong>{{ t('restocking.orderPlaced') }}</strong>
+            <p>{{ t('restocking.success', { orderNumber: placedOrderNumber, date: placedDeliveryDate }) }}</p>
+          </div>
+        </div>
+        <button
+          v-else
+          @click="placeOrder"
+          :disabled="selectedCandidates.length === 0 || submitting"
+          class="btn-place-order"
+        >
+          {{ submitting ? t('common.loading') : t('restocking.placeOrder') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency, currentLocale } = useI18n()
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? '¥' : '$'
+    })
+
+    const loading = ref(true)
+    const error = ref(null)
+    const candidates = ref([])
+    const budget = ref(0)
+    const deselected = ref(new Set())
+    const submitting = ref(false)
+    const orderPlaced = ref(false)
+    const placedOrderNumber = ref('')
+    const placedDeliveryDate = ref('')
+
+    // Sum of all candidate restock costs, rounded up to nearest $10K, minimum $50K
+    const maxBudget = computed(() => {
+      const total = candidates.value.reduce((sum, c) => sum + c.restock_cost, 0)
+      return Math.max(50000, Math.ceil(total / 10000) * 10000)
+    })
+
+    // Greedy selection: iterate candidates in urgency order, include each item if its
+    // restock_cost fits within the remaining budget AND the user has not deselected it.
+    const selectedCandidates = computed(() => {
+      let remaining = budget.value
+      return candidates.value.filter(c => {
+        if (deselected.value.has(c.sku)) return false
+        if (c.restock_cost <= remaining) {
+          remaining -= c.restock_cost
+          return true
+        }
+        return false
+      })
+    })
+
+    const allocatedCost = computed(() =>
+      selectedCandidates.value.reduce((sum, c) => sum + c.restock_cost, 0)
+    )
+
+    // Set of SKUs that are currently selected (within budget and not deselected).
+    // Used to drive checkbox :checked and row styling without filtering the rendered rows.
+    const selectedSkus = computed(() => new Set(selectedCandidates.value.map(c => c.sku)))
+
+    const remainingBudget = computed(() => budget.value - allocatedCost.value)
+
+    const totalRestockQty = computed(() =>
+      selectedCandidates.value.reduce((sum, c) => sum + c.restock_quantity, 0)
+    )
+
+    const toggleItem = (sku) => {
+      const next = new Set(deselected.value)
+      if (next.has(sku)) {
+        next.delete(sku)
+      } else {
+        next.add(sku)
+      }
+      // Replace the ref value so Vue detects the Set mutation
+      deselected.value = next
+    }
+
+    const formatDate = (isoString) => {
+      const date = new Date(isoString)
+      if (isNaN(date.getTime())) return isoString
+      const locale = currentLocale.value === 'ja' ? 'ja-JP' : 'en-US'
+      return date.toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' })
+    }
+
+    // Return the most frequently occurring value of a given key in an array of objects.
+    // Falls back to `fallback` when the array is empty.
+    const mostCommon = (items, key, fallback) => {
+      if (!items.length) return fallback
+      const freq = {}
+      for (const item of items) {
+        const val = item[key] || fallback
+        freq[val] = (freq[val] || 0) + 1
+      }
+      return Object.entries(freq).sort((a, b) => b[1] - a[1])[0][0]
+    }
+
+    const placeOrder = async () => {
+      if (selectedCandidates.value.length === 0) return
+      submitting.value = true
+      error.value = null
+      try {
+        const orderNumber = 'RESTOCK-' + Date.now()
+        const orderDate = new Date().toISOString()
+        const expectedDelivery = new Date(Date.now() + 7 * 86400000).toISOString()
+
+        const items = selectedCandidates.value.map(c => ({
+          sku: c.sku,
+          name: c.name,
+          quantity: c.restock_quantity,
+          unit_price: c.unit_cost
+        }))
+
+        const payload = {
+          order_number: orderNumber,
+          customer: 'Internal Restocking',
+          items,
+          status: 'Restocking',
+          order_date: orderDate,
+          expected_delivery: expectedDelivery,
+          total_value: allocatedCost.value,
+          warehouse: mostCommon(selectedCandidates.value, 'warehouse', 'All'),
+          category: mostCommon(selectedCandidates.value, 'category', 'Mixed')
+        }
+
+        await api.createOrder(payload)
+
+        placedOrderNumber.value = orderNumber
+        placedDeliveryDate.value = formatDate(expectedDelivery)
+        orderPlaced.value = true
+      } catch (err) {
+        error.value = 'Failed to place order: ' + (err.response?.data?.detail || err.message)
+        console.error('Place order error:', err)
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    const loadCandidates = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        candidates.value = await api.getRestockingCandidates()
+        // Set budget to max so all candidates are auto-selected on load
+        budget.value = maxBudget.value
+      } catch (err) {
+        error.value = 'Failed to load restocking candidates: ' + err.message
+        console.error('Load candidates error:', err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    onMounted(loadCandidates)
+
+    return {
+      t,
+      currencySymbol,
+      loading,
+      error,
+      candidates,
+      budget,
+      maxBudget,
+      deselected,
+      selectedCandidates,
+      selectedSkus,
+      allocatedCost,
+      remainingBudget,
+      totalRestockQty,
+      toggleItem,
+      submitting,
+      orderPlaced,
+      placedOrderNumber,
+      placedDeliveryDate,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.restocking {
+  /* Page-level wrapper — padding provided by .main-content in App.vue */
+}
+
+/* Empty state when no low-stock items exist */
+.empty-card {
+  text-align: center;
+  padding: 3rem;
+}
+
+.empty-text {
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+/* Budget card */
+.budget-card .card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.lead-time-badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  background: #ede9fe;
+  color: #5b21b6;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.slider-row {
+  padding: 0.75rem 0 1.25rem;
+}
+
+.budget-slider {
+  width: 100%;
+  height: 6px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: #e2e8f0;
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #7c3aed;
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(124, 58, 237, 0.4);
+  transition: box-shadow 0.2s;
+}
+
+.budget-slider::-webkit-slider-thumb:hover {
+  box-shadow: 0 1px 8px rgba(124, 58, 237, 0.6);
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #7c3aed;
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(124, 58, 237, 0.4);
+}
+
+/* Budget stat pills */
+.budget-pills {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.budget-pill {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 1.25rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  min-width: 160px;
+}
+
+.budget-pill.allocated {
+  border-color: #c4b5fd;
+  background: #faf5ff;
+}
+
+.budget-pill.remaining {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.budget-pill.remaining.over-budget {
+  border-color: #fecaca;
+  background: #fef2f2;
+}
+
+.budget-pill.remaining.over-budget .pill-value {
+  color: #dc2626;
+}
+
+.pill-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.pill-value {
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.budget-pill.allocated .pill-value {
+  color: #7c3aed;
+}
+
+.budget-pill.remaining .pill-value {
+  color: #059669;
+}
+
+/* Item count in card header */
+.item-count {
+  font-size: 0.938rem;
+  font-weight: 400;
+  color: #64748b;
+  margin-left: 0.375rem;
+}
+
+/* Empty state inside items card */
+.empty-state {
+  padding: 2.5rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+/* Restocking table */
+.restocking-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.col-check {
+  width: 40px;
+}
+
+.col-sku {
+  width: 120px;
+}
+
+.col-name {
+  width: 200px;
+}
+
+.col-category {
+  width: 130px;
+}
+
+.col-warehouse {
+  width: 160px;
+}
+
+.col-num {
+  width: 100px;
+  text-align: right;
+}
+
+.col-cost {
+  width: 110px;
+  text-align: right;
+}
+
+.row-checkbox {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  accent-color: #7c3aed;
+}
+
+.sku-code {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.813rem;
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  color: #475569;
+}
+
+.row-deselected td {
+  opacity: 0.45;
+  text-decoration: line-through;
+}
+
+/* Rows that don't fit within the current budget (not explicitly deselected by user) */
+.row-unaffordable td {
+  opacity: 0.5;
+  color: #94a3b8;
+}
+
+/* Summary footer row */
+.summary-row {
+  border-top: 2px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.summary-row td {
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.summary-label {
+  font-weight: 600;
+  color: #475569;
+}
+
+.summary-qty {
+  font-weight: 700;
+  color: #0f172a;
+  text-align: right;
+}
+
+.summary-total {
+  font-weight: 700;
+  color: #7c3aed;
+  text-align: right;
+  font-size: 0.938rem;
+}
+
+/* Place order section */
+.place-order-section {
+  margin-bottom: 1.5rem;
+}
+
+.btn-place-order {
+  display: block;
+  width: 100%;
+  padding: 1rem 2rem;
+  background: #7c3aed;
+  color: white;
+  border: none;
+  border-radius: 10px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, box-shadow 0.2s;
+  letter-spacing: 0.01em;
+}
+
+.btn-place-order:hover:not(:disabled) {
+  background: #6d28d9;
+  box-shadow: 0 4px 12px rgba(124, 58, 237, 0.35);
+}
+
+.btn-place-order:disabled {
+  background: #cbd5e1;
+  color: #94a3b8;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* Success banner */
+.success-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  padding: 1rem 1.25rem;
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  border-radius: 10px;
+}
+
+.success-icon {
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.success-text strong {
+  display: block;
+  font-size: 0.938rem;
+  color: #065f46;
+  margin-bottom: 0.25rem;
+}
+
+.success-text p {
+  font-size: 0.875rem;
+  color: #047857;
+  margin: 0;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,720 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>System Architecture — Factory Inventory Management</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f172a;
+      --surface: #1e293b;
+      --surface2: #273347;
+      --border: #334155;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --accent-blue: #38bdf8;
+      --accent-green: #34d399;
+      --accent-yellow: #fbbf24;
+      --accent-purple: #a78bfa;
+      --accent-orange: #fb923c;
+      --accent-red: #f87171;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 14px;
+      line-height: 1.6;
+      padding: 40px 24px 80px;
+    }
+
+    /* ── Layout ── */
+    .page { max-width: 1100px; margin: 0 auto; }
+
+    /* ── Header ── */
+    .page-header { margin-bottom: 48px; }
+    .page-header h1 {
+      font-size: 26px;
+      font-weight: 700;
+      color: var(--text);
+      letter-spacing: -0.3px;
+    }
+    .page-header p { color: var(--muted); margin-top: 6px; font-size: 14px; }
+    .badge {
+      display: inline-block;
+      padding: 2px 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.4px;
+      margin-top: 12px;
+    }
+    .badge-blue  { background: rgba(56,189,248,0.12); color: var(--accent-blue); border: 1px solid rgba(56,189,248,0.25); }
+    .badge-green { background: rgba(52,211,153,0.12); color: var(--accent-green); border: 1px solid rgba(52,211,153,0.25); }
+    .badge-yellow{ background: rgba(251,191,36,0.12); color: var(--accent-yellow); border: 1px solid rgba(251,191,36,0.25); }
+    .badge-purple{ background: rgba(167,139,250,0.12); color: var(--accent-purple); border: 1px solid rgba(167,139,250,0.25); }
+    .badge-orange{ background: rgba(251,146,60,0.12); color: var(--accent-orange); border: 1px solid rgba(251,146,60,0.25); }
+
+    /* ── Section ── */
+    section { margin-bottom: 48px; }
+    .section-title {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      color: var(--muted);
+      margin-bottom: 16px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* ── Card ── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 20px;
+    }
+
+    /* ── Tech Stack Grid ── */
+    .stack-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+    }
+    .stack-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 18px 20px;
+      border-top-width: 3px;
+    }
+    .stack-card.frontend  { border-top-color: var(--accent-blue); }
+    .stack-card.backend   { border-top-color: var(--accent-green); }
+    .stack-card.data      { border-top-color: var(--accent-yellow); }
+    .stack-card.tooling   { border-top-color: var(--accent-purple); }
+    .stack-card h3 {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      margin-bottom: 12px;
+    }
+    .stack-card.frontend h3  { color: var(--accent-blue); }
+    .stack-card.backend  h3  { color: var(--accent-green); }
+    .stack-card.data     h3  { color: var(--accent-yellow); }
+    .stack-card.tooling  h3  { color: var(--accent-purple); }
+    .stack-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding: 4px 0;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      gap: 12px;
+    }
+    .stack-item:last-child { border-bottom: none; }
+    .stack-item .name { color: var(--text); font-weight: 500; }
+    .stack-item .desc { color: var(--muted); font-size: 12px; text-align: right; }
+
+    /* ── System Diagram ── */
+    .diagram {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 28px;
+      overflow-x: auto;
+    }
+    .diagram-inner {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      min-width: 600px;
+    }
+
+    /* Layer boxes */
+    .layer {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 18px 20px;
+      position: relative;
+    }
+    .layer.browser  { border-color: rgba(56,189,248,0.4);  background: rgba(56,189,248,0.05); }
+    .layer.api-layer{ border-color: rgba(52,211,153,0.4);  background: rgba(52,211,153,0.05); }
+    .layer.data-layer{ border-color: rgba(251,191,36,0.4); background: rgba(251,191,36,0.05); }
+
+    .layer-label {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      margin-bottom: 12px;
+    }
+    .layer.browser   .layer-label { color: var(--accent-blue); }
+    .layer.api-layer .layer-label { color: var(--accent-green); }
+    .layer.data-layer .layer-label { color: var(--accent-yellow); }
+
+    .layer-content {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .box {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 8px 12px;
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .box.highlight-blue   { border-color: rgba(56,189,248,0.5);  color: var(--accent-blue); }
+    .box.highlight-green  { border-color: rgba(52,211,153,0.5);  color: var(--accent-green); }
+    .box.highlight-yellow { border-color: rgba(251,191,36,0.5);  color: var(--accent-yellow); }
+    .box.highlight-purple { border-color: rgba(167,139,250,0.5); color: var(--accent-purple); }
+    .box .sub { display: block; font-size: 10px; color: var(--muted); font-weight: 400; margin-top: 1px; }
+
+    /* Arrow connector */
+    .connector {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0;
+      padding: 6px 0;
+    }
+    .connector .arrow-line {
+      width: 1px;
+      height: 20px;
+      background: var(--border);
+    }
+    .connector .arrow-label {
+      font-size: 10px;
+      color: var(--muted);
+      background: var(--bg);
+      padding: 2px 8px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      white-space: nowrap;
+    }
+    .connector .arrow-down {
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 7px solid var(--border);
+    }
+
+    /* ── Data Flow ── */
+    .flow-steps {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+    .flow-step {
+      display: grid;
+      grid-template-columns: 36px 1fr;
+      gap: 16px;
+    }
+    .flow-step .step-left {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .step-num {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+    .step-line {
+      width: 1px;
+      flex: 1;
+      background: var(--border);
+      margin-top: 4px;
+      min-height: 16px;
+    }
+    .flow-step:last-child .step-line { display: none; }
+    .step-body {
+      padding-bottom: 20px;
+      padding-top: 4px;
+    }
+    .step-body h4 { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+    .step-body p  { color: var(--muted); font-size: 12px; line-height: 1.5; }
+    .step-body code {
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-size: 11px;
+      color: var(--accent-blue);
+    }
+
+    /* Color variants */
+    .step-num.blue   { background: rgba(56,189,248,0.15);  color: var(--accent-blue);   border: 1px solid rgba(56,189,248,0.3); }
+    .step-num.green  { background: rgba(52,211,153,0.15);  color: var(--accent-green);  border: 1px solid rgba(52,211,153,0.3); }
+    .step-num.yellow { background: rgba(251,191,36,0.15);  color: var(--accent-yellow); border: 1px solid rgba(251,191,36,0.3); }
+    .step-num.purple { background: rgba(167,139,250,0.15); color: var(--accent-purple); border: 1px solid rgba(167,139,250,0.3); }
+    .step-num.orange { background: rgba(251,146,60,0.15);  color: var(--accent-orange); border: 1px solid rgba(251,146,60,0.3); }
+    .step-num.red    { background: rgba(248,113,113,0.15); color: var(--accent-red);    border: 1px solid rgba(248,113,113,0.3); }
+
+    /* ── API Endpoints ── */
+    .endpoints-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 12px;
+    }
+    .endpoint-group { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .endpoint-group-header {
+      padding: 10px 14px;
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .endpoint-group-header.blue   { background: rgba(56,189,248,0.08);  color: var(--accent-blue); }
+    .endpoint-group-header.green  { background: rgba(52,211,153,0.08);  color: var(--accent-green); }
+    .endpoint-group-header.yellow { background: rgba(251,191,36,0.08);  color: var(--accent-yellow); }
+    .endpoint-group-header.purple { background: rgba(167,139,250,0.08); color: var(--accent-purple); }
+    .endpoint-group-header.orange { background: rgba(251,146,60,0.08);  color: var(--accent-orange); }
+    .endpoint-row {
+      display: flex;
+      align-items: baseline;
+      padding: 7px 14px;
+      gap: 10px;
+      border-bottom: 1px solid rgba(51,65,85,0.4);
+    }
+    .endpoint-row:last-child { border-bottom: none; }
+    .method {
+      font-size: 10px;
+      font-weight: 700;
+      font-family: monospace;
+      padding: 1px 5px;
+      border-radius: 3px;
+      flex-shrink: 0;
+      min-width: 36px;
+      text-align: center;
+    }
+    .method.get  { background: rgba(52,211,153,0.12); color: var(--accent-green); border: 1px solid rgba(52,211,153,0.2); }
+    .method.post { background: rgba(56,189,248,0.12); color: var(--accent-blue);  border: 1px solid rgba(56,189,248,0.2); }
+    .endpoint-path { font-family: 'SF Mono','Fira Code',monospace; font-size: 11px; color: var(--text); flex: 1; }
+    .endpoint-desc { font-size: 11px; color: var(--muted); }
+
+    /* ── File Map ── */
+    .file-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 12px;
+    }
+    .file-group { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .file-group-header {
+      padding: 10px 14px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.6px;
+      border-bottom: 1px solid var(--border);
+    }
+    .file-entry {
+      display: flex;
+      align-items: baseline;
+      padding: 6px 14px;
+      gap: 10px;
+      border-bottom: 1px solid rgba(51,65,85,0.4);
+    }
+    .file-entry:last-child { border-bottom: none; }
+    .file-name { font-family: 'SF Mono','Fira Code',monospace; font-size: 11px; color: var(--accent-blue); flex-shrink: 0; }
+    .file-desc { font-size: 11px; color: var(--muted); }
+
+    /* ── Filter system ── */
+    .filter-diagram {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
+      align-items: center;
+      gap: 8px;
+    }
+    .filter-box {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px 14px;
+      text-align: center;
+    }
+    .filter-box .fb-label { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 4px; }
+    .filter-box .fb-value { font-size: 12px; font-weight: 600; }
+    .filter-arrow { color: var(--muted); font-size: 16px; text-align: center; flex-shrink: 0; }
+
+    @media (max-width: 700px) {
+      .filter-diagram { grid-template-columns: 1fr; }
+      .filter-arrow { transform: rotate(90deg); }
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Header -->
+  <header class="page-header">
+    <h1>Factory Inventory Management System</h1>
+    <p>System architecture, tech stack, and data flow reference</p>
+    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:12px;">
+      <span class="badge badge-blue">Vue 3 + Vite &mdash; Port 3000</span>
+      <span class="badge badge-green">FastAPI + Uvicorn &mdash; Port 8001</span>
+      <span class="badge badge-yellow">In-Memory JSON Data</span>
+      <span class="badge badge-purple">REST API</span>
+    </div>
+  </header>
+
+  <!-- ── 1. System Diagram ── -->
+  <section>
+    <div class="section-title">System Architecture</div>
+    <div class="diagram">
+      <div class="diagram-inner">
+
+        <!-- Browser Layer -->
+        <div class="layer browser">
+          <div class="layer-label">Browser &mdash; Port 3000</div>
+          <div class="layer-content">
+            <div class="box highlight-blue">App.vue<span class="sub">Root + Router</span></div>
+            <div class="box highlight-blue">FilterBar.vue<span class="sub">Shared Filter UI</span></div>
+            <div class="box">Dashboard.vue<span class="sub">KPIs + Charts</span></div>
+            <div class="box">Inventory.vue<span class="sub">Stock Table</span></div>
+            <div class="box">Orders.vue<span class="sub">Order List</span></div>
+            <div class="box">Spending.vue<span class="sub">Cost Charts</span></div>
+            <div class="box">Demand.vue<span class="sub">Forecast Trends</span></div>
+            <div class="box">Reports.vue<span class="sub">Quarterly Stats</span></div>
+          </div>
+          <div style="margin-top:12px;">
+            <div class="layer-content">
+              <div class="box highlight-purple">useFilters()<span class="sub">Singleton Filter State</span></div>
+              <div class="box highlight-purple">useAuth()<span class="sub">User Session</span></div>
+              <div class="box highlight-purple">useI18n()<span class="sub">EN / JA i18n</span></div>
+              <div class="box highlight-blue">api.js<span class="sub">Axios HTTP Client</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Connector -->
+        <div class="connector">
+          <div class="arrow-line"></div>
+          <div class="arrow-label">HTTP GET /api/... &nbsp;|&nbsp; JSON Response &nbsp;(CORS enabled)</div>
+          <div class="arrow-down"></div>
+        </div>
+
+        <!-- API Layer -->
+        <div class="layer api-layer">
+          <div class="layer-label">FastAPI Server &mdash; Port 8001</div>
+          <div class="layer-content">
+            <div class="box highlight-green">main.py<span class="sub">23 Endpoints</span></div>
+            <div class="box">apply_filters()<span class="sub">warehouse / category / status</span></div>
+            <div class="box">filter_by_month()<span class="sub">YYYY-MM or Q1-2025</span></div>
+            <div class="box">Pydantic Models<span class="sub">Validation + Serialization</span></div>
+            <div class="box">CORS Middleware<span class="sub">All origins (dev)</span></div>
+          </div>
+        </div>
+
+        <!-- Connector -->
+        <div class="connector">
+          <div class="arrow-line"></div>
+          <div class="arrow-label">Loaded at startup &mdash; in-memory Python dicts/lists</div>
+          <div class="arrow-down"></div>
+        </div>
+
+        <!-- Data Layer -->
+        <div class="layer data-layer">
+          <div class="layer-label">Data Layer &mdash; In-Memory (mock_data.py)</div>
+          <div class="layer-content">
+            <div class="box highlight-yellow">inventory.json<span class="sub">~30 items, 3 warehouses</span></div>
+            <div class="box highlight-yellow">orders.json<span class="sub">1000+ orders, 148 KB</span></div>
+            <div class="box highlight-yellow">demand_forecasts.json<span class="sub">9 SKU forecasts</span></div>
+            <div class="box highlight-yellow">backlog_items.json<span class="sub">4 backlog items</span></div>
+            <div class="box highlight-yellow">spending.json<span class="sub">Summary + monthly + categories</span></div>
+            <div class="box highlight-yellow">transactions.json<span class="sub">100+ transactions</span></div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 2. Tech Stack ── -->
+  <section>
+    <div class="section-title">Tech Stack</div>
+    <div class="stack-grid">
+
+      <div class="stack-card frontend">
+        <h3>Frontend</h3>
+        <div class="stack-item"><span class="name">Vue 3</span><span class="desc">^3.4 · Composition API</span></div>
+        <div class="stack-item"><span class="name">Vue Router</span><span class="desc">^4.3 · Client-side routing</span></div>
+        <div class="stack-item"><span class="name">Axios</span><span class="desc">^1.6 · HTTP client</span></div>
+        <div class="stack-item"><span class="name">Vite</span><span class="desc">^5.2 · Dev server + bundler</span></div>
+        <div class="stack-item"><span class="name">Custom SVG Charts</span><span class="desc">No chart library</span></div>
+        <div class="stack-item"><span class="name">i18n</span><span class="desc">EN / JA · composable</span></div>
+      </div>
+
+      <div class="stack-card backend">
+        <h3>Backend</h3>
+        <div class="stack-item"><span class="name">FastAPI</span><span class="desc">&ge;0.110 · Web framework</span></div>
+        <div class="stack-item"><span class="name">Uvicorn</span><span class="desc">&ge;0.24 · ASGI server</span></div>
+        <div class="stack-item"><span class="name">Pydantic v2</span><span class="desc">&ge;2.5 · Validation</span></div>
+        <div class="stack-item"><span class="name">Python 3.11+</span><span class="desc">uv package manager</span></div>
+        <div class="stack-item"><span class="name">pytest + httpx</span><span class="desc">Backend test suite</span></div>
+      </div>
+
+      <div class="stack-card data">
+        <h3>Data</h3>
+        <div class="stack-item"><span class="name">JSON files</span><span class="desc">server/data/*.json</span></div>
+        <div class="stack-item"><span class="name">In-memory</span><span class="desc">No database</span></div>
+        <div class="stack-item"><span class="name">mock_data.py</span><span class="desc">Load at startup</span></div>
+        <div class="stack-item"><span class="name">Warehouses</span><span class="desc">SF · London · Tokyo</span></div>
+        <div class="stack-item"><span class="name">No persistence</span><span class="desc">Resets on restart</span></div>
+      </div>
+
+      <div class="stack-card tooling">
+        <h3>Tooling</h3>
+        <div class="stack-item"><span class="name">Git</span><span class="desc">Version control</span></div>
+        <div class="stack-item"><span class="name">Claude Code</span><span class="desc">AI dev agent</span></div>
+        <div class="stack-item"><span class="name">Playwright MCP</span><span class="desc">Browser testing</span></div>
+        <div class="stack-item"><span class="name">GitHub MCP</span><span class="desc">GitHub operations</span></div>
+        <div class="stack-item"><span class="name">pytest-cov</span><span class="desc">Coverage reporting</span></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── 3. Data Flow ── -->
+  <section>
+    <div class="section-title">Data Flow &mdash; Filter Change to UI Update</div>
+    <div class="card">
+      <div class="flow-steps">
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num blue">1</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>User changes a filter</h4>
+            <p><code>FilterBar.vue</code> &mdash; user selects "London" in the Location dropdown. The <code>v-model</code> binding writes to <code>selectedLocation</code> ref inside <code>useFilters()</code>.</p>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num purple">2</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>Singleton composable propagates the change</h4>
+            <p><code>useFilters()</code> holds module-level refs shared across every page. All views that call this composable see the updated value instantly. Each view watches <code>getCurrentFilters()</code> and calls its <code>loadData()</code> method.</p>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num blue">3</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>api.js builds the HTTP request</h4>
+            <p><code>getCurrentFilters()</code> returns <code>{ warehouse: "London", category: "all", status: "all", month: undefined }</code>. <code>api.js</code> converts non-"all" values into <code>URLSearchParams</code> and calls <code>axios.get("http://localhost:8001/api/dashboard/summary?warehouse=London")</code>.</p>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num green">4</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>FastAPI route receives the request</h4>
+            <p><code>main.py</code> extracts <code>warehouse="London"</code> from query params. <code>apply_filters(inventory_items, warehouse="London")</code> performs an in-memory list comprehension, keeping only items where <code>item["warehouse"] == "London"</code>. Same for orders.</p>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num yellow">5</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>Aggregation over filtered data</h4>
+            <p>Dashboard summary calculates: <code>total_inventory_value = sum(qty * unit_cost)</code>, <code>low_stock_items</code> (qty &le; reorder_point), <code>pending_orders</code> (status in Processing/Backordered). All computed in Python from the filtered in-memory list.</p>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num green">6</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>Pydantic serializes the response</h4>
+            <p>FastAPI uses Pydantic v2 models to validate and serialize the result dict to JSON. Response headers include <code>Content-Type: application/json</code>. CORS headers allow the Vue dev server on port 3000 to receive it.</p>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="step-left">
+            <div class="step-num blue">7</div>
+            <div class="step-line"></div>
+          </div>
+          <div class="step-body">
+            <h4>Vue reactive state updates &mdash; DOM re-renders</h4>
+            <p><code>summary.value = response.data</code> triggers Vue reactivity. Computed properties recalculate, <code>v-for</code> loops diff and patch the DOM. The user sees updated KPI numbers with no page reload.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 4. Filter System ── -->
+  <section>
+    <div class="section-title">Filter System</div>
+    <div class="card" style="margin-bottom:16px;">
+      <div style="margin-bottom:14px; font-size:12px; color:var(--muted);">
+        Four global filters apply across all data-driven pages via a singleton composable pattern.
+      </div>
+      <div class="filter-diagram">
+        <div class="filter-box">
+          <div class="fb-label">Time Period</div>
+          <div class="fb-value" style="color:var(--accent-blue);">selectedPeriod</div>
+          <div style="font-size:11px;color:var(--muted);margin-top:4px;">YYYY-MM or Q1-2025</div>
+        </div>
+        <div class="filter-arrow">+</div>
+        <div class="filter-box">
+          <div class="fb-label">Location</div>
+          <div class="fb-value" style="color:var(--accent-blue);">selectedLocation</div>
+          <div style="font-size:11px;color:var(--muted);margin-top:4px;">SF / London / Tokyo</div>
+        </div>
+        <div class="filter-arrow">+</div>
+        <div class="filter-box">
+          <div class="fb-label">Category</div>
+          <div class="fb-value" style="color:var(--accent-blue);">selectedCategory</div>
+          <div style="font-size:11px;color:var(--muted);margin-top:4px;">Circuit Boards, Sensors…</div>
+        </div>
+        <div class="filter-arrow">+</div>
+        <div class="filter-box">
+          <div class="fb-label">Order Status</div>
+          <div class="fb-value" style="color:var(--accent-blue);">selectedStatus</div>
+          <div style="font-size:11px;color:var(--muted);margin-top:4px;">Delivered / Shipped…</div>
+        </div>
+      </div>
+      <div style="margin-top:14px;font-size:12px;color:var(--muted);">
+        <strong style="color:var(--text);">Note:</strong>
+        Inventory endpoints support <code style="font-size:11px;background:var(--surface2);padding:1px 4px;border-radius:3px;color:var(--accent-blue);">warehouse</code> and <code style="font-size:11px;background:var(--surface2);padding:1px 4px;border-radius:3px;color:var(--accent-blue);">category</code> only (no time dimension).
+        Spending, Demand, and Reports pages do not use filters &mdash; they return all data.
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 5. API Endpoints ── -->
+  <section>
+    <div class="section-title">API Endpoints &mdash; FastAPI (Port 8001)</div>
+    <div class="endpoints-grid">
+
+      <div class="endpoint-group">
+        <div class="endpoint-group-header blue">Inventory</div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/inventory</span><span class="endpoint-desc">List all items</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/inventory/{id}</span><span class="endpoint-desc">Item detail</span></div>
+      </div>
+
+      <div class="endpoint-group">
+        <div class="endpoint-group-header green">Orders</div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/orders</span><span class="endpoint-desc">List with filters</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/orders/{id}</span><span class="endpoint-desc">Order detail</span></div>
+      </div>
+
+      <div class="endpoint-group">
+        <div class="endpoint-group-header yellow">Dashboard &amp; Reports</div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/dashboard/summary</span><span class="endpoint-desc">KPI aggregates</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/reports/quarterly</span><span class="endpoint-desc">Quarterly stats</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/reports/monthly-trends</span><span class="endpoint-desc">Monthly trends</span></div>
+      </div>
+
+      <div class="endpoint-group">
+        <div class="endpoint-group-header purple">Spending</div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/spending/summary</span><span class="endpoint-desc">Cost totals</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/spending/monthly</span><span class="endpoint-desc">Month breakdown</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/spending/categories</span><span class="endpoint-desc">By category</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/spending/transactions</span><span class="endpoint-desc">Recent transactions</span></div>
+      </div>
+
+      <div class="endpoint-group">
+        <div class="endpoint-group-header orange">Demand &amp; Backlog</div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/demand</span><span class="endpoint-desc">Forecasts (no filter)</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/backlog</span><span class="endpoint-desc">Backlog + PO flags</span></div>
+        <div class="endpoint-row"><span class="method post">POST</span><span class="endpoint-path">/api/purchase-orders</span><span class="endpoint-desc">Create PO (stub)</span></div>
+      </div>
+
+      <div class="endpoint-group">
+        <div class="endpoint-group-header" style="background:rgba(248,113,113,0.08);color:var(--accent-red);">Tasks (Stub)</div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/api/tasks</span><span class="endpoint-desc">Not implemented</span></div>
+        <div class="endpoint-row"><span class="method post">POST</span><span class="endpoint-path">/api/tasks</span><span class="endpoint-desc">Not implemented</span></div>
+        <div class="endpoint-row"><span class="method get">GET</span><span class="endpoint-path">/docs</span><span class="endpoint-desc">Swagger UI</span></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── 6. Key Files ── -->
+  <section>
+    <div class="section-title">Key File Map</div>
+    <div class="file-grid">
+
+      <div class="file-group">
+        <div class="file-group-header" style="color:var(--accent-blue); background:rgba(56,189,248,0.06); border-bottom:1px solid var(--border);">Frontend &mdash; client/src/</div>
+        <div class="file-entry"><span class="file-name">api.js</span><span class="file-desc">Centralized Axios HTTP client</span></div>
+        <div class="file-entry"><span class="file-name">App.vue</span><span class="file-desc">Root: header, nav, FilterBar, router-view</span></div>
+        <div class="file-entry"><span class="file-name">views/Dashboard.vue</span><span class="file-desc">KPIs, order health, charts</span></div>
+        <div class="file-entry"><span class="file-name">views/Inventory.vue</span><span class="file-desc">Stock table + search</span></div>
+        <div class="file-entry"><span class="file-name">views/Orders.vue</span><span class="file-desc">Order list + status breakdown</span></div>
+        <div class="file-entry"><span class="file-name">views/Spending.vue</span><span class="file-desc">Revenue vs cost charts</span></div>
+        <div class="file-entry"><span class="file-name">views/Demand.vue</span><span class="file-desc">Forecast trend cards</span></div>
+        <div class="file-entry"><span class="file-name">views/Reports.vue</span><span class="file-desc">Quarterly + monthly analysis</span></div>
+        <div class="file-entry"><span class="file-name">components/FilterBar.vue</span><span class="file-desc">Shared filter UI across all pages</span></div>
+      </div>
+
+      <div class="file-group">
+        <div class="file-group-header" style="color:var(--accent-purple); background:rgba(167,139,250,0.06); border-bottom:1px solid var(--border);">Composables &mdash; client/src/composables/</div>
+        <div class="file-entry"><span class="file-name">useFilters.js</span><span class="file-desc">Singleton filter state (4 refs)</span></div>
+        <div class="file-entry"><span class="file-name">useAuth.js</span><span class="file-desc">Current user, initials, logout</span></div>
+        <div class="file-entry"><span class="file-name">useI18n.js</span><span class="file-desc">EN/JA translation + currency</span></div>
+        <div class="file-group-header" style="color:var(--accent-green); background:rgba(52,211,153,0.06); border-bottom:1px solid var(--border); border-top:1px solid var(--border);">Backend &mdash; server/</div>
+        <div class="file-entry"><span class="file-name">main.py</span><span class="file-desc">FastAPI app, all 23 endpoints</span></div>
+        <div class="file-entry"><span class="file-name">mock_data.py</span><span class="file-desc">Loads JSON files into memory at startup</span></div>
+        <div class="file-entry"><span class="file-name">pyproject.toml</span><span class="file-desc">Python deps (FastAPI, Pydantic, pytest)</span></div>
+      </div>
+
+      <div class="file-group">
+        <div class="file-group-header" style="color:var(--accent-yellow); background:rgba(251,191,36,0.06); border-bottom:1px solid var(--border);">Data &mdash; server/data/</div>
+        <div class="file-entry"><span class="file-name">inventory.json</span><span class="file-desc">~30 items, SKU/qty/cost/warehouse</span></div>
+        <div class="file-entry"><span class="file-name">orders.json</span><span class="file-desc">1000+ orders, 148 KB, Jan–Dec 2025</span></div>
+        <div class="file-entry"><span class="file-name">demand_forecasts.json</span><span class="file-desc">9 items, trend + forecast</span></div>
+        <div class="file-entry"><span class="file-name">backlog_items.json</span><span class="file-desc">4 backlog items with priority</span></div>
+        <div class="file-entry"><span class="file-name">spending.json</span><span class="file-desc">Summary + 12-month + categories</span></div>
+        <div class="file-entry"><span class="file-name">transactions.json</span><span class="file-desc">100+ transactions, typed</span></div>
+        <div class="file-entry"><span class="file-name">purchase_orders.json</span><span class="file-desc">Empty (feature stubbed)</span></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <div style="text-align:center; color:var(--muted); font-size:12px; margin-top:32px; padding-top:24px; border-top:1px solid var(--border);">
+    Factory Inventory Management System &mdash; Architecture Reference &mdash; Generated 2026-06-16
+  </div>
+
+</div>
+</body>
+</html>

--- a/server/main.py
+++ b/server/main.py
@@ -120,6 +120,28 @@ class CreatePurchaseOrderRequest(BaseModel):
     expected_delivery_date: str
     notes: Optional[str] = None
 
+class RestockingCandidate(BaseModel):
+    sku: str
+    name: str
+    category: str
+    warehouse: str
+    quantity_on_hand: int
+    reorder_point: int
+    unit_cost: float
+    restock_quantity: int
+    restock_cost: float
+
+class CreateOrderRequest(BaseModel):
+    order_number: str
+    customer: str
+    items: List[dict]
+    status: str
+    order_date: str
+    expected_delivery: str
+    total_value: float
+    warehouse: Optional[str] = None
+    category: Optional[str] = None
+
 # API endpoints
 @app.get("/")
 def root():
@@ -303,6 +325,50 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking/candidates", response_model=List[RestockingCandidate])
+def get_restocking_candidates():
+    """Return inventory items below reorder_point, sorted by urgency (most critical first)."""
+    candidates = []
+    for item in inventory_items:
+        qty = item["quantity_on_hand"]
+        reorder = item["reorder_point"]
+        if qty < reorder:
+            restock_qty = reorder * 2 - qty
+            candidates.append({
+                "sku": item["sku"],
+                "name": item["name"],
+                "category": item["category"],
+                "warehouse": item["warehouse"],
+                "quantity_on_hand": qty,
+                "reorder_point": reorder,
+                "unit_cost": item["unit_cost"],
+                "restock_quantity": restock_qty,
+                "restock_cost": round(restock_qty * item["unit_cost"], 2),
+            })
+    # Sort by shortage ratio descending so most critical items are first
+    candidates.sort(key=lambda c: (c["reorder_point"] - c["quantity_on_hand"]) / c["reorder_point"], reverse=True)
+    return candidates
+
+@app.post("/api/orders", response_model=Order)
+def create_order(order: CreateOrderRequest):
+    """Create a new order (used by the Restocking tab) and append it to in-memory list."""
+    new_id = str(len(orders) + 1)
+    new_order = {
+        "id": new_id,
+        "order_number": order.order_number,
+        "customer": order.customer,
+        "items": order.items,
+        "status": order.status,
+        "order_date": order.order_date,
+        "expected_delivery": order.expected_delivery,
+        "total_value": order.total_value,
+        "actual_delivery": None,
+        "warehouse": order.warehouse,
+        "category": order.category,
+    }
+    orders.append(new_order)
+    return new_order
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary

- **Restocking tab** (`/restocking`): budget slider with greedy candidate selection, checkbox deselection, "Place Restocking Order" button with 7-day lead time
- **Backend**: `GET /api/restocking/candidates` returns low-stock inventory items sorted by urgency; `POST /api/orders` appends submitted orders to in-memory list
- **Orders tab**: 5th stat card for Restocking count (purple) + "Submitted Restocking Orders" section with `+7 days` delivery badge
- **i18n**: full English and Japanese translations for all new restocking keys
- **Architecture page**: `docs/architecture.html` — standalone reference with system diagram, tech stack, data flow, and API endpoint map
- **saas-redesign skill**: `.claude/skills/saas-redesign/SKILL.md` — 8-phase Claude Code skill for converting the top-nav layout to a SaaS-style vertical sidebar

## Test plan

- [ ] Navigate to `/restocking` — budget slider at max, 4 items auto-selected, allocated cost shown
- [ ] Adjust slider down — items drop out of selection as budget shrinks
- [ ] Uncheck an item — it shows strikethrough/deselected style; cost updates
- [ ] Click "Place Restocking Order" — success message with order number and expected delivery (+7 days)
- [ ] Navigate to `/orders` — Restocking stat card shows count of 1; "Submitted Restocking Orders" section visible with lead-time badge
- [ ] `curl http://localhost:8001/api/restocking/candidates` — returns JSON array of low-stock items
- [ ] Open `docs/architecture.html` in browser — architecture diagram renders correctly
- [ ] Switch language to Japanese — all restocking strings appear in Japanese

🤖 Generated with [Claude Code](https://claude.com/claude-code)