### PR TITLE
Add PurchaseOrderModal, tasks API, SaaS UI redesign, and GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ npm install && npm run dev
 - Data: `server/data/*.json`
 - Styles: `client/src/App.vue`
 
+## Code Style
+- Always document non-obvious logic changes with comments
+
 ## Design System
 - Colors: Slate/gray (#0f172a, #64748b, #e2e8f0)
 - Status: green/blue/yellow/red

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,17 @@
 <template>
-  <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
-        <LanguageSwitcher />
-        <ProfileMenu
-          @show-profile-details="showProfileDetails = true"
-          @show-tasks="showTasks = true"
-        />
+  <div class="app-shell">
+    <AppSidebar
+      @show-profile-details="showProfileDetails = true"
+      @show-tasks="showTasks = true"
+    />
+    <div class="main-area">
+      <div class="topbar">
+        <FilterBar />
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -60,19 +35,17 @@ import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
 import FilterBar from './components/FilterBar.vue'
-import ProfileMenu from './components/ProfileMenu.vue'
 import ProfileDetailsModal from './components/ProfileDetailsModal.vue'
 import TasksModal from './components/TasksModal.vue'
-import LanguageSwitcher from './components/LanguageSwitcher.vue'
+import AppSidebar from './components/AppSidebar.vue'
 
 export default {
   name: 'App',
   components: {
     FilterBar,
-    ProfileMenu,
     ProfileDetailsModal,
     TasksModal,
-    LanguageSwitcher
+    AppSidebar
   },
   setup() {
     const { currentUser } = useAuth()
@@ -176,101 +149,29 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.app {
-  display: flex;
-  flex-direction: column;
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
+.main-area {
   display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
-}
-
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
-}
-
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.nav-tabs a:hover {
-  color: #0f172a;
+  flex-direction: column;
   background: #f1f5f9;
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 90;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0.6rem 1.5rem;
 }
 
 .main-content {
   flex: 1;
-  max-width: 1600px;
-  width: 100%;
-  margin: 0 auto;
   padding: 1.5rem 2rem;
 }
 
@@ -302,7 +203,8 @@ body {
   background: white;
   padding: 1.25rem;
   border-radius: 10px;
-  border: 1px solid #e2e8f0;
+  border: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.04);
   transition: all 0.2s ease;
 }
 
@@ -347,7 +249,8 @@ body {
   background: white;
   border-radius: 10px;
   padding: 1.25rem;
-  border: 1px solid #e2e8f0;
+  border: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.04);
   margin-bottom: 1.25rem;
 }
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="app-shell">
+  <div class="app-shell" :style="{ gridTemplateColumns: sidebarCollapsed ? '64px 1fr' : '240px 1fr' }">
     <AppSidebar
+      :collapsed="sidebarCollapsed"
+      @toggle-collapse="toggleSidebar"
       @show-profile-details="showProfileDetails = true"
       @show-tasks="showTasks = true"
     />
@@ -52,6 +54,8 @@ export default {
     const { t } = useI18n()
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
+    const sidebarCollapsed = ref(false)
+    const toggleSidebar = () => { sidebarCollapsed.value = !sidebarCollapsed.value }
     const apiTasks = ref([])
 
     // Merge mock tasks from currentUser with API tasks
@@ -125,6 +129,8 @@ export default {
       t,
       showProfileDetails,
       showTasks,
+      sidebarCollapsed,
+      toggleSidebar,
       tasks,
       addTask,
       deleteTask,
@@ -153,6 +159,7 @@ body {
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
+  transition: grid-template-columns 0.2s ease;
 }
 
 .main-area {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,27 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getReportsQuarterly(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    if (filters.status && filters.status !== 'all') params.append('status', filters.status)
+    if (filters.month && filters.month !== 'all') params.append('month', filters.month)
+
+    const response = await axios.get(`${API_BASE_URL}/reports/quarterly?${params.toString()}`)
+    return response.data
+  },
+
+  async getMonthlyTrends(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    if (filters.status && filters.status !== 'all') params.append('status', filters.status)
+    if (filters.month && filters.month !== 'all') params.append('month', filters.month)
+
+    const response = await axios.get(`${API_BASE_URL}/reports/monthly-trends?${params.toString()}`)
+    return response.data
   }
 }

--- a/client/src/components/AppSidebar.vue
+++ b/client/src/components/AppSidebar.vue
@@ -1,0 +1,180 @@
+<template>
+  <aside class="sidebar">
+    <!-- Logo -->
+    <div class="sidebar-logo">
+      <div class="logo-name">{{ t('nav.companyName') }}</div>
+      <div class="logo-sub">{{ t('nav.subtitle') }}</div>
+    </div>
+
+    <!-- Nav -->
+    <nav class="sidebar-nav">
+      <a
+        v-for="item in navItems"
+        :key="item.path"
+        class="nav-item"
+        :class="{ active: isActive(item) }"
+        @click.prevent="$router.push(item.path)"
+        href="#"
+      >
+        <span class="nav-icon" v-html="item.icon"></span>
+        <span class="nav-label">{{ item.label || t(item.labelKey) }}</span>
+      </a>
+    </nav>
+
+    <!-- Footer -->
+    <div class="sidebar-footer">
+      <LanguageSwitcher />
+      <ProfileMenu
+        @show-profile-details="$emit('show-profile-details')"
+        @show-tasks="$emit('show-tasks')"
+      />
+    </div>
+  </aside>
+</template>
+
+<script>
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from '../composables/useI18n.js'
+import ProfileMenu from './ProfileMenu.vue'
+import LanguageSwitcher from './LanguageSwitcher.vue'
+
+export default {
+  name: 'AppSidebar',
+  components: { ProfileMenu, LanguageSwitcher },
+  emits: ['show-profile-details', 'show-tasks'],
+  setup() {
+    const route = useRoute()
+    const { t } = useI18n()
+
+    const navItems = [
+      {
+        path: '/',
+        labelKey: 'nav.overview',
+        icon: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>`
+      },
+      {
+        path: '/inventory',
+        labelKey: 'nav.inventory',
+        icon: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>`
+      },
+      {
+        path: '/orders',
+        labelKey: 'nav.orders',
+        icon: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>`
+      },
+      {
+        path: '/spending',
+        labelKey: 'nav.finance',
+        icon: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>`
+      },
+      {
+        path: '/demand',
+        labelKey: 'nav.demandForecast',
+        icon: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg>`
+      },
+      {
+        path: '/reports',
+        label: 'Reports',
+        icon: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>`
+      },
+    ]
+
+    const isActive = (item) =>
+      item.path === '/' ? route.path === '/' : route.path.startsWith(item.path)
+
+    return { t, navItems, isActive }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #0f172a;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+.sidebar-logo {
+  padding: 1.25rem 1rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.logo-name {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #ffffff;
+  letter-spacing: -0.01em;
+}
+
+.logo-sub {
+  font-size: 0.7rem;
+  color: #475569;
+  margin-top: 2px;
+}
+
+.sidebar-nav {
+  flex: 1;
+  padding: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nav-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.45rem 0.75rem;
+  margin: 0 0.5rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #64748b;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  cursor: pointer;
+}
+
+.nav-item:hover {
+  color: #f1f5f9;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.nav-item.active {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+/* Active left border indicator */
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -0.5rem;
+  top: 15%;
+  height: 70%;
+  width: 3px;
+  background: #2563eb;
+  border-radius: 0 2px 2px 0;
+}
+
+.nav-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+</style>

--- a/client/src/components/AppSidebar.vue
+++ b/client/src/components/AppSidebar.vue
@@ -108,11 +108,11 @@ export default {
   display: flex;
   flex-direction: column;
   background: #0f172a;
-  overflow-y: auto;
   flex-shrink: 0;
   width: 240px;
   transition: width 0.2s ease;
-  overflow: hidden;
+  overflow: visible;
+  z-index: 10;
 }
 
 .sidebar.collapsed {
@@ -226,5 +226,10 @@ export default {
 }
 .collapse-btn:hover {
   color: #94a3b8;
+}
+
+.sidebar.collapsed :deep(.profile-name),
+.sidebar.collapsed :deep(.chevron) {
+  display: none;
 }
 </style>

--- a/client/src/components/AppSidebar.vue
+++ b/client/src/components/AppSidebar.vue
@@ -1,9 +1,16 @@
 <template>
-  <aside class="sidebar">
+  <aside class="sidebar" :class="{ collapsed: collapsed }">
     <!-- Logo -->
     <div class="sidebar-logo">
-      <div class="logo-name">{{ t('nav.companyName') }}</div>
-      <div class="logo-sub">{{ t('nav.subtitle') }}</div>
+      <div class="logo-text" v-show="!collapsed">
+        <div class="logo-name">{{ t('nav.companyName') }}</div>
+        <div class="logo-sub">{{ t('nav.subtitle') }}</div>
+      </div>
+      <button class="collapse-btn" @click="$emit('toggle-collapse')" :title="collapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+        <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <polyline :points="collapsed ? '9 18 15 12 9 6' : '15 18 9 12 15 6'"></polyline>
+        </svg>
+      </button>
     </div>
 
     <!-- Nav -->
@@ -17,13 +24,13 @@
         href="#"
       >
         <span class="nav-icon" v-html="item.icon"></span>
-        <span class="nav-label">{{ item.label || t(item.labelKey) }}</span>
+        <span v-show="!collapsed" class="nav-label">{{ item.label || t(item.labelKey) }}</span>
       </a>
     </nav>
 
     <!-- Footer -->
     <div class="sidebar-footer">
-      <LanguageSwitcher />
+      <LanguageSwitcher v-show="!collapsed" />
       <ProfileMenu
         @show-profile-details="$emit('show-profile-details')"
         @show-tasks="$emit('show-tasks')"
@@ -41,7 +48,13 @@ import LanguageSwitcher from './LanguageSwitcher.vue'
 export default {
   name: 'AppSidebar',
   components: { ProfileMenu, LanguageSwitcher },
-  emits: ['show-profile-details', 'show-tasks'],
+  props: {
+    collapsed: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['show-profile-details', 'show-tasks', 'toggle-collapse'],
   setup() {
     const route = useRoute()
     const { t } = useI18n()
@@ -97,11 +110,24 @@ export default {
   background: #0f172a;
   overflow-y: auto;
   flex-shrink: 0;
+  width: 240px;
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.sidebar.collapsed {
+  width: 64px;
 }
 
 .sidebar-logo {
   padding: 1.25rem 1rem 1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  display: flex;
+  align-items: center;
+}
+
+.logo-text {
+  flex: 1;
 }
 
 .logo-name {
@@ -176,5 +202,29 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+/* When collapsed, center the icons */
+.sidebar.collapsed .nav-item {
+  justify-content: center;
+  padding: 0.6rem;
+  margin: 0 0.35rem;
+}
+
+/* Collapse button */
+.collapse-btn {
+  background: none;
+  border: none;
+  color: #475569;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+  margin-left: auto;
+}
+.collapse-btn:hover {
+  color: #94a3b8;
 }
 </style>

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -102,18 +102,14 @@ export default {
 
 <style scoped>
 .filters-bar {
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
-  padding: 0.75rem 0;
-  position: sticky;
-  top: 70px;
-  z-index: 90;
+  background: transparent;
+  border-bottom: none;
+  padding: 0;
 }
 
 .filters-container {
-  max-width: 1600px;
-  margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0;
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 1rem;

--- a/client/src/components/LanguageSwitcher.vue
+++ b/client/src/components/LanguageSwitcher.vue
@@ -134,7 +134,7 @@ const selectLanguage = (locale) => {
 
 .dropdown-menu {
   position: absolute;
-  top: calc(100% + 0.5rem);
+  bottom: calc(100% + 0.5rem);
   right: 0;
   min-width: 160px;
   background: white;

--- a/client/src/components/ProfileMenu.vue
+++ b/client/src/components/ProfileMenu.vue
@@ -169,9 +169,9 @@ const handleLogout = () => {
 
 .dropdown-menu {
   position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
-  min-width: 280px;
+  bottom: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 220px;
   background: white;
   border: 1px solid #e2e8f0;
   border-radius: 10px;

--- a/client/src/components/PurchaseOrderModal.vue
+++ b/client/src/components/PurchaseOrderModal.vue
@@ -1,0 +1,551 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="isOpen && backlogItem" class="modal-overlay" @click="close">
+        <div class="modal-container" @click.stop>
+          <div class="modal-header">
+            <h3 class="modal-title">
+              {{ mode === 'create' ? 'Create Purchase Order' : 'Purchase Order Details' }}
+            </h3>
+            <button class="close-button" @click="close">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+
+          <div class="modal-body">
+            <!-- Item context header -->
+            <div class="item-context">
+              <div class="item-context-info">
+                <div class="item-context-name">{{ backlogItem.item_name }}</div>
+                <div class="item-context-sku">SKU: {{ backlogItem.item_sku }}</div>
+              </div>
+              <span class="priority-badge" :class="backlogItem.priority">
+                {{ backlogItem.priority }} Priority
+              </span>
+            </div>
+
+            <!-- CREATE MODE -->
+            <template v-if="mode === 'create'">
+              <div class="form-grid">
+                <div class="form-group">
+                  <label class="form-label" for="po-supplier">Supplier Name</label>
+                  <input
+                    id="po-supplier"
+                    v-model="form.supplier"
+                    type="text"
+                    class="form-input"
+                    placeholder="Enter supplier name"
+                  />
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="po-quantity">Quantity to Order</label>
+                  <input
+                    id="po-quantity"
+                    v-model.number="form.quantity"
+                    type="number"
+                    class="form-input"
+                    min="1"
+                  />
+                  <div class="form-hint">Shortage: {{ shortage }} units</div>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="po-delivery">Expected Delivery Date</label>
+                  <input
+                    id="po-delivery"
+                    v-model="form.delivery_date"
+                    type="date"
+                    class="form-input"
+                  />
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="po-priority">Priority</label>
+                  <select id="po-priority" v-model="form.priority" class="form-select">
+                    <option value="urgent">Urgent</option>
+                    <option value="standard">Standard</option>
+                    <option value="low">Low</option>
+                  </select>
+                </div>
+              </div>
+            </template>
+
+            <!-- VIEW MODE -->
+            <template v-else-if="mode === 'view'">
+              <template v-if="backlogItem.purchase_order">
+                <div class="po-details-grid">
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">PO ID</div>
+                    <div class="po-detail-value po-id">{{ backlogItem.purchase_order.id }}</div>
+                  </div>
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">Supplier</div>
+                    <div class="po-detail-value">{{ backlogItem.purchase_order.supplier }}</div>
+                  </div>
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">Quantity Ordered</div>
+                    <div class="po-detail-value">{{ backlogItem.purchase_order.quantity }} units</div>
+                  </div>
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">Expected Delivery</div>
+                    <div class="po-detail-value">{{ formatDate(backlogItem.purchase_order.delivery_date) }}</div>
+                  </div>
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">Priority</div>
+                    <div class="po-detail-value">
+                      <span class="priority-badge" :class="backlogItem.purchase_order.priority">
+                        {{ backlogItem.purchase_order.priority }}
+                      </span>
+                    </div>
+                  </div>
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">Status</div>
+                    <div class="po-detail-value">
+                      <span class="status-badge">{{ backlogItem.purchase_order.status }}</span>
+                    </div>
+                  </div>
+                  <div class="po-detail-item">
+                    <div class="po-detail-label">Created At</div>
+                    <div class="po-detail-value">{{ formatDate(backlogItem.purchase_order.created_at) }}</div>
+                  </div>
+                </div>
+              </template>
+              <template v-else>
+                <div class="empty-state">
+                  <div class="empty-state-icon">
+                    <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
+                      <rect x="8" y="6" width="24" height="28" rx="3" stroke="#94a3b8" stroke-width="2"/>
+                      <path d="M14 14h12M14 20h8M14 26h6" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                  </div>
+                  <div class="empty-state-text">No purchase order created yet</div>
+                  <div class="empty-state-hint">Use "Create PO" from the backlog to generate a purchase order for this item.</div>
+                </div>
+              </template>
+            </template>
+          </div>
+
+          <div class="modal-footer">
+            <button class="btn-secondary" @click="close">Close</button>
+            <button
+              v-if="mode === 'create'"
+              class="btn-primary"
+              :disabled="!isFormValid"
+              @click="submitPO"
+            >
+              Create Purchase Order
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  isOpen: {
+    type: Boolean,
+    default: false
+  },
+  backlogItem: {
+    type: Object,
+    default: null
+  },
+  mode: {
+    type: String,
+    default: 'create',
+    validator: (val) => ['create', 'view'].includes(val)
+  }
+})
+
+const emit = defineEmits(['close', 'po-created'])
+
+// Shortage amount = quantity needed minus what is available
+const shortage = computed(() => {
+  if (!props.backlogItem) return 0
+  return Math.max(0, props.backlogItem.quantity_needed - props.backlogItem.quantity_available)
+})
+
+// Form state with defaults
+const form = ref({
+  supplier: '',
+  quantity: 0,
+  delivery_date: '',
+  priority: 'standard'
+})
+
+// Reset form when modal opens or backlog item changes
+watch(
+  () => [props.isOpen, props.backlogItem],
+  ([isOpen]) => {
+    if (isOpen && props.backlogItem) {
+      form.value = {
+        supplier: '',
+        quantity: shortage.value,
+        delivery_date: '',
+        priority: props.backlogItem.priority === 'high' ? 'urgent' : (props.backlogItem.priority || 'standard')
+      }
+    }
+  },
+  { immediate: true }
+)
+
+const isFormValid = computed(() => {
+  return (
+    form.value.supplier.trim().length > 0 &&
+    form.value.quantity > 0 &&
+    form.value.delivery_date.length > 0
+  )
+})
+
+const close = () => {
+  emit('close')
+}
+
+const submitPO = () => {
+  if (!isFormValid.value || !props.backlogItem) return
+
+  const poData = {
+    id: 'PO-' + Date.now(),
+    backlog_item_id: props.backlogItem.id,
+    supplier: form.value.supplier.trim(),
+    quantity: form.value.quantity,
+    delivery_date: form.value.delivery_date,
+    priority: form.value.priority,
+    status: 'pending',
+    created_at: new Date().toISOString()
+  }
+
+  emit('po-created', poData)
+}
+
+const formatDate = (dateString) => {
+  if (!dateString) return 'N/A'
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return 'N/A'
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 1rem;
+}
+
+.modal-container {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modal-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+}
+
+.close-button:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+}
+
+/* Item context row at top of body */
+.item-context {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 1.5rem;
+}
+
+.item-context-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 0.25rem;
+}
+
+.item-context-sku {
+  font-size: 0.813rem;
+  color: #64748b;
+  font-family: 'Monaco', 'Courier New', monospace;
+}
+
+.priority-badge {
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.813rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  letter-spacing: 0.025em;
+  flex-shrink: 0;
+}
+
+.priority-badge.high,
+.priority-badge.urgent {
+  background: #fecaca;
+  color: #991b1b;
+}
+
+.priority-badge.medium,
+.priority-badge.standard {
+  background: #fed7aa;
+  color: #92400e;
+}
+
+.priority-badge.low {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+/* Create mode form */
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+/* Supplier field spans full width */
+.form-group:first-child {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-size: 0.813rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.form-input,
+.form-select {
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  color: #0f172a;
+  background: white;
+  font-family: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  outline: none;
+}
+
+.form-input:focus,
+.form-select:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-hint {
+  font-size: 0.813rem;
+  color: #64748b;
+}
+
+/* View mode PO details */
+.po-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.po-detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.po-detail-label {
+  font-size: 0.813rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.po-detail-value {
+  font-size: 0.938rem;
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.po-detail-value.po-id {
+  font-family: 'Monaco', 'Courier New', monospace;
+  color: #2563eb;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  background: #dbeafe;
+  color: #1e40af;
+  border-radius: 4px;
+  font-size: 0.813rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+/* Empty state for view mode with no PO */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  gap: 1rem;
+}
+
+.empty-state-icon {
+  width: 64px;
+  height: 64px;
+  background: #f1f5f9;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty-state-text {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.empty-state-hint {
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 320px;
+}
+
+.modal-footer {
+  padding: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.btn-secondary {
+  padding: 0.625rem 1.25rem;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #334155;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
+}
+
+.btn-secondary:hover {
+  background: #e2e8f0;
+  border-color: #cbd5e1;
+}
+
+.btn-primary {
+  padding: 0.625rem 1.25rem;
+  background: #2563eb;
+  border: 1px solid #2563eb;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: white;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Modal transition animations */
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active .modal-container,
+.modal-leave-active .modal-container {
+  transition: transform 0.2s ease;
+}
+
+.modal-enter-from .modal-container,
+.modal-leave-to .modal-container {
+  transform: scale(0.95);
+}
+</style>

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -188,6 +188,18 @@ export default {
     }
   },
 
+  // Backlog
+  backlog: {
+    title: 'Backlog Management',
+    description: 'Track and resolve inventory shortages',
+    cardTitle: 'Backlog Items',
+    highPriority: 'High Priority',
+    mediumPriority: 'Medium Priority',
+    lowPriority: 'Low Priority',
+    totalItems: 'Total Backlog Items',
+    noItems: 'No backlog items - all orders can be fulfilled!'
+  },
+
   // Reports
   reports: {
     title: 'Performance Reports',

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -188,6 +188,37 @@ export default {
     }
   },
 
+  // Reports
+  reports: {
+    title: 'Performance Reports',
+    description: 'View quarterly performance metrics and monthly trends',
+    quarterly: {
+      title: 'Quarterly Performance',
+      quarter: 'Quarter',
+      totalOrders: 'Total Orders',
+      totalRevenue: 'Total Revenue',
+      avgOrderValue: 'Avg Order Value',
+      fulfillmentRate: 'Fulfillment Rate'
+    },
+    monthlyTrend: {
+      title: 'Monthly Revenue Trend'
+    },
+    momAnalysis: {
+      title: 'Month-over-Month Analysis',
+      month: 'Month',
+      orders: 'Orders',
+      revenue: 'Revenue',
+      change: 'Change',
+      growthRate: 'Growth Rate'
+    },
+    summary: {
+      totalRevenueYTD: 'Total Revenue (YTD)',
+      avgMonthlyRevenue: 'Avg Monthly Revenue',
+      totalOrdersYTD: 'Total Orders (YTD)',
+      bestQuarter: 'Best Performing Quarter'
+    }
+  },
+
   // Filters
   filters: {
     timePeriod: 'Time Period',

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -188,6 +188,18 @@ export default {
     }
   },
 
+  // Backlog
+  backlog: {
+    title: 'バックログ管理',
+    description: '在庫不足の追跡と解決',
+    cardTitle: 'バックログ品目',
+    highPriority: '高優先度',
+    mediumPriority: '中優先度',
+    lowPriority: '低優先度',
+    totalItems: '総バックログ品目数',
+    noItems: '在庫不足なし - すべての注文を履行できます！'
+  },
+
   // Reports
   reports: {
     title: 'パフォーマンスレポート',

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -188,6 +188,37 @@ export default {
     }
   },
 
+  // Reports
+  reports: {
+    title: 'パフォーマンスレポート',
+    description: '四半期パフォーマンス指標と月次トレンドを表示',
+    quarterly: {
+      title: '四半期パフォーマンス',
+      quarter: '四半期',
+      totalOrders: '総注文数',
+      totalRevenue: '総収益',
+      avgOrderValue: '平均注文額',
+      fulfillmentRate: '履行率'
+    },
+    monthlyTrend: {
+      title: '月次収益トレンド'
+    },
+    momAnalysis: {
+      title: '前月比分析',
+      month: '月',
+      orders: '注文数',
+      revenue: '収益',
+      change: '変化',
+      growthRate: '成長率'
+    },
+    summary: {
+      totalRevenueYTD: '総収益（年初来）',
+      avgMonthlyRevenue: '平均月次収益',
+      totalOrdersYTD: '総注文数（年初来）',
+      bestQuarter: '最高業績四半期'
+    }
+  },
+
   // Filters
   filters: {
     timePeriod: '期間',

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -1,75 +1,75 @@
 <template>
   <div class="backlog">
     <div class="page-header">
-      <h2>Backlog Management</h2>
-      <p>Track and resolve inventory shortages</p>
+      <h2>{{ t('backlog.title') }}</h2>
+      <p>{{ t('backlog.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading backlog...</div>
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <div class="stats-grid">
         <div class="stat-card danger">
-          <div class="stat-label">High Priority</div>
+          <div class="stat-label">{{ t('backlog.highPriority') }}</div>
           <div class="stat-value">{{ getBacklogByPriority('high').length }}</div>
         </div>
         <div class="stat-card warning">
-          <div class="stat-label">Medium Priority</div>
+          <div class="stat-label">{{ t('backlog.mediumPriority') }}</div>
           <div class="stat-value">{{ getBacklogByPriority('medium').length }}</div>
         </div>
         <div class="stat-card info">
-          <div class="stat-label">Low Priority</div>
+          <div class="stat-label">{{ t('backlog.lowPriority') }}</div>
           <div class="stat-value">{{ getBacklogByPriority('low').length }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Backlog Items</div>
+          <div class="stat-label">{{ t('backlog.totalItems') }}</div>
           <div class="stat-value">{{ backlogItems.length }}</div>
         </div>
       </div>
 
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Backlog Items</h3>
+          <h3 class="card-title">{{ t('backlog.cardTitle') }}</h3>
         </div>
         <div v-if="backlogItems.length === 0" style="padding: 3rem; text-align: center;">
           <p style="font-size: 1.125rem; color: #10b981; font-weight: 600;">
-            ✓ No backlog items - all orders can be fulfilled!
+            {{ t('backlog.noItems') }}
           </p>
         </div>
         <div v-else class="table-container">
           <table>
             <thead>
               <tr>
-                <th>Order ID</th>
-                <th>SKU</th>
-                <th>Item Name</th>
-                <th>Quantity Needed</th>
-                <th>Quantity Available</th>
-                <th>Shortage</th>
-                <th>Days Delayed</th>
-                <th>Priority</th>
+                <th>{{ t('dashboard.inventoryShortages.orderId') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.sku') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.itemName') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.quantityNeeded') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.quantityAvailable') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.shortage') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.daysDelayed') }}</th>
+                <th>{{ t('dashboard.inventoryShortages.priority') }}</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="item in backlogItems" :key="item.id">
                 <td><strong>{{ item.order_id }}</strong></td>
                 <td><strong>{{ item.item_sku }}</strong></td>
-                <td>{{ item.item_name }}</td>
+                <td>{{ translateProductName(item.item_name) }}</td>
                 <td>{{ item.quantity_needed }}</td>
                 <td>{{ item.quantity_available }}</td>
                 <td>
                   <span class="badge danger">
-                    {{ item.quantity_needed - item.quantity_available }} units short
+                    {{ item.quantity_needed - item.quantity_available }} {{ t('dashboard.inventoryShortages.unitsShort') }}
                   </span>
                 </td>
                 <td>
                   <span :style="{ color: item.days_delayed > 7 ? '#ef4444' : '#f59e0b' }">
-                    {{ item.days_delayed }} days
+                    {{ item.days_delayed }} {{ t('dashboard.inventoryShortages.days') }}
                   </span>
                 </td>
                 <td>
                   <span :class="['badge', item.priority]">
-                    {{ item.priority }}
+                    {{ item.priority === 'high' ? t('priority.high') : item.priority === 'medium' ? t('priority.medium') : t('priority.low') }}
                   </span>
                 </td>
               </tr>
@@ -85,6 +85,7 @@
 import { ref, onMounted, watch, computed } from 'vue'
 import { api } from '../api'
 import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
 
 export default {
   name: 'Backlog',
@@ -96,6 +97,9 @@ export default {
 
     // Use shared filters
     const { selectedLocation, selectedCategory, getCurrentFilters } = useFilters()
+
+    // i18n
+    const { t, translateProductName } = useI18n()
 
     // Filter backlog based on inventory filters
     const backlogItems = computed(() => {
@@ -145,7 +149,9 @@ export default {
       loading,
       error,
       backlogItems,
-      getBacklogByPriority
+      getBacklogByPriority,
+      t,
+      translateProductName
     }
   }
 }

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -304,12 +304,14 @@ import { useI18n } from '../composables/useI18n'
 import { formatCurrency } from '../utils/currency'
 import ProductDetailModal from '../components/ProductDetailModal.vue'
 import BacklogDetailModal from '../components/BacklogDetailModal.vue'
+import PurchaseOrderModal from '../components/PurchaseOrderModal.vue'
 
 export default {
   name: 'Dashboard',
   components: {
     ProductDetailModal,
     BacklogDetailModal,
+    PurchaseOrderModal,
   },
   setup() {
     const { t, currentCurrency, translateProductName, translateWarehouse } = useI18n()

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -1,35 +1,35 @@
 <template>
   <div class="reports">
     <div class="page-header">
-      <h2>Performance Reports</h2>
-      <p>View quarterly performance metrics and monthly trends</p>
+      <h2>{{ t('reports.title') }}</h2>
+      <p>{{ t('reports.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading reports...</div>
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <!-- Quarterly Performance -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Quarterly Performance</h3>
+          <h3 class="card-title">{{ t('reports.quarterly.title') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Quarter</th>
-                <th>Total Orders</th>
-                <th>Total Revenue</th>
-                <th>Avg Order Value</th>
-                <th>Fulfillment Rate</th>
+                <th>{{ t('reports.quarterly.quarter') }}</th>
+                <th>{{ t('reports.quarterly.totalOrders') }}</th>
+                <th>{{ t('reports.quarterly.totalRevenue') }}</th>
+                <th>{{ t('reports.quarterly.avgOrderValue') }}</th>
+                <th>{{ t('reports.quarterly.fulfillmentRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(q, index) in quarterlyData" :key="index">
+              <tr v-for="q in quarterlyData" :key="q.quarter">
                 <td><strong>{{ q.quarter }}</strong></td>
                 <td>{{ q.total_orders }}</td>
-                <td>${{ formatNumber(q.total_revenue) }}</td>
-                <td>${{ formatNumber(q.avg_order_value) }}</td>
+                <td>{{ formatCurrency(q.total_revenue, currentCurrency) }}</td>
+                <td>{{ formatCurrency(q.avg_order_value, currentCurrency) }}</td>
                 <td>
                   <span :class="getFulfillmentClass(q.fulfillment_rate)">
                     {{ q.fulfillment_rate }}%
@@ -44,16 +44,16 @@
       <!-- Monthly Trends Chart -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Monthly Revenue Trend</h3>
+          <h3 class="card-title">{{ t('reports.monthlyTrend.title') }}</h3>
         </div>
         <div class="chart-container">
           <div class="bar-chart">
-            <div v-for="(month, index) in monthlyData" :key="index" class="bar-wrapper">
+            <div v-for="month in monthlyData" :key="month.month" class="bar-wrapper">
               <div class="bar-container">
                 <div
                   class="bar"
                   :style="{ height: getBarHeight(month.revenue) + 'px' }"
-                  :title="'$' + formatNumber(month.revenue)"
+                  :title="formatCurrency(month.revenue, currentCurrency)"
                 ></div>
               </div>
               <div class="bar-label">{{ formatMonth(month.month) }}</div>
@@ -65,24 +65,24 @@
       <!-- Month-over-Month Comparison -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Month-over-Month Analysis</h3>
+          <h3 class="card-title">{{ t('reports.momAnalysis.title') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Month</th>
-                <th>Orders</th>
-                <th>Revenue</th>
-                <th>Change</th>
-                <th>Growth Rate</th>
+                <th>{{ t('reports.momAnalysis.month') }}</th>
+                <th>{{ t('reports.momAnalysis.orders') }}</th>
+                <th>{{ t('reports.momAnalysis.revenue') }}</th>
+                <th>{{ t('reports.momAnalysis.change') }}</th>
+                <th>{{ t('reports.momAnalysis.growthRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(month, index) in monthlyData" :key="index">
+              <tr v-for="(month, index) in monthlyData" :key="month.month">
                 <td><strong>{{ formatMonth(month.month) }}</strong></td>
                 <td>{{ month.order_count }}</td>
-                <td>${{ formatNumber(month.revenue) }}</td>
+                <td>{{ formatCurrency(month.revenue, currentCurrency) }}</td>
                 <td>
                   <span v-if="index > 0" :class="getChangeClass(month.revenue, monthlyData[index - 1].revenue)">
                     {{ getChangeValue(month.revenue, monthlyData[index - 1].revenue) }}
@@ -104,19 +104,19 @@
       <!-- Summary Stats -->
       <div class="stats-grid">
         <div class="stat-card">
-          <div class="stat-label">Total Revenue (YTD)</div>
-          <div class="stat-value">${{ formatNumber(totalRevenue) }}</div>
+          <div class="stat-label">{{ t('reports.summary.totalRevenueYTD') }}</div>
+          <div class="stat-value">{{ formatCurrency(totalRevenue, currentCurrency) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Avg Monthly Revenue</div>
-          <div class="stat-value">${{ formatNumber(avgMonthlyRevenue) }}</div>
+          <div class="stat-label">{{ t('reports.summary.avgMonthlyRevenue') }}</div>
+          <div class="stat-value">{{ formatCurrency(avgMonthlyRevenue, currentCurrency) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Orders (YTD)</div>
+          <div class="stat-label">{{ t('reports.summary.totalOrdersYTD') }}</div>
           <div class="stat-value">{{ totalOrders }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Best Performing Quarter</div>
+          <div class="stat-label">{{ t('reports.summary.bestQuarter') }}</div>
           <div class="stat-value">{{ bestQuarter }}</div>
         </div>
       </div>
@@ -125,192 +125,139 @@
 </template>
 
 <script>
-import axios from 'axios'
+import { ref, computed, watch, onMounted } from 'vue'
+import { api } from '../api'
+import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
+import { formatCurrency } from '../utils/currency'
 
 export default {
   name: 'Reports',
-  data() {
-    return {
-      loading: true,
-      error: null,
-      quarterlyData: [],
-      monthlyData: [],
-      totalRevenue: 0,
-      avgMonthlyRevenue: 0,
-      totalOrders: 0,
-      bestQuarter: ''
-    }
-  },
-  mounted() {
-    console.log('Reports component mounted')
-    this.loadData()
-  },
-  methods: {
-    async loadData() {
-      console.log('Loading reports data...')
+  setup() {
+    const { t, currentCurrency, currentLocale } = useI18n()
+    const { selectedPeriod, selectedLocation, selectedCategory, selectedStatus, getCurrentFilters } = useFilters()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const quarterlyData = ref([])
+    const monthlyData = ref([])
+
+    // Summary stats as computed properties derived from reactive data refs
+    const totalRevenue = computed(() => {
+      return monthlyData.value.reduce((sum, m) => sum + m.revenue, 0)
+    })
+
+    const avgMonthlyRevenue = computed(() => {
+      if (monthlyData.value.length === 0) return 0
+      return totalRevenue.value / monthlyData.value.length
+    })
+
+    const totalOrders = computed(() => {
+      return monthlyData.value.reduce((sum, m) => sum + m.order_count, 0)
+    })
+
+    const bestQuarter = computed(() => {
+      if (quarterlyData.value.length === 0) return ''
+      return quarterlyData.value.reduce((best, q) => {
+        return q.total_revenue > best.total_revenue ? q : best
+      }, quarterlyData.value[0]).quarter
+    })
+
+    // Max revenue used for bar height calculation
+    const maxRevenue = computed(() => {
+      if (monthlyData.value.length === 0) return 0
+      return Math.max(...monthlyData.value.map(m => m.revenue))
+    })
+
+    const loadData = async () => {
       try {
-        this.loading = true
+        loading.value = true
+        error.value = null
+        const filters = getCurrentFilters()
 
-        // Fetch quarterly data
-        console.log('Fetching quarterly data...')
-        const quarterlyResponse = await axios.get('http://localhost:8001/api/reports/quarterly')
-        this.quarterlyData = quarterlyResponse.data
-        console.log('Quarterly data:', this.quarterlyData)
+        const [quarterly, monthly] = await Promise.all([
+          api.getReportsQuarterly(filters),
+          api.getMonthlyTrends(filters)
+        ])
 
-        // Fetch monthly data
-        console.log('Fetching monthly data...')
-        const monthlyResponse = await axios.get('http://localhost:8001/api/reports/monthly-trends')
-        this.monthlyData = monthlyResponse.data
-        console.log('Monthly data:', this.monthlyData)
-
-        // Calculate summary stats
-        console.log('Calculating summary stats...')
-        this.calculateSummaryStats()
-        console.log('Summary stats calculated')
-
+        quarterlyData.value = quarterly
+        monthlyData.value = monthly
       } catch (err) {
-        console.log('Error loading reports:', err)
-        this.error = 'Failed to load reports: ' + err.message
+        error.value = 'Failed to load reports: ' + err.message
       } finally {
-        this.loading = false
-        console.log('Loading complete')
+        loading.value = false
       }
-    },
+    }
 
-    calculateSummaryStats() {
-      // Calculate total revenue
-      var total = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        total = total + this.monthlyData[i].revenue
-      }
-      this.totalRevenue = total
+    // Use locale-aware month name translation
+    const formatMonth = (monthStr) => {
+      const parts = monthStr.split('-')
+      const year = parts[0]
+      const monthIndex = parseInt(parts[1]) - 1
+      const monthKeys = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+      return t(`months.${monthKeys[monthIndex]}`) + ' ' + year
+    }
 
-      // Calculate average monthly revenue
-      if (this.monthlyData.length > 0) {
-        this.avgMonthlyRevenue = total / this.monthlyData.length
-      } else {
-        this.avgMonthlyRevenue = 0
-      }
+    const getBarHeight = (revenue) => {
+      if (maxRevenue.value === 0) return 0
+      return (revenue / maxRevenue.value) * 200
+    }
 
-      // Calculate total orders
-      var orders = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        orders = orders + this.monthlyData[i].order_count
-      }
-      this.totalOrders = orders
+    const getFulfillmentClass = (rate) => {
+      if (rate >= 90) return 'badge success'
+      if (rate >= 75) return 'badge warning'
+      return 'badge danger'
+    }
 
-      // Find best quarter
-      var bestQ = ''
-      var bestRevenue = 0
-      for (var i = 0; i < this.quarterlyData.length; i++) {
-        if (this.quarterlyData[i].total_revenue > bestRevenue) {
-          bestRevenue = this.quarterlyData[i].total_revenue
-          bestQ = this.quarterlyData[i].quarter
-        }
-      }
-      this.bestQuarter = bestQ
-    },
-
-    formatNumber(num) {
-      console.log('Formatting number:', num)
-      // Format number with commas
-      var str = num.toString()
-      var parts = str.split('.')
-      var intPart = parts[0]
-      var decPart = parts.length > 1 ? parts[1] : '00'
-
-      var formatted = ''
-      var count = 0
-      for (var i = intPart.length - 1; i >= 0; i--) {
-        if (count > 0 && count % 3 === 0) {
-          formatted = ',' + formatted
-        }
-        formatted = intPart[i] + formatted
-        count++
-      }
-
-      if (decPart.length === 1) {
-        decPart = decPart + '0'
-      }
-      if (decPart.length > 2) {
-        decPart = decPart.substring(0, 2)
-      }
-
-      return formatted + '.' + decPart
-    },
-
-    formatMonth(monthStr) {
-      console.log('Formatting month:', monthStr)
-      // Convert YYYY-MM to readable format
-      var parts = monthStr.split('-')
-      var year = parts[0]
-      var month = parts[1]
-
-      var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-      var monthIndex = parseInt(month) - 1
-
-      return monthNames[monthIndex] + ' ' + year
-    },
-
-    getBarHeight(revenue) {
-      console.log('Calculating bar height for revenue:', revenue)
-      // Calculate bar height (max height 200px)
-      var maxRevenue = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        if (this.monthlyData[i].revenue > maxRevenue) {
-          maxRevenue = this.monthlyData[i].revenue
-        }
-      }
-
-      if (maxRevenue === 0) {
-        return 0
-      }
-
-      var height = (revenue / maxRevenue) * 200
-      return height
-    },
-
-    getFulfillmentClass(rate) {
-      if (rate >= 90) {
-        return 'badge success'
-      } else if (rate >= 75) {
-        return 'badge warning'
-      } else {
-        return 'badge danger'
-      }
-    },
-
-    getChangeValue(current, previous) {
-      var change = current - previous
+    const getChangeValue = (current, previous) => {
+      const change = current - previous
       if (change > 0) {
-        return '+$' + this.formatNumber(change)
+        return '+' + formatCurrency(change, currentCurrency.value)
       } else if (change < 0) {
-        return '-$' + this.formatNumber(Math.abs(change))
-      } else {
-        return '$0.00'
+        return '-' + formatCurrency(Math.abs(change), currentCurrency.value)
       }
-    },
+      return formatCurrency(0, currentCurrency.value)
+    }
 
-    getChangeClass(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return 'positive-change'
-      } else if (change < 0) {
-        return 'negative-change'
-      } else {
-        return ''
-      }
-    },
+    const getChangeClass = (current, previous) => {
+      const change = current - previous
+      if (change > 0) return 'positive-change'
+      if (change < 0) return 'negative-change'
+      return ''
+    }
 
-    getGrowthRate(current, previous) {
-      if (previous === 0) {
-        return 'N/A'
-      }
-
-      var rate = ((current - previous) / previous) * 100
-      var sign = rate > 0 ? '+' : ''
-
+    const getGrowthRate = (current, previous) => {
+      if (previous === 0) return 'N/A'
+      const rate = ((current - previous) / previous) * 100
+      const sign = rate > 0 ? '+' : ''
       return sign + rate.toFixed(1) + '%'
+    }
+
+    // Reload whenever any global filter changes
+    watch([selectedPeriod, selectedLocation, selectedCategory, selectedStatus], () => {
+      loadData()
+    })
+
+    onMounted(loadData)
+
+    return {
+      t,
+      currentCurrency,
+      loading,
+      error,
+      quarterlyData,
+      monthlyData,
+      totalRevenue,
+      avgMonthlyRevenue,
+      totalOrders,
+      bestQuarter,
+      formatCurrency,
+      formatMonth,
+      getBarHeight,
+      getFulfillmentClass,
+      getChangeValue,
+      getChangeClass,
+      getGrowthRate
     }
   }
 }

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,514 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventory System — Architecture</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Courier New', Courier, monospace;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+
+    /* ── Header ── */
+    .page-header {
+      display: flex;
+      align-items: baseline;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+      border-bottom: 1px solid #334155;
+      padding-bottom: 1rem;
+    }
+    .page-header h1 {
+      font-size: 1.25rem;
+      color: #f1f5f9;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .port-badges {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .badge {
+      font-size: 0.7rem;
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-weight: bold;
+      letter-spacing: 0.05em;
+    }
+    .badge-green  { background: #14532d; color: #86efac; border: 1px solid #166534; }
+    .badge-blue   { background: #1e3a5f; color: #93c5fd; border: 1px solid #1e40af; }
+    .badge-amber  { background: #451a03; color: #fcd34d; border: 1px solid #78350f; }
+
+    /* ── Stack bands ── */
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      overflow: hidden;
+      margin-bottom: 2rem;
+    }
+    .band {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+    }
+    .band-label {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: 1.25rem 1rem;
+      font-size: 0.65rem;
+      font-weight: bold;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      border-right: 1px solid #334155;
+      gap: 0.4rem;
+    }
+    .band-content {
+      padding: 1.25rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      border-top: 1px solid #1e293b;
+    }
+    .band:first-child .band-content { border-top: none; }
+    .band-content .row {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+    .band-content .label {
+      font-size: 0.7rem;
+      color: #64748b;
+      min-width: 90px;
+      flex-shrink: 0;
+    }
+    .band-content .value {
+      font-size: 0.8rem;
+      color: #cbd5e1;
+    }
+    .band-content .chips {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+    .chip {
+      font-size: 0.68rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 3px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      color: #94a3b8;
+    }
+
+    /* Band colours */
+    .band-frontend .band-label { background: #052e16; color: #86efac; }
+    .band-backend  .band-label { background: #0c1a2e; color: #93c5fd; }
+    .band-data     .band-label { background: #1c0f00; color: #fcd34d; }
+    .band-frontend { background: #0a1a10; }
+    .band-backend  { background: #080f1c; }
+    .band-data     { background: #100800; }
+
+    /* ── Data Flow ── */
+    .section-title {
+      font-size: 0.65rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #475569;
+      margin-bottom: 0.75rem;
+    }
+    .flow-box {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 2rem;
+    }
+    .flow-steps {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+    }
+    .flow-step {
+      padding: 0.3rem 0.6rem;
+      border-radius: 4px;
+      white-space: nowrap;
+    }
+    .flow-step.ui     { background: #052e16; color: #86efac; border: 1px solid #166534; }
+    .flow-step.state  { background: #052e16; color: #6ee7b7; border: 1px solid #065f46; }
+    .flow-step.http   { background: #0c1a2e; color: #93c5fd; border: 1px solid #1e40af; }
+    .flow-step.server { background: #0c1a2e; color: #60a5fa; border: 1px solid #1e3a5f; }
+    .flow-step.data   { background: #1c0f00; color: #fcd34d; border: 1px solid #78350f; }
+    .flow-step.model  { background: #1c0f00; color: #fbbf24; border: 1px solid #92400e; }
+    .flow-arrow {
+      color: #475569;
+      font-size: 0.9rem;
+    }
+    .flow-note {
+      margin-top: 0.75rem;
+      font-size: 0.68rem;
+      color: #475569;
+    }
+    .flow-note code {
+      color: #94a3b8;
+      background: #1e293b;
+      padding: 0.1rem 0.3rem;
+      border-radius: 3px;
+    }
+
+    /* ── Endpoint Table ── */
+    .table-box {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.75rem;
+    }
+    thead th {
+      text-align: left;
+      font-size: 0.62rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #475569;
+      padding: 0 0.75rem 0.6rem 0;
+      border-bottom: 1px solid #1e293b;
+    }
+    tbody td {
+      padding: 0.45rem 0.75rem 0.45rem 0;
+      border-bottom: 1px solid #1e293b;
+      vertical-align: top;
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    .method {
+      display: inline-block;
+      font-size: 0.62rem;
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      font-weight: bold;
+      background: #1e293b;
+      color: #93c5fd;
+      border: 1px solid #1e40af;
+    }
+    code { color: #86efac; font-size: 0.75rem; }
+    .param-tag {
+      display: inline-block;
+      font-size: 0.62rem;
+      padding: 0.05rem 0.3rem;
+      border-radius: 3px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      color: #94a3b8;
+      margin: 0.1rem 0.1rem 0.1rem 0;
+    }
+    .note { color: #64748b; font-size: 0.68rem; }
+  </style>
+</head>
+<body>
+
+  <!-- Header -->
+  <header class="page-header">
+    <h1>Inventory System — Architecture</h1>
+    <div class="port-badges">
+      <span class="badge badge-green">Frontend :3000</span>
+      <span class="badge badge-blue">Backend :8001</span>
+    </div>
+  </header>
+
+  <!-- Stack Bands -->
+  <div class="stack">
+
+    <!-- Frontend -->
+    <div class="band band-frontend">
+      <div class="band-label">
+        <span class="badge badge-green">Frontend</span>
+        <span>Vue 3 · Vite</span>
+      </div>
+      <div class="band-content">
+        <div class="row">
+          <span class="label">Framework</span>
+          <span class="value">Vue 3.4 · Composition API · Vue Router 4.3</span>
+        </div>
+        <div class="row">
+          <span class="label">Build / HTTP</span>
+          <span class="value">Vite 5.2 · Axios 1.6</span>
+        </div>
+        <div class="row">
+          <span class="label">Views (6)</span>
+          <div class="chips">
+            <span class="chip">Dashboard</span>
+            <span class="chip">Inventory</span>
+            <span class="chip">Orders</span>
+            <span class="chip">Demand</span>
+            <span class="chip">Spending</span>
+            <span class="chip">Reports</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Components</span>
+          <div class="chips">
+            <span class="chip">FilterBar</span>
+            <span class="chip">LanguageSwitcher</span>
+            <span class="chip">ProfileMenu</span>
+            <span class="chip">+ 6 Modals</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Composables</span>
+          <div class="chips">
+            <span class="chip">useFilters</span>
+            <span class="chip">useI18n</span>
+            <span class="chip">useAuth</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">API Client</span>
+          <span class="value">client/src/api.js — Axios wrapper, builds query params from filter state</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Backend -->
+    <div class="band band-backend">
+      <div class="band-label">
+        <span class="badge badge-blue">Backend</span>
+        <span>FastAPI · Uvicorn</span>
+      </div>
+      <div class="band-content">
+        <div class="row">
+          <span class="label">Framework</span>
+          <span class="value">FastAPI · Pydantic · Uvicorn (ASGI)</span>
+        </div>
+        <div class="row">
+          <span class="label">Entry point</span>
+          <span class="value">server/main.py — ~20 REST endpoints, CORS enabled</span>
+        </div>
+        <div class="row">
+          <span class="label">Filtering</span>
+          <div class="chips">
+            <span class="chip">apply_filters()</span>
+            <span class="chip">filter_by_month()</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Data loader</span>
+          <span class="value">server/mock_data.py — loads all JSON into memory at startup</span>
+        </div>
+        <div class="row">
+          <span class="label">Models</span>
+          <div class="chips">
+            <span class="chip">InventoryItem</span>
+            <span class="chip">Order</span>
+            <span class="chip">DemandForecast</span>
+            <span class="chip">BacklogItem</span>
+            <span class="chip">PurchaseOrder</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Data -->
+    <div class="band band-data">
+      <div class="band-label">
+        <span class="badge badge-amber">Data</span>
+        <span>JSON · In-memory</span>
+      </div>
+      <div class="band-content">
+        <div class="row">
+          <span class="label">Location</span>
+          <span class="value">server/data/ — 7 JSON files, loaded once at startup, never mutated</span>
+        </div>
+        <div class="row">
+          <span class="label">Files</span>
+          <div class="chips">
+            <span class="chip">inventory.json</span>
+            <span class="chip">orders.json</span>
+            <span class="chip">spending.json</span>
+            <span class="chip">backlog_items.json</span>
+            <span class="chip">demand_forecasts.json</span>
+            <span class="chip">transactions.json</span>
+            <span class="chip">purchase_orders.json</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Scale</span>
+          <span class="value">~50 inventory SKUs · 700+ orders · 60+ transactions · 3 warehouses</span>
+        </div>
+        <div class="row">
+          <span class="label">Warehouses</span>
+          <div class="chips">
+            <span class="chip">San Francisco</span>
+            <span class="chip">London</span>
+            <span class="chip">Tokyo</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /stack -->
+
+  <!-- Data Flow -->
+  <div class="flow-box">
+    <div class="section-title">Data Flow</div>
+    <div class="flow-steps">
+      <span class="flow-step ui">FilterBar (UI)</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step state">useFilters (shared state)</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step state">getCurrentFilters()</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step http">api.js (Axios)</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step server">FastAPI endpoint</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step server">apply_filters() + filter_by_month()</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step data">JSON data</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step model">Pydantic model</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step http">JSON response</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step state">Vue ref() → re-render</span>
+    </div>
+    <div class="flow-note">
+      Filter sentinel: <code>"all"</code> skips that filter. Month supports ISO format (<code>2025-09</code>) and quarter format (<code>Q3-2025</code>). Inventory endpoints do not support month filtering.
+    </div>
+  </div>
+
+  <!-- Endpoint Quick Ref -->
+  <div class="table-box">
+    <div class="section-title">API Endpoints — Quick Reference</div>
+    <table>
+      <thead>
+        <tr>
+          <th>Endpoint</th>
+          <th>Method</th>
+          <th>Params</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>/api/inventory</code></td>
+          <td><span class="method">GET</span></td>
+          <td><span class="param-tag">warehouse</span><span class="param-tag">category</span></td>
+          <td class="note">No month filter</td>
+        </tr>
+        <tr>
+          <td><code>/api/inventory/{id}</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Single item detail</td>
+        </tr>
+        <tr>
+          <td><code>/api/orders</code></td>
+          <td><span class="method">GET</span></td>
+          <td><span class="param-tag">warehouse</span><span class="param-tag">category</span><span class="param-tag">status</span><span class="param-tag">month</span></td>
+          <td class="note">month supports Q1-2025 format</td>
+        </tr>
+        <tr>
+          <td><code>/api/orders/{id}</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Single order detail</td>
+        </tr>
+        <tr>
+          <td><code>/api/dashboard/summary</code></td>
+          <td><span class="method">GET</span></td>
+          <td><span class="param-tag">warehouse</span><span class="param-tag">category</span><span class="param-tag">status</span><span class="param-tag">month</span></td>
+          <td class="note">Aggregated KPIs</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/summary</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Total cost breakdown</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/monthly</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Month-by-month costs</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/categories</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Cost by category</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/transactions</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">60+ recent transactions</td>
+        </tr>
+        <tr>
+          <td><code>/api/demand</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">9 demand forecasts</td>
+        </tr>
+        <tr>
+          <td><code>/api/backlog</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Includes has_purchase_order flag</td>
+        </tr>
+        <tr>
+          <td><code>/api/reports/quarterly</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Q1–Q4 2025 metrics</td>
+        </tr>
+        <tr>
+          <td><code>/api/reports/monthly-trends</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Month-over-month trends</td>
+        </tr>
+        <tr>
+          <td><code>/api/tasks</code></td>
+          <td><span class="method">GET</span> <span class="method">POST</span></td>
+          <td>—</td>
+          <td class="note">In api.js; not in server/main.py</td>
+        </tr>
+        <tr>
+          <td><code>/api/tasks/{id}</code></td>
+          <td><span class="method">DELETE</span> <span class="method">PATCH</span></td>
+          <td>—</td>
+          <td class="note">Toggle completion, delete</td>
+        </tr>
+        <tr>
+          <td><code>/api/purchase-orders/{backlogItemId}</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Path param; draft feature</td>
+        </tr>
+        <tr>
+          <td><code>/api/purchase-orders</code></td>
+          <td><span class="method">POST</span></td>
+          <td>—</td>
+          <td class="note">Create PO; empty data currently</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</body>
+</html>

--- a/docs/superpowers/plans/2026-06-22-architecture-page.md
+++ b/docs/superpowers/plans/2026-06-22-architecture-page.md
@@ -1,0 +1,560 @@
+# Architecture Page Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a single self-contained `docs/architecture.html` developer reference page showing the system's layered architecture, tech stack, data flow, and API endpoint quick-reference.
+
+**Architecture:** One pure HTML/CSS file — no JavaScript, no external dependencies. Three stacked horizontal bands (Frontend / Backend / Data) followed by a data flow section and an endpoint table. Dark theme matching the app's slate color palette.
+
+**Tech Stack:** HTML5, CSS3 (CSS Grid, Flexbox). No build step required.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-architecture-page-design.md`
+
+---
+
+## Chunk 1: Create the HTML file
+
+### Task 1: Scaffold the HTML shell with styles
+
+**Files:**
+- Create: `docs/architecture.html`
+
+- [ ] **Step 1: Create `docs/architecture.html` with the full page**
+
+Create the file with this complete content:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventory System — Architecture</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Courier New', Courier, monospace;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+
+    /* ── Header ── */
+    .page-header {
+      display: flex;
+      align-items: baseline;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+      border-bottom: 1px solid #334155;
+      padding-bottom: 1rem;
+    }
+    .page-header h1 {
+      font-size: 1.25rem;
+      color: #f1f5f9;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .port-badges {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .badge {
+      font-size: 0.7rem;
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-weight: bold;
+      letter-spacing: 0.05em;
+    }
+    .badge-green  { background: #14532d; color: #86efac; border: 1px solid #166534; }
+    .badge-blue   { background: #1e3a5f; color: #93c5fd; border: 1px solid #1e40af; }
+    .badge-amber  { background: #451a03; color: #fcd34d; border: 1px solid #78350f; }
+
+    /* ── Stack bands ── */
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      overflow: hidden;
+      margin-bottom: 2rem;
+    }
+    .band {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+    }
+    .band-label {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: 1.25rem 1rem;
+      font-size: 0.65rem;
+      font-weight: bold;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      border-right: 1px solid #334155;
+      gap: 0.4rem;
+    }
+    .band-content {
+      padding: 1.25rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      border-top: 1px solid #1e293b;
+    }
+    .band:first-child .band-content { border-top: none; }
+    .band-content .row {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+    .band-content .label {
+      font-size: 0.7rem;
+      color: #64748b;
+      min-width: 90px;
+      flex-shrink: 0;
+    }
+    .band-content .value {
+      font-size: 0.8rem;
+      color: #cbd5e1;
+    }
+    .band-content .chips {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+    .chip {
+      font-size: 0.68rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 3px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      color: #94a3b8;
+    }
+
+    /* Band colours */
+    .band-frontend .band-label { background: #052e16; color: #86efac; }
+    .band-backend  .band-label { background: #0c1a2e; color: #93c5fd; }
+    .band-data     .band-label { background: #1c0f00; color: #fcd34d; }
+    .band-frontend { background: #0a1a10; }
+    .band-backend  { background: #080f1c; }
+    .band-data     { background: #100800; }
+
+    /* ── Data Flow ── */
+    .section-title {
+      font-size: 0.65rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #475569;
+      margin-bottom: 0.75rem;
+    }
+    .flow-box {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 2rem;
+    }
+    .flow-steps {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+    }
+    .flow-step {
+      padding: 0.3rem 0.6rem;
+      border-radius: 4px;
+      white-space: nowrap;
+    }
+    .flow-step.ui     { background: #052e16; color: #86efac; border: 1px solid #166534; }
+    .flow-step.state  { background: #052e16; color: #6ee7b7; border: 1px solid #065f46; }
+    .flow-step.http   { background: #0c1a2e; color: #93c5fd; border: 1px solid #1e40af; }
+    .flow-step.server { background: #0c1a2e; color: #60a5fa; border: 1px solid #1e3a5f; }
+    .flow-step.data   { background: #1c0f00; color: #fcd34d; border: 1px solid #78350f; }
+    .flow-step.model  { background: #1c0f00; color: #fbbf24; border: 1px solid #92400e; }
+    .flow-arrow {
+      color: #475569;
+      font-size: 0.9rem;
+    }
+    .flow-note {
+      margin-top: 0.75rem;
+      font-size: 0.68rem;
+      color: #475569;
+    }
+    .flow-note code {
+      color: #94a3b8;
+      background: #1e293b;
+      padding: 0.1rem 0.3rem;
+      border-radius: 3px;
+    }
+
+    /* ── Endpoint Table ── */
+    .table-box {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.75rem;
+    }
+    thead th {
+      text-align: left;
+      font-size: 0.62rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #475569;
+      padding: 0 0.75rem 0.6rem 0;
+      border-bottom: 1px solid #1e293b;
+    }
+    tbody td {
+      padding: 0.45rem 0.75rem 0.45rem 0;
+      border-bottom: 1px solid #1e293b;
+      vertical-align: top;
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    .method {
+      display: inline-block;
+      font-size: 0.62rem;
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      font-weight: bold;
+      background: #1e293b;
+      color: #93c5fd;
+      border: 1px solid #1e40af;
+    }
+    code { color: #86efac; font-size: 0.75rem; }
+    .param-tag {
+      display: inline-block;
+      font-size: 0.62rem;
+      padding: 0.05rem 0.3rem;
+      border-radius: 3px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      color: #94a3b8;
+      margin: 0.1rem 0.1rem 0.1rem 0;
+    }
+    .note { color: #64748b; font-size: 0.68rem; }
+  </style>
+</head>
+<body>
+
+  <!-- Header -->
+  <header class="page-header">
+    <h1>Inventory System — Architecture</h1>
+    <div class="port-badges">
+      <span class="badge badge-green">Frontend :3000</span>
+      <span class="badge badge-blue">Backend :8001</span>
+    </div>
+  </header>
+
+  <!-- Stack Bands -->
+  <div class="stack">
+
+    <!-- Frontend -->
+    <div class="band band-frontend">
+      <div class="band-label">
+        <span class="badge badge-green">Frontend</span>
+        <span>Vue 3 · Vite</span>
+      </div>
+      <div class="band-content">
+        <div class="row">
+          <span class="label">Framework</span>
+          <span class="value">Vue 3.4 · Composition API · Vue Router 4.3</span>
+        </div>
+        <div class="row">
+          <span class="label">Build / HTTP</span>
+          <span class="value">Vite 5.2 · Axios 1.6</span>
+        </div>
+        <div class="row">
+          <span class="label">Views (6)</span>
+          <div class="chips">
+            <span class="chip">Dashboard</span>
+            <span class="chip">Inventory</span>
+            <span class="chip">Orders</span>
+            <span class="chip">Demand</span>
+            <span class="chip">Spending</span>
+            <span class="chip">Reports</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Components</span>
+          <div class="chips">
+            <span class="chip">FilterBar</span>
+            <span class="chip">LanguageSwitcher</span>
+            <span class="chip">ProfileMenu</span>
+            <span class="chip">+ 6 Modals</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Composables</span>
+          <div class="chips">
+            <span class="chip">useFilters</span>
+            <span class="chip">useI18n</span>
+            <span class="chip">useAuth</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">API Client</span>
+          <span class="value">client/src/api.js — Axios wrapper, builds query params from filter state</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Backend -->
+    <div class="band band-backend">
+      <div class="band-label">
+        <span class="badge badge-blue">Backend</span>
+        <span>FastAPI · Uvicorn</span>
+      </div>
+      <div class="band-content">
+        <div class="row">
+          <span class="label">Framework</span>
+          <span class="value">FastAPI · Pydantic · Uvicorn (ASGI)</span>
+        </div>
+        <div class="row">
+          <span class="label">Entry point</span>
+          <span class="value">server/main.py — ~20 REST endpoints, CORS enabled</span>
+        </div>
+        <div class="row">
+          <span class="label">Filtering</span>
+          <div class="chips">
+            <span class="chip">apply_filters()</span>
+            <span class="chip">filter_by_month()</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Data loader</span>
+          <span class="value">server/mock_data.py — loads all JSON into memory at startup</span>
+        </div>
+        <div class="row">
+          <span class="label">Models</span>
+          <div class="chips">
+            <span class="chip">InventoryItem</span>
+            <span class="chip">Order</span>
+            <span class="chip">DemandForecast</span>
+            <span class="chip">BacklogItem</span>
+            <span class="chip">PurchaseOrder</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Data -->
+    <div class="band band-data">
+      <div class="band-label">
+        <span class="badge badge-amber">Data</span>
+        <span>JSON · In-memory</span>
+      </div>
+      <div class="band-content">
+        <div class="row">
+          <span class="label">Location</span>
+          <span class="value">server/data/ — 7 JSON files, loaded once at startup, never mutated</span>
+        </div>
+        <div class="row">
+          <span class="label">Files</span>
+          <div class="chips">
+            <span class="chip">inventory.json</span>
+            <span class="chip">orders.json</span>
+            <span class="chip">spending.json</span>
+            <span class="chip">backlog_items.json</span>
+            <span class="chip">demand_forecasts.json</span>
+            <span class="chip">transactions.json</span>
+            <span class="chip">purchase_orders.json</span>
+          </div>
+        </div>
+        <div class="row">
+          <span class="label">Scale</span>
+          <span class="value">~50 inventory SKUs · 700+ orders · 60+ transactions · 3 warehouses</span>
+        </div>
+        <div class="row">
+          <span class="label">Warehouses</span>
+          <div class="chips">
+            <span class="chip">San Francisco</span>
+            <span class="chip">London</span>
+            <span class="chip">Tokyo</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /stack -->
+
+  <!-- Data Flow -->
+  <div class="flow-box">
+    <div class="section-title">Data Flow</div>
+    <div class="flow-steps">
+      <span class="flow-step ui">FilterBar (UI)</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step state">useFilters (shared state)</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step state">getCurrentFilters()</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step http">api.js (Axios)</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step server">FastAPI endpoint</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step server">apply_filters() + filter_by_month()</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step data">JSON data</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step model">Pydantic model</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step http">JSON response</span>
+      <span class="flow-arrow">→</span>
+      <span class="flow-step state">Vue ref() → re-render</span>
+    </div>
+    <div class="flow-note">
+      Filter sentinel: <code>"all"</code> skips that filter. Month supports ISO format (<code>2025-09</code>) and quarter format (<code>Q3-2025</code>). Inventory endpoints do not support month filtering.
+    </div>
+  </div>
+
+  <!-- Endpoint Quick Ref -->
+  <div class="table-box">
+    <div class="section-title">API Endpoints — Quick Reference</div>
+    <table>
+      <thead>
+        <tr>
+          <th>Endpoint</th>
+          <th>Method</th>
+          <th>Params</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>/api/inventory</code></td>
+          <td><span class="method">GET</span></td>
+          <td><span class="param-tag">warehouse</span><span class="param-tag">category</span></td>
+          <td class="note">No month filter</td>
+        </tr>
+        <tr>
+          <td><code>/api/inventory/{id}</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Single item detail</td>
+        </tr>
+        <tr>
+          <td><code>/api/orders</code></td>
+          <td><span class="method">GET</span></td>
+          <td><span class="param-tag">warehouse</span><span class="param-tag">category</span><span class="param-tag">status</span><span class="param-tag">month</span></td>
+          <td class="note">month supports Q1-2025 format</td>
+        </tr>
+        <tr>
+          <td><code>/api/orders/{id}</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Single order detail</td>
+        </tr>
+        <tr>
+          <td><code>/api/dashboard/summary</code></td>
+          <td><span class="method">GET</span></td>
+          <td><span class="param-tag">warehouse</span><span class="param-tag">category</span><span class="param-tag">status</span><span class="param-tag">month</span></td>
+          <td class="note">Aggregated KPIs</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/summary</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Total cost breakdown</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/monthly</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Month-by-month costs</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/categories</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Cost by category</td>
+        </tr>
+        <tr>
+          <td><code>/api/spending/transactions</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">60+ recent transactions</td>
+        </tr>
+        <tr>
+          <td><code>/api/demand</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">9 demand forecasts</td>
+        </tr>
+        <tr>
+          <td><code>/api/backlog</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Includes has_purchase_order flag</td>
+        </tr>
+        <tr>
+          <td><code>/api/reports/quarterly</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Q1–Q4 2025 metrics</td>
+        </tr>
+        <tr>
+          <td><code>/api/reports/monthly-trends</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Month-over-month trends</td>
+        </tr>
+        <tr>
+          <td><code>/api/tasks</code></td>
+          <td><span class="method">GET</span> <span class="method">POST</span></td>
+          <td>—</td>
+          <td class="note">In api.js; not in server/main.py</td>
+        </tr>
+        <tr>
+          <td><code>/api/tasks/{id}</code></td>
+          <td><span class="method">DELETE</span> <span class="method">PATCH</span></td>
+          <td>—</td>
+          <td class="note">Toggle completion, delete</td>
+        </tr>
+        <tr>
+          <td><code>/api/purchase-orders/{backlogItemId}</code></td>
+          <td><span class="method">GET</span></td>
+          <td>—</td>
+          <td class="note">Path param; draft feature</td>
+        </tr>
+        <tr>
+          <td><code>/api/purchase-orders</code></td>
+          <td><span class="method">POST</span></td>
+          <td>—</td>
+          <td class="note">Create PO; empty data currently</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</body>
+</html>
+```
+
+- [ ] **Step 2: Open in browser to verify rendering**
+
+```bash
+open docs/architecture.html
+```
+
+Confirm:
+- Dark background renders (#0f172a)
+- Three bands visible: green (Frontend), blue (Backend), amber (Data)
+- Data flow steps display horizontally with arrows
+- Endpoint table is readable
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.html
+git commit -m "Add architecture reference page"
+```

--- a/docs/superpowers/specs/2026-06-22-architecture-page-design.md
+++ b/docs/superpowers/specs/2026-06-22-architecture-page-design.md
@@ -1,0 +1,76 @@
+# Architecture Page Design
+
+**Date:** 2026-06-22  
+**Status:** Approved  
+**Output:** `docs/architecture.html`
+
+## Goal
+
+A single self-contained HTML file that serves as a developer reference for the Factory Inventory Management System architecture — something to glance at while building.
+
+## Audience
+
+Developer (internal reference). Not a stakeholder presentation or demo artifact. Scannable over polished.
+
+## Approach
+
+Layered stack diagram: three horizontal bands (Frontend / Backend / Data) with a data flow arrow diagram and quick-reference endpoint table below.
+
+## Layout
+
+```
+HEADER — title + port badges (3000 / 8001)
+─────────────────────────────────────────
+FRONTEND band — Vue 3 + Vite · port 3000
+  6 Views, 8 Components, useFilters, useI18n, api.js
+─────────────────────────────────────────
+BACKEND band — FastAPI + Pydantic · port 8001
+  20+ endpoints, apply_filters(), mock_data.py
+─────────────────────────────────────────
+DATA band — 7 JSON files in server/data/
+  inventory, orders, spending, backlog, demand, transactions
+─────────────────────────────────────────
+DATA FLOW — left-to-right arrow diagram
+  Filter UI → useFilters → api.js → FastAPI
+  → apply_filters() → JSON → Pydantic → Vue ref
+─────────────────────────────────────────
+QUICK REF TABLE — key endpoints + params
+```
+
+## Style
+
+- Background: `#0f172a` (matches app design system)
+- Font: monospace
+- Band colors: slate gradient darkening top to bottom
+- Badges: green=Frontend, blue=Backend, amber=Data
+- No JavaScript — pure HTML/CSS
+- No external dependencies — fully self-contained
+
+## Key Content
+
+### Tech Stack
+| Layer | Tech | Version | Port |
+|-------|------|---------|------|
+| Frontend | Vue 3 + Composition API | 3.4.21 | 3000 |
+| Build | Vite | 5.2.0 | — |
+| HTTP | Axios | 1.6.7 | — |
+| Backend | FastAPI + Pydantic | latest | 8001 |
+| Server | Uvicorn (ASGI) | — | — |
+| Data | JSON files (in-memory) | — | — |
+
+### Data Flow
+Filter UI → `useFilters` composable → `api.js` (Axios) → FastAPI endpoint → `apply_filters()` → JSON data → Pydantic model → JSON response → Vue `ref()` → re-render
+
+### Key Endpoints
+- `GET /api/inventory` — warehouse, category filters
+- `GET /api/orders` — warehouse, category, status, month filters
+- `GET /api/dashboard/summary` — all filters
+- `GET /api/spending/*` — summary, monthly, categories, transactions
+- `GET /api/demand`, `/api/backlog` — no filters
+
+## Out of Scope
+
+- Interactive diagrams (static only)
+- External CDN dependencies
+- JavaScript behavior
+- Mobile responsiveness (dev tool, viewed on desktop)

--- a/docs/superpowers/specs/2026-06-22-architecture-page-design.md
+++ b/docs/superpowers/specs/2026-06-22-architecture-page-design.md
@@ -1,7 +1,6 @@
 # Architecture Page Design
 
 **Date:** 2026-06-22  
-**Status:** Approved  
 **Output:** `docs/architecture.html`
 
 ## Goal
@@ -22,17 +21,18 @@ Layered stack diagram: three horizontal bands (Frontend / Backend / Data) with a
 HEADER — title + port badges (3000 / 8001)
 ─────────────────────────────────────────
 FRONTEND band — Vue 3 + Vite · port 3000
-  6 Views, 8 Components, useFilters, useI18n, api.js
+  6 Views, 8 Components, useFilters, useI18n, useAuth, api.js
 ─────────────────────────────────────────
 BACKEND band — FastAPI + Pydantic · port 8001
   20+ endpoints, apply_filters(), mock_data.py
 ─────────────────────────────────────────
 DATA band — 7 JSON files in server/data/
-  inventory, orders, spending, backlog, demand, transactions
+  inventory, orders, spending, backlog, demand, transactions, purchase_orders
 ─────────────────────────────────────────
 DATA FLOW — left-to-right arrow diagram
-  Filter UI → useFilters → api.js → FastAPI
-  → apply_filters() → JSON → Pydantic → Vue ref
+  FilterBar (UI) → useFilters (shared state) → View calls getCurrentFilters()
+  → api.js (Axios) → FastAPI → apply_filters() + filter_by_month()
+  → JSON → Pydantic → JSON response → Vue ref() → re-render
 ─────────────────────────────────────────
 QUICK REF TABLE — key endpoints + params
 ```
@@ -61,12 +61,21 @@ QUICK REF TABLE — key endpoints + params
 ### Data Flow
 Filter UI → `useFilters` composable → `api.js` (Axios) → FastAPI endpoint → `apply_filters()` → JSON data → Pydantic model → JSON response → Vue `ref()` → re-render
 
-### Key Endpoints
-- `GET /api/inventory` — warehouse, category filters
-- `GET /api/orders` — warehouse, category, status, month filters
-- `GET /api/dashboard/summary` — all filters
-- `GET /api/spending/*` — summary, monthly, categories, transactions
-- `GET /api/demand`, `/api/backlog` — no filters
+### Key Endpoints Table Columns
+`Endpoint | Method | Params | Notes`
+
+| Endpoint | Method | Params | Notes |
+|----------|--------|--------|-------|
+| `/api/inventory` | GET | warehouse, category | No month filter |
+| `/api/orders` | GET | warehouse, category, status, month | Supports quarter (Q1-2025) |
+| `/api/dashboard/summary` | GET | warehouse, category, status, month | Aggregated KPIs |
+| `/api/spending/summary` | GET | — | No filters |
+| `/api/spending/monthly` | GET | — | Monthly breakdown |
+| `/api/spending/categories` | GET | — | Category totals |
+| `/api/spending/transactions` | GET | — | 60+ transaction records |
+| `/api/demand` | GET | — | No filters |
+| `/api/backlog` | GET | — | No filters |
+| `/api/purchase-orders` | GET/POST | backlogItemId | Draft feature (empty data) |
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-06-22-saas-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-22-saas-ui-redesign-design.md
@@ -1,0 +1,200 @@
+# SaaS UI Redesign Design Spec
+
+**Date:** 2026-06-22
+**Output:** Modified `App.vue`, new `AppSidebar.vue`, modified `FilterBar.vue`
+
+## Goal
+
+Redesign the inventory management app's UI from a horizontal top navigation bar to a modern SaaS-style interface with a vertical sidebar, elevated card layouts, and a polished professional aesthetic — using only global CSS changes (no view files touched).
+
+## Decisions Made
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Sidebar style | Dark (`#0f172a`) | High contrast, Linear/Vercel aesthetic, already in the app's palette |
+| Card style | Elevated | White cards + drop shadow on `#f1f5f9` bg — most common SaaS pattern |
+| Scope | Global CSS only | Views unchanged; all card/typography improvements via unscoped globals in App.vue |
+| Responsive | Desktop only | No mobile breakpoints in this pass |
+
+## Layout Architecture
+
+### Shell (App.vue)
+
+CSS Grid two-column layout replaces the current flex-column `.app`:
+
+```css
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  /* NO overflow: hidden/auto — breaks sticky */
+}
+
+.main-area {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;       /* scroll target is here, not app-shell */
+  background: #f1f5f9;   /* light gray page background */
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 90;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0.6rem 1.5rem;
+}
+
+.main-content {
+  flex: 1;
+  padding: 1.5rem 2rem;
+  /* No max-width — sidebar already constrains width */
+}
+```
+
+### Sidebar (AppSidebar.vue — new file)
+
+```css
+.sidebar {
+  position: sticky;     /* NOT fixed — stays in grid flow */
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #0f172a;
+  overflow-y: auto;
+}
+```
+
+Structure:
+- **Logo block** — "Factory IMS" + subtitle, bottom border divider
+- **Nav section** — `v-for` over `navItems` array, `useRoute()` + `startsWith` for active state, inline SVG icons (no library)
+- **Footer** — `ProfileMenu` + `LanguageSwitcher`, pinned via `margin-top: auto`
+
+Nav item active state:
+```js
+// Root path uses strict equality; others use startsWith
+item.path === '/' ? route.path === '/' : route.path.startsWith(item.path)
+```
+
+Active indicator: `3px solid #2563eb` left border via `::before` pseudo-element.
+
+Modal events emitted up to App.vue: `@show-profile-details`, `@show-tasks`.
+
+## Design Tokens (all existing palette values)
+
+| Element | Value |
+|---|---|
+| Sidebar bg | `#0f172a` |
+| Page bg | `#f1f5f9` |
+| Topbar bg | `#ffffff` |
+| Card bg | `#ffffff` |
+| Card shadow | `0 1px 3px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.04)` |
+| Card border-radius | `10px` |
+| Nav default text | `#64748b` |
+| Nav hover | `#f1f5f9` text + `rgba(255,255,255,0.06)` bg |
+| Nav active | `#ffffff` text + `rgba(255,255,255,0.12)` bg |
+| Active indicator | `3px solid #2563eb` |
+| Sidebar dividers | `rgba(255,255,255,0.07)` |
+| Topbar border | `1px solid #e2e8f0` |
+
+## Global CSS Changes (App.vue unscoped styles)
+
+### Cards
+```css
+.card, .metric-card {
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.04);
+  border: none;   /* remove existing 1px border */
+}
+```
+
+### KPI metric cards
+```css
+.metric-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.metric-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+```
+
+### Tables
+```css
+.table-container {
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.04);
+  overflow: hidden;
+}
+thead th {
+  background: #f8fafc;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+```
+
+### Page-level typography
+```css
+.page-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+.page-subtitle {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-top: 2px;
+}
+```
+
+## FilterBar Changes
+
+Two targeted fixes — scoped CSS in `FilterBar.vue`:
+
+1. Remove `position: sticky; top: 70px` (topbar owns stickiness now)
+2. Remove `max-width: 1600px; margin: 0 auto` on `.filters-container`
+
+```css
+.filters-bar {
+  position: static;
+  max-width: none;
+  padding: 0;
+  border-bottom: none;
+  background: transparent;
+}
+.filters-container {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+```
+
+## Files Changed
+
+| File | Type | Change |
+|---|---|---|
+| `client/src/App.vue` | Modify | Grid shell, remove top-nav template + CSS, add global card/table/typography styles |
+| `client/src/components/AppSidebar.vue` | Create | Logo, nav items, ProfileMenu/LanguageSwitcher footer, modal emits |
+| `client/src/components/FilterBar.vue` | Modify | Remove sticky offset + max-width from scoped CSS |
+
+## Out of Scope
+
+- `src/views/*.vue` — untouched
+- `src/main.js` — untouched
+- `src/api.js`, `src/composables/` — untouched
+- Mobile/responsive breakpoints
+- Icon library (inline SVGs only)
+- Dark mode content area

--- a/docs/superpowers/specs/2026-06-22-saas-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-22-saas-ui-redesign-design.md
@@ -15,26 +15,59 @@ Redesign the inventory management app's UI from a horizontal top navigation bar 
 | Card style | Elevated | White cards + drop shadow on `#f1f5f9` bg — most common SaaS pattern |
 | Scope | Global CSS only | Views unchanged; all card/typography improvements via unscoped globals in App.vue |
 | Responsive | Desktop only | No mobile breakpoints in this pass |
+| Scroll model | Viewport scroll (Option A) | `.main-area` has no overflow — page scrolls naturally, sidebar sticks via viewport |
 
 ## Layout Architecture
 
-### Shell (App.vue)
+### App.vue Template Skeleton
 
-CSS Grid two-column layout replaces the current flex-column `.app`:
+The root element changes from `.app` to `.app-shell`. The full new template structure:
+
+```html
+<template>
+  <div class="app-shell">
+    <AppSidebar
+      @show-profile-details="showProfileDetails = true"
+      @show-tasks="showTasks = true"
+    />
+    <div class="main-area">
+      <div class="topbar">
+        <FilterBar />
+      </div>
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
+    <ProfileDetailsModal
+      :is-open="showProfileDetails"
+      @close="showProfileDetails = false"
+    />
+    <TasksModal
+      :is-open="showTasks"
+      @close="showTasks = false"
+    />
+  </div>
+</template>
+```
+
+`FilterBar` lives inside `.topbar`. Modals stay in `App.vue` — owned by `showProfileDetails` and `showTasks` refs, which remain in `App.vue`'s script.
+
+### Shell CSS (App.vue)
 
 ```css
+/* Replaces .app */
 .app-shell {
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
-  /* NO overflow: hidden/auto — breaks sticky */
+  /* NO overflow on this element — viewport is the scroll container */
 }
 
 .main-area {
   display: flex;
   flex-direction: column;
-  overflow-y: auto;       /* scroll target is here, not app-shell */
-  background: #f1f5f9;   /* light gray page background */
+  /* NO overflow-y: auto — page scrolls via viewport, not this element */
+  background: #f1f5f9;
 }
 
 .topbar {
@@ -53,11 +86,13 @@ CSS Grid two-column layout replaces the current flex-column `.app`:
 }
 ```
 
-### Sidebar (AppSidebar.vue — new file)
+**Why no `overflow-y: auto` on `.main-area`:** For `position: sticky` to work on the sidebar, the scroll container must be an ancestor of the sidebar — not a sibling. Putting `overflow-y: auto` on `.main-area` (a sibling of the sidebar in the grid) creates a separate scroll context that the sidebar cannot respond to. With viewport scrolling, the sidebar sticks correctly to the top of the browser window as the user scrolls down.
+
+### Sidebar CSS (AppSidebar.vue)
 
 ```css
 .sidebar {
-  position: sticky;     /* NOT fixed — stays in grid flow */
+  position: sticky;   /* NOT fixed — stays in grid flow */
   top: 0;
   height: 100vh;
   display: flex;
@@ -67,20 +102,102 @@ CSS Grid two-column layout replaces the current flex-column `.app`:
 }
 ```
 
-Structure:
-- **Logo block** — "Factory IMS" + subtitle, bottom border divider
-- **Nav section** — `v-for` over `navItems` array, `useRoute()` + `startsWith` for active state, inline SVG icons (no library)
-- **Footer** — `ProfileMenu` + `LanguageSwitcher`, pinned via `margin-top: auto`
+### AppSidebar.vue Structure
 
-Nav item active state:
-```js
-// Root path uses strict equality; others use startsWith
-item.path === '/' ? route.path === '/' : route.path.startsWith(item.path)
+**Logo block:**
+```html
+<div class="sidebar-logo">
+  <div class="logo-name">Factory IMS</div>
+  <div class="logo-sub">Inventory Management</div>
+</div>
 ```
 
-Active indicator: `3px solid #2563eb` left border via `::before` pseudo-element.
+**Nav items — data-driven, using existing i18n keys:**
+```js
+import { useRoute } from 'vue-router'
+import { useI18n } from '../composables/useI18n.js'
 
-Modal events emitted up to App.vue: `@show-profile-details`, `@show-tasks`.
+const route = useRoute()
+const { t } = useI18n()
+
+const navItems = [
+  { path: '/',          labelKey: 'nav.overview',        icon: 'grid'      },
+  { path: '/inventory', labelKey: 'nav.inventory',       icon: 'box'       },
+  { path: '/orders',    labelKey: 'nav.orders',          icon: 'clipboard' },
+  { path: '/spending',  labelKey: 'nav.finance',         icon: 'dollar'    },
+  { path: '/demand',    labelKey: 'nav.demandForecast',  icon: 'trend'     },
+  { path: '/reports',   labelKey: 'nav.reports',         icon: 'file'      },
+]
+
+const isActive = (item) =>
+  item.path === '/' ? route.path === '/' : route.path.startsWith(item.path)
+```
+
+**Nav item template:**
+```html
+<a
+  v-for="item in navItems"
+  :key="item.path"
+  :href="item.path"
+  class="nav-item"
+  :class="{ active: isActive(item) }"
+  @click.prevent="$router.push(item.path)"
+>
+  <!-- inline SVG icon here -->
+  <span class="nav-label">{{ t(item.labelKey) }}</span>
+</a>
+```
+
+**Active indicator** — nav item needs `position: relative`, then `::before`:
+```css
+.nav-item {
+  position: relative;   /* required for ::before to position correctly */
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.45rem 0.75rem;
+  margin: 0.125rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #64748b;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+.nav-item:hover { color: #f1f5f9; background: rgba(255,255,255,0.06); }
+.nav-item.active { color: #ffffff; background: rgba(255,255,255,0.12); }
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -0.5rem;       /* flush with the margin edge */
+  top: 15%;
+  height: 70%;
+  width: 3px;
+  background: #2563eb;
+  border-radius: 0 2px 2px 0;
+}
+```
+
+**Footer — ProfileMenu + LanguageSwitcher:**
+```html
+<div class="sidebar-footer">
+  <LanguageSwitcher />
+  <ProfileMenu
+    @show-profile-details="$emit('show-profile-details')"
+    @show-tasks="$emit('show-tasks')"
+  />
+</div>
+```
+
+`ProfileMenu` emits `show-profile-details` and `show-tasks` — forward both up to App.vue.
+`LanguageSwitcher` manages its own state internally — no event forwarding needed.
+
+Both components use light-background scoped styles (white bg, dark text). They will render as white/light pills inside the dark sidebar footer — this is intentional and acceptable. No overrides needed.
+
+**AppSidebar emits:**
+```js
+const emit = defineEmits(['show-profile-details', 'show-tasks'])
+```
 
 ## Design Tokens (all existing palette values)
 
@@ -161,33 +278,36 @@ thead th {
 
 ## FilterBar Changes
 
-Two targeted fixes — scoped CSS in `FilterBar.vue`:
-
-1. Remove `position: sticky; top: 70px` (topbar owns stickiness now)
-2. Remove `max-width: 1600px; margin: 0 auto` on `.filters-container`
+`FilterBar` is placed inside `.topbar` in `App.vue` — it is no longer sticky itself (`.topbar` owns stickiness). Two CSS properties to remove from `FilterBar.vue`'s scoped styles:
 
 ```css
+/* FilterBar.vue scoped styles — update these values */
 .filters-bar {
-  position: static;
-  max-width: none;
+  position: static;       /* was: sticky */
+  top: auto;              /* was: 70px (old nav height offset — remove) */
+  max-width: none;        /* was: 1600px */
   padding: 0;
-  border-bottom: none;
+  border-bottom: none;    /* topbar owns the border */
   background: transparent;
 }
 .filters-container {
-  max-width: none;
+  max-width: none;        /* was: 1600px */
   margin: 0;
   padding: 0;
   width: 100%;
 }
 ```
 
+## Icons
+
+Use inline SVG for each nav item — no icon library. Six small SVGs directly in `AppSidebar.vue`'s template. Each `<svg>` is `width="16" height="16"`, `stroke="currentColor"`, `fill="none"`, `stroke-width="2"`. The `currentColor` inherits from the nav item's `color` property so hover/active states automatically update icon color.
+
 ## Files Changed
 
 | File | Type | Change |
 |---|---|---|
 | `client/src/App.vue` | Modify | Grid shell, remove top-nav template + CSS, add global card/table/typography styles |
-| `client/src/components/AppSidebar.vue` | Create | Logo, nav items, ProfileMenu/LanguageSwitcher footer, modal emits |
+| `client/src/components/AppSidebar.vue` | Create | Logo, nav items (v-for + i18n), ProfileMenu/LanguageSwitcher footer, modal emits |
 | `client/src/components/FilterBar.vue` | Modify | Remove sticky offset + max-width from scoped CSS |
 
 ## Out of Scope
@@ -198,3 +318,4 @@ Two targeted fixes — scoped CSS in `FilterBar.vue`:
 - Mobile/responsive breakpoints
 - Icon library (inline SVGs only)
 - Dark mode content area
+- ProfileMenu / LanguageSwitcher internal style overrides

--- a/server/main.py
+++ b/server/main.py
@@ -228,12 +228,20 @@ def get_recent_transactions():
     return recent_transactions
 
 @app.get("/api/reports/quarterly")
-def get_quarterly_reports():
+def get_quarterly_reports(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None,
+    status: Optional[str] = None,
+    month: Optional[str] = None
+):
     """Get quarterly performance reports"""
+    filtered_orders = apply_filters(orders, warehouse=warehouse, category=category, status=status)
+    filtered_orders = filter_by_month(filtered_orders, month)
+
     # Calculate quarterly statistics from orders
     quarters = {}
 
-    for order in orders:
+    for order in filtered_orders:
         order_date = order.get('order_date', '')
         # Determine quarter
         if '2025-01' in order_date or '2025-02' in order_date or '2025-03' in order_date:
@@ -274,30 +282,38 @@ def get_quarterly_reports():
     return result
 
 @app.get("/api/reports/monthly-trends")
-def get_monthly_trends():
+def get_monthly_trends(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None,
+    status: Optional[str] = None,
+    month: Optional[str] = None
+):
     """Get month-over-month trends"""
+    filtered_orders = apply_filters(orders, warehouse=warehouse, category=category, status=status)
+    filtered_orders = filter_by_month(filtered_orders, month)
+
     months = {}
 
-    for order in orders:
+    for order in filtered_orders:
         order_date = order.get('order_date', '')
         if not order_date:
             continue
 
         # Extract month (format: YYYY-MM-DD)
-        month = order_date[:7]  # Gets YYYY-MM
+        month_key = order_date[:7]  # Gets YYYY-MM
 
-        if month not in months:
-            months[month] = {
-                'month': month,
+        if month_key not in months:
+            months[month_key] = {
+                'month': month_key,
                 'order_count': 0,
                 'revenue': 0,
                 'delivered_count': 0
             }
 
-        months[month]['order_count'] += 1
-        months[month]['revenue'] += order.get('total_value', 0)
+        months[month_key]['order_count'] += 1
+        months[month_key]['revenue'] += order.get('total_value', 0)
         if order.get('status') == 'Delivered':
-            months[month]['delivered_count'] += 1
+            months[month_key]['delivered_count'] += 1
 
     # Convert to list and sort
     result = list(months.values())

--- a/server/main.py
+++ b/server/main.py
@@ -304,6 +304,53 @@ def get_monthly_trends():
     result.sort(key=lambda x: x['month'])
     return result
 
+# In-memory tasks store
+_tasks: List[dict] = []
+_task_counter = 1
+
+class Task(BaseModel):
+    id: str
+    title: str
+    status: str
+    created_at: str
+
+class TaskCreate(BaseModel):
+    title: str
+
+@app.get("/api/tasks", response_model=List[Task])
+def get_tasks():
+    return _tasks
+
+@app.post("/api/tasks", response_model=Task, status_code=201)
+def create_task(task: TaskCreate):
+    global _task_counter
+    from datetime import datetime
+    new_task = {
+        "id": f"task-{_task_counter}",
+        "title": task.title,
+        "status": "pending",
+        "created_at": datetime.utcnow().isoformat()
+    }
+    _task_counter += 1
+    _tasks.append(new_task)
+    return new_task
+
+@app.delete("/api/tasks/{task_id}", status_code=204)
+def delete_task(task_id: str):
+    global _tasks
+    original_len = len(_tasks)
+    _tasks = [t for t in _tasks if t["id"] != task_id]
+    if len(_tasks) == original_len:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+
+@app.patch("/api/tasks/{task_id}", response_model=Task)
+def toggle_task(task_id: str):
+    task = next((t for t in _tasks if t["id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    task["status"] = "completed" if task["status"] == "pending" else "pending"
+    return task
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8001)


### PR DESCRIPTION
## Summary

- Add `PurchaseOrderModal` Vue component for creating purchase orders from the dashboard
- Register `PurchaseOrderModal` in Dashboard view
- Add in-memory tasks CRUD API (`GET/POST /api/tasks`, `DELETE/PATCH /api/tasks/{id}`) to FastAPI backend
- Redesign UI to a vertical sidebar SaaS layout with collapsible icons-only mode
- Add architecture reference page
- Add GitHub Actions CI workflows (Claude Code Review + Claude PR Assistant)
- Document code style conventions in CLAUDE.md

## Test plan

- [ ] Start backend (`cd server && uv run python main.py`) and verify `/api/tasks` endpoints respond correctly
- [ ] Start frontend (`cd client && npm run dev`) and verify sidebar collapses to icons-only mode
- [ ] Open Dashboard and confirm PurchaseOrderModal opens without errors
- [ ] Verify GitHub Actions workflows appear under the repo's Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)