### PR TITLE
Add Restocking tab, SaaS sidebar redesign, and architecture page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ npm install && npm run dev
 - Data: `server/data/*.json`
 - Styles: `client/src/App.vue`
 
+## Code Style
+- Always document non-obvious logic changes with comments
+
 ## Design System
 - Colors: Slate/gray (#0f172a, #64748b, #e2e8f0)
 - Status: green/blue/yellow/red

--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,493 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>System Architecture — Inventory Management</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f8fafc;
+      color: #0f172a;
+      line-height: 1.5;
+    }
+
+    header {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 2rem 3rem;
+      border-bottom: 3px solid #3b82f6;
+    }
+    header h1 { font-size: 1.6rem; font-weight: 700; letter-spacing: -0.02em; }
+    header p { color: #94a3b8; font-size: 0.9rem; margin-top: 0.3rem; }
+
+    main { max-width: 1200px; margin: 0 auto; padding: 2.5rem 2rem 4rem; }
+
+    /* ── Section headings ── */
+    h2 {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #0f172a;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 1.2rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    section { margin-bottom: 3rem; }
+
+    /* ── Cards ── */
+    .card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 1.25rem 1.5rem;
+    }
+
+    /* ── Arch diagram ── */
+    .arch-grid {
+      display: grid;
+      grid-template-columns: 1fr 48px 1fr 48px 1fr;
+      align-items: center;
+      gap: 0;
+    }
+    .layer {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 1.4rem 1.2rem;
+    }
+    .layer-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid;
+    }
+    .layer.frontend .layer-label  { color: #2563eb; border-color: #2563eb; }
+    .layer.backend  .layer-label  { color: #16a34a; border-color: #16a34a; }
+    .layer.data     .layer-label  { color: #d97706; border-color: #d97706; }
+
+    .layer-item {
+      font-size: 0.8rem;
+      color: #334155;
+      padding: 0.3rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .layer-item::before {
+      content: '';
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: #cbd5e1;
+      flex-shrink: 0;
+    }
+    .layer.frontend .layer-item::before { background: #93c5fd; }
+    .layer.backend  .layer-item::before { background: #86efac; }
+    .layer.data     .layer-item::before { background: #fcd34d; }
+
+    .arch-arrow {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      color: #64748b;
+      font-size: 0.65rem;
+      text-align: center;
+    }
+    .arch-arrow svg { width: 28px; }
+
+    /* ── Tech stack pills ── */
+    .stack-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; }
+    .stack-item {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+    }
+    .stack-item .name { font-weight: 600; font-size: 0.85rem; }
+    .stack-item .ver  { font-size: 0.75rem; color: #64748b; }
+    .stack-item.fe    { border-left: 3px solid #2563eb; }
+    .stack-item.be    { border-left: 3px solid #16a34a; }
+    .stack-item.tool  { border-left: 3px solid #7c3aed; }
+
+    /* ── Data flow ── */
+    .flow { display: flex; flex-direction: column; gap: 0; }
+    .flow-step {
+      display: grid;
+      grid-template-columns: 32px 1fr;
+      gap: 1rem;
+      align-items: flex-start;
+    }
+    .flow-num {
+      width: 28px; height: 28px;
+      background: #0f172a;
+      color: #fff;
+      border-radius: 50%;
+      font-size: 0.75rem;
+      font-weight: 700;
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+    .flow-body h4 { font-size: 0.85rem; font-weight: 600; margin-bottom: 0.2rem; }
+    .flow-body p  { font-size: 0.8rem; color: #475569; }
+    code { background: #f1f5f9; border-radius: 4px; padding: 1px 5px; font-size: 0.78rem; font-family: 'SF Mono', Consolas, monospace; color: #0f172a; }
+
+    .flow-connector {
+      width: 2px; height: 28px;
+      background: #e2e8f0;
+      margin-left: 13px;
+    }
+
+    /* ── API endpoints ── */
+    .endpoint-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .endpoint {
+      display: grid;
+      grid-template-columns: 56px 1fr auto;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.6rem 0.9rem;
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 7px;
+      font-size: 0.8rem;
+    }
+    .method {
+      font-weight: 700;
+      font-size: 0.7rem;
+      text-align: center;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .method.GET    { background: #dcfce7; color: #15803d; }
+    .method.POST   { background: #dbeafe; color: #1d4ed8; }
+    .method.DELETE { background: #fee2e2; color: #b91c1c; }
+    .method.PATCH  { background: #fef9c3; color: #b45309; }
+    .endpoint-path { font-family: 'SF Mono', Consolas, monospace; color: #0f172a; }
+    .endpoint-desc { color: #64748b; font-size: 0.75rem; text-align: right; }
+
+    /* ── Filters ── */
+    .filters-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+    .filter-card {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1rem 1.2rem;
+    }
+    .filter-card h4 { font-size: 0.8rem; font-weight: 700; margin-bottom: 0.5rem; color: #0f172a; }
+    .filter-card .options { font-size: 0.78rem; color: #475569; }
+
+    /* ── Pages table ── */
+    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    th {
+      background: #f1f5f9;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #475569;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    td {
+      padding: 0.6rem 0.9rem;
+      border-bottom: 1px solid #f1f5f9;
+      color: #334155;
+      vertical-align: top;
+    }
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: #f8fafc; }
+
+    /* ── Two col ── */
+    .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+
+    @media (max-width: 768px) {
+      .arch-grid { grid-template-columns: 1fr; }
+      .arch-arrow { transform: rotate(90deg); }
+      .two-col, .filters-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Inventory Management System — Architecture</h1>
+  <p>Vue 3 + FastAPI full-stack demo with in-memory mock data &nbsp;·&nbsp; Factory operations dashboard</p>
+</header>
+
+<main>
+
+  <!-- ── System Architecture ── -->
+  <section>
+    <h2>System Architecture</h2>
+    <div class="card">
+      <div class="arch-grid">
+
+        <!-- Frontend -->
+        <div class="layer frontend">
+          <div class="layer-label">Frontend &nbsp;· port 3000</div>
+          <div class="layer-item">Vue 3 (Composition API)</div>
+          <div class="layer-item">Vue Router 4</div>
+          <div class="layer-item">Vite dev server</div>
+          <div class="layer-item">Axios HTTP client</div>
+          <div class="layer-item">Custom SVG charts</div>
+          <div class="layer-item">i18n (EN / JA)</div>
+          <div class="layer-item">useFilters composable</div>
+        </div>
+
+        <!-- Arrow -->
+        <div class="arch-arrow">
+          <svg viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 14h20M16 8l8 6-8 6" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span>HTTP/JSON<br>REST API</span>
+        </div>
+
+        <!-- Backend -->
+        <div class="layer backend">
+          <div class="layer-label">Backend &nbsp;· port 8001</div>
+          <div class="layer-item">FastAPI (Python)</div>
+          <div class="layer-item">Uvicorn ASGI server</div>
+          <div class="layer-item">Pydantic v2 models</div>
+          <div class="layer-item">CORS middleware</div>
+          <div class="layer-item">In-memory filtering</div>
+          <div class="layer-item">Swagger UI /docs</div>
+          <div class="layer-item">uv package manager</div>
+        </div>
+
+        <!-- Arrow -->
+        <div class="arch-arrow">
+          <svg viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 14h20M16 8l8 6-8 6" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span>File<br>reads</span>
+        </div>
+
+        <!-- Data -->
+        <div class="layer data">
+          <div class="layer-label">Data &nbsp;· JSON files</div>
+          <div class="layer-item">inventory.json</div>
+          <div class="layer-item">orders.json (~1000+)</div>
+          <div class="layer-item">demand_forecasts.json</div>
+          <div class="layer-item">backlog_items.json</div>
+          <div class="layer-item">spending.json</div>
+          <div class="layer-item">transactions.json</div>
+          <div class="layer-item">purchase_orders.json</div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Tech Stack ── -->
+  <section>
+    <h2>Tech Stack</h2>
+    <div class="stack-grid">
+      <div class="stack-item fe"><div class="name">Vue 3</div><div class="ver">Composition API · v3.4</div></div>
+      <div class="stack-item fe"><div class="name">Vue Router</div><div class="ver">SPA routing · v4.3</div></div>
+      <div class="stack-item fe"><div class="name">Vite</div><div class="ver">Dev server / bundler · v5.2</div></div>
+      <div class="stack-item fe"><div class="name">Axios</div><div class="ver">HTTP client · v1.6</div></div>
+      <div class="stack-item be"><div class="name">FastAPI</div><div class="ver">Python REST framework · v0.110+</div></div>
+      <div class="stack-item be"><div class="name">Uvicorn</div><div class="ver">ASGI server · v0.24+</div></div>
+      <div class="stack-item be"><div class="name">Pydantic v2</div><div class="ver">Data validation / serialisation</div></div>
+      <div class="stack-item be"><div class="name">Python 3.13</div><div class="ver">Runtime</div></div>
+      <div class="stack-item tool"><div class="name">uv</div><div class="ver">Python package manager</div></div>
+      <div class="stack-item tool"><div class="name">pytest</div><div class="ver">Backend test suite</div></div>
+      <div class="stack-item tool"><div class="name">No database</div><div class="ver">All data from JSON files</div></div>
+      <div class="stack-item tool"><div class="name">Node 24 / npm 11</div><div class="ver">Frontend toolchain</div></div>
+    </div>
+  </section>
+
+  <!-- ── Data Flow ── -->
+  <section>
+    <h2>Data Flow</h2>
+    <div class="card">
+      <div class="flow">
+
+        <div class="flow-step">
+          <div class="flow-num">1</div>
+          <div class="flow-body">
+            <h4>User selects filters</h4>
+            <p><code>FilterBar.vue</code> updates shared state in <code>useFilters()</code> composable — <code>selectedPeriod</code>, <code>selectedLocation</code>, <code>selectedCategory</code>, <code>selectedStatus</code>.</p>
+          </div>
+        </div>
+        <div class="flow-connector"></div>
+
+        <div class="flow-step">
+          <div class="flow-num">2</div>
+          <div class="flow-body">
+            <h4>Vue view reacts &amp; calls API</h4>
+            <p>Each view watches filter state. On change, it calls the relevant function in <code>client/src/api.js</code>, mapping filter values to query parameters (<code>warehouse</code>, <code>category</code>, <code>status</code>, <code>month</code>).</p>
+          </div>
+        </div>
+        <div class="flow-connector"></div>
+
+        <div class="flow-step">
+          <div class="flow-num">3</div>
+          <div class="flow-body">
+            <h4>Axios sends HTTP request</h4>
+            <p>e.g. <code>GET http://localhost:8001/api/orders?category=Sensors&amp;month=2025-01</code></p>
+          </div>
+        </div>
+        <div class="flow-connector"></div>
+
+        <div class="flow-step">
+          <div class="flow-num">4</div>
+          <div class="flow-body">
+            <h4>FastAPI filters in memory</h4>
+            <p><code>apply_filters()</code> narrows by warehouse, category, status. <code>filter_by_month()</code> handles month strings (<code>2025-01</code>) and quarter strings (<code>Q1-2025</code>).</p>
+          </div>
+        </div>
+        <div class="flow-connector"></div>
+
+        <div class="flow-step">
+          <div class="flow-num">5</div>
+          <div class="flow-body">
+            <h4>Pydantic serialises response</h4>
+            <p>Filtered Python dicts are validated and serialised into JSON by Pydantic v2 models before being returned.</p>
+          </div>
+        </div>
+        <div class="flow-connector"></div>
+
+        <div class="flow-step">
+          <div class="flow-num">6</div>
+          <div class="flow-body">
+            <h4>Vue renders computed data</h4>
+            <p>Raw data stored in <code>ref()</code> variables (<code>allOrders</code>, <code>inventoryItems</code>). Derived values (totals, percentages, chart data) live in <code>computed()</code> properties and update automatically.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Pages & Views ── -->
+  <section>
+    <h2>Pages &amp; Views</h2>
+    <div class="card" style="padding: 0; overflow: hidden;">
+      <table>
+        <thead>
+          <tr>
+            <th>Route</th>
+            <th>View</th>
+            <th>Purpose</th>
+            <th>API Endpoints</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>/</code></td>
+            <td>Dashboard.vue</td>
+            <td>KPI cards, order health donut, revenue summary</td>
+            <td><code>/api/dashboard/summary</code> <code>/api/orders</code></td>
+          </tr>
+          <tr>
+            <td><code>/inventory</code></td>
+            <td>Inventory.vue</td>
+            <td>Stock levels table with search &amp; detail modal</td>
+            <td><code>/api/inventory</code></td>
+          </tr>
+          <tr>
+            <td><code>/orders</code></td>
+            <td>Orders.vue</td>
+            <td>Order list with status badges &amp; expandable items</td>
+            <td><code>/api/orders</code></td>
+          </tr>
+          <tr>
+            <td><code>/demand</code></td>
+            <td>Demand.vue</td>
+            <td>Demand forecasts grouped by trend</td>
+            <td><code>/api/demand</code></td>
+          </tr>
+          <tr>
+            <td><code>/spending</code></td>
+            <td>Spending.vue</td>
+            <td>Financial KPIs, cost charts, category breakdown</td>
+            <td><code>/api/spending/*</code></td>
+          </tr>
+          <tr>
+            <td><code>/reports</code></td>
+            <td>Reports.vue</td>
+            <td>Quarterly performance &amp; monthly trend charts</td>
+            <td><code>/api/reports/*</code></td>
+          </tr>
+          <tr>
+            <td><code>/backlog</code></td>
+            <td>Backlog.vue</td>
+            <td>Inventory shortages, priority breakdown, PO creation</td>
+            <td><code>/api/backlog</code> <code>/api/inventory</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ── Filter System ── -->
+  <section>
+    <h2>Global Filter System</h2>
+    <div class="filters-grid">
+      <div class="filter-card">
+        <h4>Time Period</h4>
+        <div class="options">All · Jan–Dec 2025 (individual months) · Q1 · Q2 · Q3 · Q4</div>
+      </div>
+      <div class="filter-card">
+        <h4>Warehouse / Location</h4>
+        <div class="options">All · San Francisco · London · Tokyo</div>
+      </div>
+      <div class="filter-card">
+        <h4>Category</h4>
+        <div class="options">All · Circuit Boards · Sensors · Actuators · Controllers · Power Supplies</div>
+      </div>
+      <div class="filter-card">
+        <h4>Order Status</h4>
+        <div class="options">All · Delivered · Shipped · Processing · Backordered</div>
+      </div>
+    </div>
+    <div style="margin-top: 0.75rem; font-size: 0.8rem; color: #64748b; padding: 0 0.25rem;">
+      Filter state is managed globally in <code>useFilters.js</code> (singleton composable). All views watch this state and re-fetch on change. Query params map as: <code>selectedLocation → warehouse</code>, <code>selectedPeriod → month</code>.
+    </div>
+  </section>
+
+  <!-- ── API Endpoints ── -->
+  <section>
+    <h2>API Endpoints</h2>
+    <div class="two-col">
+      <div>
+        <div style="font-size:0.75rem; font-weight:700; color:#475569; margin-bottom:0.6rem; text-transform:uppercase; letter-spacing:0.05em;">Core Data</div>
+        <div class="endpoint-list">
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/inventory</span><span class="endpoint-desc">warehouse, category</span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/inventory/{id}</span><span class="endpoint-desc">single item</span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/orders</span><span class="endpoint-desc">warehouse, category, status, month</span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/orders/{id}</span><span class="endpoint-desc">single order</span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/demand</span><span class="endpoint-desc">no filters</span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/backlog</span><span class="endpoint-desc">no filters</span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/dashboard/summary</span><span class="endpoint-desc">all filters</span></div>
+        </div>
+      </div>
+      <div>
+        <div style="font-size:0.75rem; font-weight:700; color:#475569; margin-bottom:0.6rem; text-transform:uppercase; letter-spacing:0.05em;">Spending, Reports &amp; Actions</div>
+        <div class="endpoint-list">
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/spending/summary</span><span class="endpoint-desc"></span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/spending/monthly</span><span class="endpoint-desc"></span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/spending/categories</span><span class="endpoint-desc"></span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/reports/quarterly</span><span class="endpoint-desc"></span></div>
+          <div class="endpoint"><span class="method GET">GET</span><span class="endpoint-path">/api/reports/monthly-trends</span><span class="endpoint-desc"></span></div>
+          <div class="endpoint"><span class="method POST">POST</span><span class="endpoint-path">/api/tasks</span><span class="endpoint-desc">create task</span></div>
+          <div class="endpoint"><span class="method POST">POST</span><span class="endpoint-path">/api/purchase-orders</span><span class="endpoint-desc">create PO</span></div>
+          <div class="endpoint"><span class="method PATCH">PATCH</span><span class="endpoint-path">/api/tasks/{id}</span><span class="endpoint-desc">toggle status</span></div>
+          <div class="endpoint"><span class="method DELETE">DELETE</span><span class="endpoint-path">/api/tasks/{id}</span><span class="endpoint-desc">remove task</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</main>
+</body>
+</html>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,50 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
+    <aside class="sidebar">
+      <div class="sidebar-logo">
+        <h1>{{ t('nav.companyName') }}</h1>
+        <span class="sidebar-subtitle">{{ t('nav.subtitle') }}</span>
+      </div>
+
+      <nav class="sidebar-nav">
+        <router-link to="/" :class="{ active: $route.path === '/' }">
+          {{ t('nav.overview') }}
+        </router-link>
+        <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
+          {{ t('nav.inventory') }}
+        </router-link>
+        <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
+          {{ t('nav.orders') }}
+        </router-link>
+        <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
+          {{ t('nav.finance') }}
+        </router-link>
+        <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
+          {{ t('nav.demandForecast') }}
+        </router-link>
+        <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
+          Reports
+        </router-link>
+        <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+          Restocking
+        </router-link>
+      </nav>
+
+      <div class="sidebar-footer">
         <LanguageSwitcher />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    </aside>
+
+    <div class="content-area">
+      <FilterBar />
+      <main class="page-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -162,6 +170,24 @@ export default {
 </script>
 
 <style>
+:root {
+  --sidebar-width: 240px;
+  --sidebar-bg: #0f172a;
+  --sidebar-text: #94a3b8;
+  --sidebar-text-active: #f8fafc;
+  --sidebar-hover-bg: rgba(255, 255, 255, 0.05);
+  --sidebar-active-bg: rgba(255, 255, 255, 0.08);
+  --sidebar-border: rgba(255, 255, 255, 0.08);
+  --color-bg: #f8fafc;
+  --color-card: #ffffff;
+  --color-border: #e2e8f0;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-card-hover: 0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04);
+  --radius-card: 10px;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -170,7 +196,7 @@ export default {
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
+  background: var(--color-bg);
   color: #1e293b;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -178,102 +204,100 @@ body {
 
 .app {
   display: flex;
-  flex-direction: column;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
+/* ── Sidebar ── */
+.sidebar {
+  position: fixed;
+  left: 0;
   top: 0;
-  z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
+  height: 100vh;
+  width: var(--sidebar-width);
+  background: var(--sidebar-bg);
   display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
+  flex-direction: column;
+  z-index: 50;
 }
 
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
+.sidebar-logo {
+  padding: 1.5rem 1.25rem 1.25rem;
+  border-bottom: 1px solid var(--sidebar-border);
 }
 
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
+.sidebar-logo h1 {
+  font-size: 1.125rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--sidebar-text-active);
   letter-spacing: -0.025em;
+  margin-bottom: 0.25rem;
 }
 
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
+.sidebar-subtitle {
+  font-size: 0.75rem;
+  color: var(--sidebar-text);
   font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
 }
 
-.nav-tabs {
+.sidebar-nav {
+  flex: 1;
+  padding: 0.75rem 0.75rem;
   display: flex;
-  gap: 0.25rem;
+  flex-direction: column;
+  gap: 0.125rem;
+  overflow-y: auto;
 }
 
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
+.sidebar-nav a {
+  display: block;
+  padding: 0.625rem 0.875rem;
+  color: var(--sidebar-text);
   text-decoration: none;
   font-weight: 500;
-  font-size: 0.938rem;
+  font-size: 0.875rem;
   border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
+  border-left: 3px solid transparent;
+  transition: all 0.15s ease;
 }
 
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
+.sidebar-nav a:hover {
+  background: var(--sidebar-hover-bg);
+  color: #cbd5e1;
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
+.sidebar-nav a.active {
+  background: var(--sidebar-active-bg);
+  color: var(--sidebar-text-active);
+  border-left-color: #3b82f6;
 }
 
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+.sidebar-footer {
+  padding: 0.75rem;
+  border-top: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.main-content {
+/* ── Main content area ── */
+.content-area {
+  margin-left: var(--sidebar-width);
   flex: 1;
-  max-width: 1600px;
+  min-height: 100vh;
+  background: var(--color-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.page-content {
+  flex: 1;
+  max-width: 1360px;
   width: 100%;
   margin: 0 auto;
   padding: 1.5rem 2rem;
 }
 
+/* ── Page header ── */
 .page-header {
   margin-bottom: 1.5rem;
 }
@@ -291,6 +315,7 @@ body {
   font-size: 0.938rem;
 }
 
+/* ── Stats grid ── */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -301,14 +326,15 @@ body {
 .stat-card {
   background: white;
   padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
   transition: all 0.2s ease;
 }
 
 .stat-card:hover {
   border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .stat-label {
@@ -343,12 +369,18 @@ body {
   color: #2563eb;
 }
 
+/* ── Card ── */
 .card {
-  background: white;
-  border-radius: 10px;
+  background: var(--color-card);
+  border-radius: var(--radius-card);
   padding: 1.25rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
   margin-bottom: 1.25rem;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-card-hover);
 }
 
 .card-header {
@@ -367,6 +399,7 @@ body {
   letter-spacing: -0.025em;
 }
 
+/* ── Tables ── */
 .table-container {
   overflow-x: auto;
 }
@@ -407,6 +440,7 @@ tbody tr:hover {
   background: #f8fafc;
 }
 
+/* ── Badges ── */
 .badge {
   display: inline-block;
   padding: 0.313rem 0.75rem;
@@ -467,6 +501,7 @@ tbody tr:hover {
   color: #1e40af;
 }
 
+/* ── States ── */
 .loading {
   text-align: center;
   padding: 3rem;
@@ -482,5 +517,10 @@ tbody tr:hover {
   border-radius: 8px;
   margin: 1rem 0;
   font-size: 0.938rem;
+}
+
+/* ── Modal z-index safety (must sit above sidebar z-index: 50) ── */
+.modal-overlay {
+  z-index: 200;
 }
 </style>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,15 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking-orders`)
+    return response.data
+  },
+
+  async createRestockingOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/restocking-orders`, orderData)
+    return response.data
   }
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -8,6 +8,51 @@
     <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
+      <!-- Submitted Restocking Orders -->
+      <div v-if="restockingOrders.length > 0" class="card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders ({{ restockingOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="restocking-table">
+            <thead>
+              <tr>
+                <th>Order Number</th>
+                <th>Items</th>
+                <th>Total Cost</th>
+                <th>Order Date</th>
+                <th>Expected Delivery</th>
+                <th>Lead Time</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="rst in restockingOrders" :key="rst.order_number">
+                <td><strong>{{ rst.order_number }}</strong></td>
+                <td>
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ rst.items.length }} item{{ rst.items.length !== 1 ? 's' : '' }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="item in rst.items" :key="item.sku" class="item-entry">
+                        <span class="item-name">{{ item.sku }}</span>
+                        <span class="item-meta">Qty: {{ item.quantity }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td><strong>${{ rst.total_cost.toLocaleString() }}</strong></td>
+                <td>{{ formatDate(rst.order_date) }}</td>
+                <td>{{ formatDate(rst.expected_delivery) }}</td>
+                <td><span class="badge info">7 days</span></td>
+                <td><span class="badge info">Submitted</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="stats-grid">
         <div class="stat-card success">
           <div class="stat-label">{{ t('status.delivered') }}</div>
@@ -95,6 +140,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -153,13 +199,25 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    const loadRestockingOrders = async () => {
+      try {
+        restockingOrders.value = await api.getRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load restocking orders:', err)
+      }
+    }
+
+    onMounted(() => {
+      loadOrders()
+      loadRestockingOrders()
+    })
 
     return {
       t,
       loading,
       error,
       orders,
+      restockingOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,
@@ -201,6 +259,12 @@ export default {
 
 .col-value {
   width: 120px;
+}
+
+/* Restocking table */
+.restocking-table {
+  table-layout: auto;
+  width: 100%;
 }
 
 /* Items details styling */

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,422 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking Planner</h2>
+      <p>Set your budget and review AI-recommended items to restock</p>
+    </div>
+
+    <div v-if="loading" class="loading">Loading...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Budget Section -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Budget</h3>
+          <span class="budget-display">${{ budget.toLocaleString() }}</span>
+        </div>
+        <div class="budget-slider-container">
+          <div class="slider-labels">
+            <span>$10,000</span>
+            <span>$500,000</span>
+          </div>
+          <input
+            type="range"
+            class="budget-slider"
+            :min="10000"
+            :max="500000"
+            :step="5000"
+            v-model.number="budget"
+          />
+        </div>
+      </div>
+
+      <!-- Recommendations Card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">
+            Recommended Items
+            <span class="badge info count-badge">{{ recommendations.length }}</span>
+          </h3>
+        </div>
+
+        <div v-if="recommendations.length === 0" class="empty-state">
+          No items can be recommended within the current budget.
+        </div>
+        <div v-else class="table-container">
+          <table class="recommendations-table">
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Item Name</th>
+                <th>Forecasted Demand</th>
+                <th>Trend</th>
+                <th>Unit Cost</th>
+                <th>Qty to Order</th>
+                <th>Total Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendations" :key="item.sku">
+                <td><code class="sku-code">{{ item.sku }}</code></td>
+                <td>{{ item.name }}</td>
+                <td>{{ item.forecasted_demand.toLocaleString() }}</td>
+                <td>
+                  <span :class="['badge', item.trend]">{{ item.trend }}</span>
+                </td>
+                <td>${{ item.unit_cost.toLocaleString() }}</td>
+                <td>{{ item.recommended_qty.toLocaleString() }}</td>
+                <td><strong>${{ item.item_cost.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Summary Row -->
+        <div class="summary-row">
+          <div class="summary-item">
+            <span class="summary-label">Items selected:</span>
+            <span class="summary-value">{{ recommendations.length }} of {{ allCandidates.length }}</span>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">Total cost:</span>
+            <span class="summary-value">${{ totalCost.toLocaleString() }}</span>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">Budget remaining:</span>
+            <span :class="['summary-value', budgetRemaining >= 0 ? 'positive' : 'negative']">
+              ${{ Math.abs(budgetRemaining).toLocaleString() }}
+              {{ budgetRemaining < 0 ? ' over' : '' }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Place Order Button -->
+      <div class="actions-row">
+        <button
+          class="btn-primary"
+          :disabled="recommendations.length === 0 || loading || submitting"
+          @click="placeOrder"
+        >
+          {{ submitting ? 'Submitting...' : 'Place Order' }}
+        </button>
+      </div>
+
+      <!-- Success Message -->
+      <div v-if="successMessage" class="success-message">
+        <p>{{ successMessage }}</p>
+        <router-link to="/orders" class="view-orders-link">View in Orders tab</router-link>
+      </div>
+
+      <!-- Submit Error -->
+      <div v-if="submitError" class="error">{{ submitError }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const loading = ref(true)
+    const error = ref(null)
+    const submitting = ref(false)
+    const submitError = ref(null)
+    const successMessage = ref(null)
+
+    const demandForecasts = ref([])
+    const inventoryItems = ref([])
+    const budget = ref(100000)
+
+    // Join demand forecasts with inventory by SKU to get unit_cost
+    const allCandidates = computed(() => {
+      return demandForecasts.value
+        .map(forecast => {
+          const inventoryItem = inventoryItems.value.find(inv => inv.sku === forecast.item_sku)
+          // Skip items with no matching inventory (no unit_cost available)
+          if (!inventoryItem) return null
+
+          const recommended_qty = forecast.forecasted_demand
+          const item_cost = recommended_qty * inventoryItem.unit_cost
+
+          return {
+            sku: forecast.item_sku,
+            name: forecast.item_name,
+            forecasted_demand: forecast.forecasted_demand,
+            trend: forecast.trend,
+            unit_cost: inventoryItem.unit_cost,
+            recommended_qty,
+            item_cost
+          }
+        })
+        .filter(Boolean)
+        // Sort by forecasted_demand descending
+        .sort((a, b) => b.forecasted_demand - a.forecasted_demand)
+    })
+
+    // Greedy selection: pick items in demand order until budget would be exceeded
+    const recommendations = computed(() => {
+      let remaining = budget.value
+      const selected = []
+      for (const item of allCandidates.value) {
+        if (remaining - item.item_cost < 0) break
+        selected.push(item)
+        remaining -= item.item_cost
+      }
+      return selected
+    })
+
+    const totalCost = computed(() => {
+      return recommendations.value.reduce((sum, item) => sum + item.item_cost, 0)
+    })
+
+    const budgetRemaining = computed(() => {
+      return budget.value - totalCost.value
+    })
+
+    const loadData = async () => {
+      loading.value = true
+      error.value = null
+      try {
+        // Fetch demand forecasts and inventory in parallel
+        const [forecasts, inventory] = await Promise.all([
+          api.getDemandForecasts(),
+          api.getInventory()
+        ])
+        demandForecasts.value = forecasts
+        inventoryItems.value = inventory
+      } catch (err) {
+        error.value = 'Failed to load restocking data'
+        console.error(err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      if (recommendations.value.length === 0) return
+
+      submitting.value = true
+      submitError.value = null
+      successMessage.value = null
+
+      try {
+        const items = recommendations.value.map(item => ({
+          sku: item.sku,
+          name: item.name,
+          quantity: item.recommended_qty,
+          unit_cost: item.unit_cost,
+          total_cost: item.item_cost
+        }))
+
+        const response = await api.createRestockingOrder({
+          items,
+          total_cost: totalCost.value,
+          budget: budget.value
+        })
+
+        successMessage.value = `Restocking order ${response.order_number} submitted. Expected delivery in 7 days.`
+      } catch (err) {
+        submitError.value = 'Failed to submit restocking order. Please try again.'
+        console.error(err)
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    onMounted(loadData)
+
+    return {
+      loading,
+      error,
+      submitting,
+      submitError,
+      successMessage,
+      budget,
+      allCandidates,
+      recommendations,
+      totalCost,
+      budgetRemaining,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.restocking {
+  padding-bottom: 2rem;
+}
+
+.budget-display {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2563eb;
+  letter-spacing: -0.025em;
+}
+
+.budget-slider-container {
+  padding: 0.5rem 0 0.25rem;
+}
+
+.slider-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.813rem;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.budget-slider {
+  width: 100%;
+  height: 6px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: #e2e8f0;
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(37, 99, 235, 0.4);
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(37, 99, 235, 0.4);
+}
+
+.count-badge {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.recommendations-table {
+  width: 100%;
+  table-layout: auto;
+}
+
+.sku-code {
+  font-family: 'Courier New', monospace;
+  font-size: 0.813rem;
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  color: #475569;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+.summary-row {
+  display: flex;
+  gap: 2rem;
+  padding: 1rem 0.75rem 0.25rem;
+  border-top: 1px solid #e2e8f0;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.summary-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.summary-label {
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.summary-value {
+  font-size: 0.938rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.summary-value.positive {
+  color: #059669;
+}
+
+.summary-value.negative {
+  color: #dc2626;
+}
+
+.actions-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.625rem 1.5rem;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.success-message {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.success-message p {
+  font-size: 0.938rem;
+  font-weight: 500;
+}
+
+.view-orders-link {
+  color: #065f46;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: underline;
+}
+
+.view-orders-link:hover {
+  color: #047857;
+}
+</style>

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,12 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+
+# In-memory store for submitted restocking orders
+restocking_orders: list = []
+restocking_order_counter = 0
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -119,6 +124,29 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+    total_cost: float
+
+class RestockingOrder(BaseModel):
+    id: str
+    order_number: str
+    items: List[RestockingOrderItem]
+    total_cost: float
+    budget: float
+    status: str
+    order_date: str
+    expected_delivery: str
+    lead_time_days: int
+
+class CreateRestockingOrderRequest(BaseModel):
+    items: List[RestockingOrderItem]
+    total_cost: float
+    budget: float
 
 # API endpoints
 @app.get("/")
@@ -303,6 +331,35 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+@app.get("/api/restocking-orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all submitted restocking orders"""
+    return restocking_orders
+
+@app.post("/api/restocking-orders", response_model=RestockingOrder)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Submit a new restocking order"""
+    global restocking_order_counter
+    restocking_order_counter += 1
+
+    now = datetime.now()
+    order_date = now.strftime("%Y-%m-%dT%H:%M:%S")
+    expected_delivery = (now + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S")
+
+    order = {
+        "id": str(restocking_order_counter),
+        "order_number": f"RST-{now.strftime('%Y')}-{restocking_order_counter:04d}",
+        "items": [item.model_dump() for item in request.items],
+        "total_cost": request.total_cost,
+        "budget": request.budget,
+        "status": "Submitted",
+        "order_date": order_date,
+        "expected_delivery": expected_delivery,
+        "lead_time_days": 7,
+    }
+    restocking_orders.insert(0, order)
+    return order
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary

- **Restocking tab**: New view with a budget slider, demand-forecast-based item recommendations, and a Place Order button
- **Orders tab**: Submitted restocking orders appear at top with 7-day lead time badge
- **SaaS sidebar redesign**: App.vue converted from top nav to dark vertical sidebar with CSS design token system
- **Backend**: Added GET/POST /api/restocking-orders endpoints with in-memory store
- **Architecture page**: Standalone architecture.html with system overview, tech stack, and data flow
- **CLAUDE.md**: Added Code Style rule for documenting non-obvious logic

## Test plan

- [ ] Restocking tab: budget slider adjusts recommendations by forecasted demand
- [ ] Place Order shows success with order number and link to Orders tab
- [ ] Orders tab: restocking orders appear at top with 7-day lead time badge
- [ ] Sidebar navigation works for all 7 tabs
- [ ] Open architecture.html to view system documentation

Generated with [Claude Code](https://claude.com/claude-code)