### PR TITLE
Add sidebar navigation, Restocking view, and purchase-order backend

### DIFF
--- a/.claude/skills/vue-saas-redesign/SKILL.md
+++ b/.claude/skills/vue-saas-redesign/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: vue-saas-redesign
+description: Redesign a Vue 3 application's UI into a modern SaaS-style interface — replace a top navigation bar with a left vertical sidebar, introduce a consistent spacing/design-token system, and give the app a polished, professional look. Use this whenever the user wants to modernize, restyle, or "make a Vue app look professional", add a sidebar/left-nav layout, fix inconsistent spacing, improve visual hierarchy, or move navigation out of a top bar — even if they don't use the exact word "redesign".
+license: MIT
+metadata:
+  author: Michał
+  version: "1.0.0"
+---
+
+# Vue 3 SaaS Redesign
+
+Turn an existing Vue 3 app into a modern SaaS-style interface: a fixed **left
+sidebar** for navigation, a **design-token system** for consistent spacing and
+color, and a **polished, calm visual hierarchy**. The goal is a focused structural
++ stylistic upgrade, not a rewrite of business logic.
+
+A guiding principle runs through everything below: **adapt to the app you are
+given.** Read its current colors, fonts, and component styles first, then extend
+them into a token system — don't impose an unrelated theme or a new CSS framework
+unless the user asks. A redesign that respects the app's existing identity feels
+intentional; one that replaces it wholesale feels like a different product.
+
+## When this applies
+
+Reach for this skill when the user wants to modernize a Vue app's look, move
+navigation from a top bar to a left sidebar, make spacing/typography consistent, or
+generally "make it look like a real SaaS product." It assumes Vue 3 (Options or
+Composition API, Vue Router). It does **not** change routes, data flow, or backend.
+
+## The method
+
+Work in this order. Each step has detail in a bundled reference file — read the
+referenced file before doing that step the first time.
+
+1. **Audit.** Find the app shell (usually `App.vue`) and how global styles are
+   organized (scoped vs a global `<style>`, any existing CSS variables, a color
+   palette, the nav markup, the router links). Note the framework in use so you can
+   adapt rather than replace. Inventory the nav destinations and any header widgets
+   (search, language switch, profile menu).
+
+2. **Establish design tokens.** Add one global stylesheet of CSS custom properties
+   for spacing, color roles, radius, elevation, and typography — seeded from the
+   app's *existing* values so nothing visually jumps. See
+   `references/design-principles.md` and start from `templates/design-tokens.css`.
+   Import it once, globally.
+
+3. **Build the app shell.** Replace the top bar with a two-area layout: a fixed
+   left **sidebar** and a scrollable **main** region. See
+   `references/sidebar-pattern.md` and start from `templates/AppSidebar.vue`.
+
+4. **Migrate navigation.** Move every top-nav link into the sidebar as a vertical
+   list with clear active states; pin secondary widgets (profile, language, settings)
+   to the **bottom** of the sidebar. Preserve existing router links, labels, and i18n
+   calls exactly — you are restyling, not renaming.
+
+5. **Apply spacing & polish.** Re-express the app's cards, tables, and headers in
+   terms of the tokens so vertical rhythm and padding are consistent everywhere.
+   Favor calm neutrals, one accent color, generous whitespace, and restrained
+   elevation. Details in `references/design-principles.md`.
+
+6. **Make it responsive.** Collapse the sidebar to icons (or a drawer) below a
+   breakpoint so the app still works on narrow screens. See
+   `references/sidebar-pattern.md`.
+
+7. **Verify.** Walk `references/redesign-checklist.md`: every route reachable and
+   active state correct, header widgets still function, no dead top-nav remnants,
+   spacing consistent, responsive behavior works, and nothing in the views broke.
+
+## How to use the bundled files
+
+- `references/design-principles.md` — the spacing scale, color roles, typography,
+  density and elevation rules that define the "SaaS look", plus how to derive tokens
+  from an existing palette. Read before step 2.
+- `references/sidebar-pattern.md` — the app-shell architecture, the sidebar anatomy,
+  active-state and accessibility guidance, and responsive collapse. Read before
+  steps 3–6.
+- `references/redesign-checklist.md` — the audit + acceptance checklist. Use in
+  steps 1 and 7.
+- `templates/AppSidebar.vue` — a literal starting point for the sidebar component
+  (logo, nav list with inline SVG icons, profile slot). Adapt its labels/links to
+  the target app; keep its structure.
+- `templates/design-tokens.css` — a drop-in token sheet. Re-seed the color values
+  from the target app's palette before using it.
+
+## Boundaries
+
+- Don't add a CSS framework or other dependency unless the user explicitly asks.
+- Don't rename routes or rewrite view logic — restyle the shell and global styles;
+  per-view polish should flow from the shared tokens.
+- No emojis as UI chrome; use inline SVG icons for a professional feel.
+- Comment any non-obvious layout decision so the next maintainer understands the why.

--- a/.claude/skills/vue-saas-redesign/references/design-principles.md
+++ b/.claude/skills/vue-saas-redesign/references/design-principles.md
@@ -1,0 +1,78 @@
+# Design principles — the SaaS look
+
+This file defines the visual language. The aim is a calm, dense-but-breathable
+interface that reads as a professional product: clear hierarchy, consistent rhythm,
+one accent color, restrained elevation.
+
+## Adapt to the existing palette first
+
+Before inventing colors, extract what the app already uses (search the global
+stylesheet and a few components for hex values and font families). Map those into
+**roles** rather than copying raw hex everywhere:
+
+- `--color-bg` — app background (usually the lightest neutral)
+- `--color-surface` — cards/panels (usually white)
+- `--color-border` — hairlines and dividers
+- `--color-text` / `--color-text-muted` — primary and secondary text
+- `--color-accent` (+ `--color-accent-weak` for tinted backgrounds) — the single
+  brand/action color, reused for active nav, primary buttons, links
+- status roles: `--color-success`, `--color-warning`, `--color-danger`, `--color-info`
+
+Seeding tokens from existing values means the redesign changes *structure and
+consistency* without a jarring repaint. Introduce new color only where the app had
+none (e.g. a dedicated sidebar surface).
+
+## Spacing scale
+
+Use a single 4px-based scale and reference it everywhere — this is the biggest
+lever for a "polished" feel, because inconsistent padding is what makes UIs look
+amateur.
+
+```
+--space-1: 4px    --space-2: 8px    --space-3: 12px   --space-4: 16px
+--space-5: 24px   --space-6: 32px   --space-7: 48px   --space-8: 64px
+```
+
+Rules of thumb: card padding `--space-5`; gaps between cards `--space-5`; section
+gaps `--space-6`; label↔value `--space-2`; icon↔text `--space-3`. Pick one value per
+relationship and reuse it — never hand-tune one-off pixel values.
+
+## Typography
+
+- One font family (keep the app's if it has one). A small type scale:
+  `--text-xs 12 / --text-sm 14 / --text-base 15 / --text-lg 18 / --text-xl 24 / --text-2xl 30`.
+- Weights: 400 body, 500 emphasis, 600–700 headings/values.
+- Use muted text (`--color-text-muted`) and uppercase micro-labels with letter
+  spacing for section/stat labels — a hallmark of the SaaS look.
+- Tabular numbers for tables/metrics where available.
+
+## Hierarchy & density
+
+- Establish three levels: page title → section/card title → body.
+- Generous but consistent whitespace; don't fill every pixel. Whitespace signals
+  quality.
+- Tables: comfortable row height, subtle zebra or hover, hairline row separators,
+  sticky header for long tables.
+
+## Elevation & shape
+
+- Keep it flat. Prefer 1px borders over heavy shadows. Use at most a soft shadow on
+  raised/floating elements (menus, modals):
+  `--shadow-sm: 0 1px 2px rgba(15,23,42,.06)` and
+  `--shadow-md: 0 4px 12px rgba(15,23,42,.08)`.
+- One radius scale: `--radius-sm 6 / --radius-md 10 / --radius-lg 14`. Pick one for
+  cards and reuse it.
+
+## Color usage discipline
+
+- Exactly one accent color for interactive emphasis (active nav item, primary
+  button, links, focus ring). Everything else is neutral + status colors.
+- Active/selected states: accent text on an `--color-accent-weak` tint, optionally a
+  left or bottom accent bar.
+- Always show a visible focus ring (accessibility): `outline: 2px solid var(--color-accent)`.
+
+## What to avoid
+
+- Multiple competing accent colors, heavy drop shadows, gradients as chrome.
+- Emojis as icons — use inline SVG.
+- One-off magic-number paddings — always reference the spacing scale.

--- a/.claude/skills/vue-saas-redesign/references/redesign-checklist.md
+++ b/.claude/skills/vue-saas-redesign/references/redesign-checklist.md
@@ -1,0 +1,40 @@
+# Redesign checklist
+
+Use the **audit** section before starting (step 1) and the **acceptance** section to
+verify when done (step 7).
+
+## Audit (before)
+
+- [ ] Located the app shell component (where the top nav + `<router-view>` live).
+- [ ] Identified how global styles are organized (global `<style>`, scoped, existing
+      CSS variables) and whether a CSS framework is in use.
+- [ ] Extracted the existing palette (bg, surface, border, text, accent, status) and
+      font family.
+- [ ] Listed every navigation destination (route + label + any i18n key).
+- [ ] Listed header widgets to relocate (search, language, profile, settings).
+- [ ] Confirmed the styling decision with the project's conventions (e.g. a
+      CLAUDE.md: no emojis, comment non-obvious logic, no new deps without asking).
+
+## Build
+
+- [ ] Added a global design-token stylesheet, seeded from the existing palette,
+      imported exactly once.
+- [ ] Replaced the top bar with the sidebar + scrollable main shell.
+- [ ] Every nav link migrated to the sidebar with its original `to`/label/i18n intact.
+- [ ] Secondary widgets pinned to the sidebar footer.
+- [ ] Cards/tables/headers re-expressed using the tokens (spacing, radius, color).
+- [ ] Responsive collapse implemented (icon rail or drawer).
+
+## Acceptance (after)
+
+- [ ] No remnant of the old top nav (markup or styles).
+- [ ] All routes reachable from the sidebar; the active item is highlighted and sets
+      `aria-current="page"`.
+- [ ] Header widgets (profile, language, filters, search) still function.
+- [ ] Spacing is consistent — padding/gaps come from the scale, no one-off pixels.
+- [ ] Single accent color; status colors only for status; flat elevation.
+- [ ] Visible focus ring on interactive elements; `nav` landmark present.
+- [ ] Wide content (tables) does not overflow horizontally (`min-width: 0` on main).
+- [ ] Works at a narrow viewport (sidebar collapses, content usable).
+- [ ] No view logic changed; app still builds/hot-reloads with no console errors.
+- [ ] No emojis used as chrome; non-obvious layout choices are commented.

--- a/.claude/skills/vue-saas-redesign/references/sidebar-pattern.md
+++ b/.claude/skills/vue-saas-redesign/references/sidebar-pattern.md
@@ -1,0 +1,80 @@
+# Sidebar app-shell pattern
+
+The structural heart of the redesign: move navigation from a horizontal top bar to
+a fixed vertical sidebar, and give the content its own scrollable region.
+
+## Shell architecture
+
+```
+.app                      (flex row, min-height: 100vh)
+├── aside.sidebar         (fixed width e.g. 248px; column; full height; own surface)
+│   ├── .sidebar-brand    (logo / product name, top)
+│   ├── nav.sidebar-nav   (the vertical link list, scrolls if long; flex: 1)
+│   └── .sidebar-footer   (profile, language, settings — pinned bottom)
+└── .app-main            (flex: 1; min-width: 0; column; the scrollable area)
+    ├── .app-topbar       (optional slim bar: filters, page context, search)
+    └── main.content      (router-view; padding from the spacing scale)
+```
+
+Why this shape: a persistent left rail is the dominant pattern for tools with many
+destinations — it scales to more nav items than a top bar, keeps navigation visible
+while scrolling content, and gives a natural home (the footer) for account/settings
+widgets. `min-width: 0` on the main column is essential so wide tables don't blow out
+the layout.
+
+## Sidebar anatomy
+
+- **Brand** at top: product name (+ small mark). Keep it compact.
+- **Nav list**: one item per destination. Each item = inline SVG icon + label,
+  comfortable hit area (`padding: var(--space-3) var(--space-4)`), `--radius-md`,
+  `gap: var(--space-3)`.
+- **Active state**: accent text on `--color-accent-weak`; optionally a left accent
+  bar. Drive it from the router (`router-link-active`, or compare `$route.path`).
+- **Footer**: profile menu, language switch, settings — pinned to the bottom with
+  `margin-top: auto`.
+
+## Migrating existing top-nav links
+
+Map each existing top-bar `<router-link>` to a sidebar item one-to-one. **Preserve
+the original `to`, label text, and any i18n call** (e.g. `t('nav.orders')`) — this is
+a restyle, not a rename. Add an icon per item. If the app had header widgets
+(language, profile), relocate them into the sidebar footer rather than deleting them.
+
+## Accessibility
+
+- Wrap links in a `<nav aria-label="Primary">` landmark.
+- Active item: set `aria-current="page"`.
+- Keep a visible focus ring on every interactive element.
+- Icons are decorative when paired with a text label — mark `aria-hidden="true"`.
+
+## Collapsible / responsive behaviour
+
+Make the rail collapsible to an **icons-only** mode. The recommended model (see
+`templates/AppSidebar.vue`) combines a manual toggle with responsive forcing:
+
+- Drive a single `collapsed` boolean. Bind it to a `.collapsed` class that narrows
+  the rail to `--sidebar-width-collapsed` (~64–68px) and hides the brand text and
+  nav labels. Animate `width` for a smooth transition.
+- **Force collapse on small screens.** Watch a media query
+  (`window.matchMedia('(max-width: 1024px)')`); when it matches, `collapsed` is true
+  regardless of preference, so phones/tablets always get the compact rail. Add the
+  listener in `onMounted` and remove it in `onBeforeUnmount`.
+- **Toggle + persist on large screens.** A toggle button flips a `manualCollapsed`
+  ref and saves it to `localStorage`; `collapsed = isSmall || manualCollapsed`. Hide
+  the toggle when the small-screen force is active (it would be a no-op).
+- **Keep destinations discoverable when collapsed.** Add a native `title` (tooltip)
+  on each nav item showing its label, and keep an accessible name on the toggle
+  (`aria-label` for collapse/expand, `aria-expanded`).
+
+Alternative for true mobile: a **drawer** — hide the rail off-canvas and reveal it
+with a hamburger + backdrop. Prefer the icon rail when desktop-first; the drawer
+when mobile is the primary target. Either way the main region must stay fully usable
+with the sidebar collapsed (`min-width: 0` on the main column).
+
+## Common pitfalls
+
+- Forgetting `min-width: 0` on the main column → horizontal overflow from tables.
+- Sidebar that scrolls with content instead of staying fixed → use full-height
+  column with its own overflow.
+- Losing active state because the old top-nav active CSS was removed — re-implement
+  it on the sidebar item.

--- a/.claude/skills/vue-saas-redesign/templates/AppSidebar.vue
+++ b/.claude/skills/vue-saas-redesign/templates/AppSidebar.vue
@@ -1,0 +1,196 @@
+<!--
+  AppSidebar.vue — literal starting point for a COLLAPSIBLE SaaS sidebar.
+
+  HOW TO USE: replace the `navItems` entries and `ICON` map with the target app's
+  real routes/labels (keep its i18n calls), and swap the brand. Keep the STRUCTURE
+  and the collapse behaviour:
+    - Below the breakpoint the rail is FORCED to icons-only (small screens).
+    - On larger screens the user toggles it and the choice is persisted.
+    - Collapsed items expose their label via a native `title` tooltip.
+  Icons are decorative inline SVG (no emojis). Styling consumes design-tokens.css.
+-->
+<template>
+  <aside class="sidebar" :class="{ collapsed }">
+    <div class="sidebar-brand">
+      <span class="brand-mark" aria-hidden="true">◆</span>
+      <span class="brand-name">{{ brand }}</span>
+    </div>
+
+    <nav class="sidebar-nav" aria-label="Primary">
+      <router-link
+        v-for="item in navItems"
+        :key="item.to"
+        :to="item.to"
+        class="nav-item"
+        :class="{ active: isActive(item.to) }"
+        :aria-current="isActive(item.to) ? 'page' : null"
+        :title="collapsed ? item.label : null"
+      >
+        <span class="nav-icon" aria-hidden="true" v-html="ICON[item.icon]"></span>
+        <span class="nav-label">{{ item.label }}</span>
+      </router-link>
+    </nav>
+
+    <!-- Toggle only matters on larger screens; small screens are forced to icons-only. -->
+    <button
+      v-if="!isSmall"
+      type="button"
+      class="sidebar-toggle"
+      :aria-label="collapsed ? expandLabel : collapseLabel"
+      :aria-expanded="!collapsed"
+      @click="toggleCollapsed"
+    >
+      <span class="toggle-icon" aria-hidden="true">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+      </span>
+      <span class="toggle-label">{{ collapseLabel }}</span>
+    </button>
+
+    <div class="sidebar-footer">
+      <slot name="footer" />
+    </div>
+  </aside>
+</template>
+
+<script>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute } from 'vue-router'
+
+const COLLAPSE_BREAKPOINT = '(max-width: 1024px)'
+const STORAGE_KEY = 'sidebar-collapsed'
+
+// Minimal inline SVG icons (20px). Add one entry per destination.
+const ICON = {
+  dashboard: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>',
+  list: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>'
+}
+
+export default {
+  name: 'AppSidebar',
+  props: {
+    brand: { type: String, default: 'Product' },
+    navItems: { type: Array, required: true }, // [{ to, label, icon }]
+    collapseLabel: { type: String, default: 'Collapse sidebar' },
+    expandLabel: { type: String, default: 'Expand sidebar' }
+  },
+  setup() {
+    const route = useRoute()
+    const isActive = (to) => (to === '/' ? route.path === '/' : route.path.startsWith(to))
+
+    const manualCollapsed = ref(localStorage.getItem(STORAGE_KEY) === 'true')
+    const isSmall = ref(false)
+
+    // Small screens force icons-only; otherwise honor the user's saved preference.
+    const collapsed = computed(() => isSmall.value || manualCollapsed.value)
+
+    const toggleCollapsed = () => {
+      manualCollapsed.value = !manualCollapsed.value
+      localStorage.setItem(STORAGE_KEY, String(manualCollapsed.value))
+    }
+
+    let mq
+    const onMqChange = (e) => { isSmall.value = e.matches }
+    onMounted(() => {
+      mq = window.matchMedia(COLLAPSE_BREAKPOINT)
+      isSmall.value = mq.matches
+      mq.addEventListener('change', onMqChange)
+    })
+    onBeforeUnmount(() => { if (mq) mq.removeEventListener('change', onMqChange) })
+
+    return { isActive, ICON, collapsed, isSmall, toggleCollapsed }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  transition: width 0.18s ease;
+}
+.sidebar.collapsed { width: var(--sidebar-width-collapsed); }
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-4);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+  overflow: hidden;
+}
+.brand-mark { color: var(--color-accent); flex-shrink: 0; }
+.sidebar.collapsed .sidebar-brand { justify-content: center; padding-left: 0; padding-right: 0; }
+
+.sidebar-nav {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-3);
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.nav-item:hover { background: var(--color-surface-alt); color: var(--color-text); }
+.nav-item.active { background: var(--color-accent-weak); color: var(--color-accent); }
+.nav-icon { display: inline-flex; flex-shrink: 0; }
+.sidebar.collapsed .nav-item { justify-content: center; padding-left: 0; padding-right: 0; }
+
+.sidebar.collapsed .brand-name,
+.sidebar.collapsed .nav-label,
+.sidebar.collapsed .toggle-label { display: none; }
+
+.sidebar-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0 var(--space-3) var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.sidebar-toggle:hover { background: var(--color-surface-alt); color: var(--color-text); }
+.sidebar.collapsed .sidebar-toggle { justify-content: center; margin-left: 0; margin-right: 0; padding-left: 0; padding-right: 0; }
+.toggle-icon { display: inline-flex; transition: transform 0.18s ease; }
+.sidebar.collapsed .toggle-icon { transform: rotate(180deg); }
+
+.sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+.sidebar.collapsed .sidebar-footer { flex-direction: column; padding-left: var(--space-2); padding-right: var(--space-2); }
+</style>

--- a/.claude/skills/vue-saas-redesign/templates/design-tokens.css
+++ b/.claude/skills/vue-saas-redesign/templates/design-tokens.css
@@ -1,0 +1,56 @@
+/*
+ * design-tokens.css — drop-in design-token layer for a SaaS-style Vue app.
+ *
+ * HOW TO USE: re-seed the COLOR values below from the target app's existing
+ * palette so the redesign restyles structure without a jarring repaint, then
+ * import this file once globally (e.g. in main.js or the root component). The
+ * spacing / radius / shadow / typography scales are app-agnostic and can be kept.
+ *
+ * The values below are seeded with a neutral "slate" palette as a starting point.
+ */
+:root {
+  /* Color roles (re-seed from the target app) */
+  --color-bg: #f8fafc;          /* app background */
+  --color-surface: #ffffff;     /* cards, panels, sidebar */
+  --color-surface-alt: #f1f5f9; /* subtle fills, hover */
+  --color-border: #e2e8f0;      /* hairlines, dividers */
+  --color-text: #0f172a;        /* primary text */
+  --color-text-muted: #64748b;  /* secondary text, labels */
+
+  --color-accent: #2563eb;      /* single brand/action color */
+  --color-accent-weak: #eff6ff; /* tinted bg for active/selected */
+  --color-accent-strong: #1d4ed8;
+
+  --color-success: #059669;
+  --color-warning: #d97706;
+  --color-danger: #dc2626;
+  --color-info: #2563eb;
+
+  /* Spacing scale (4px base) — reference these, never magic numbers */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
+  --space-5: 24px; --space-6: 32px; --space-7: 48px; --space-8: 64px;
+
+  /* Radius */
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px;
+
+  /* Elevation — keep it flat; shadows only for floating elements */
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08);
+
+  /* Typography */
+  --text-xs: 12px; --text-sm: 14px; --text-base: 15px;
+  --text-lg: 18px; --text-xl: 24px; --text-2xl: 30px;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Shell dimensions */
+  --sidebar-width: 248px;
+  --sidebar-width-collapsed: 64px;
+}
+
+/* Accessibility: a consistent, visible focus ring on interactive elements. */
+:where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,9 @@ Use the Task tool with these specialized subagents for appropriate tasks:
 - **Backend**: Python FastAPI (port 8001)
 - **Data**: JSON files in `server/data/` loaded via `server/mock_data.py`
 
+## Code Conventions
+- Always document non-obvious logic changes with comments (explain *why*, not *what*).
+
 ## Quick Start
 
 ```bash

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Factory Inventory Management System</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%233b82f6'/><path d='M8 22V14l8-6 8 6v8H8z' fill='none' stroke='white' stroke-width='2'/><rect x='13' y='17' width='6' height='5' fill='white'/></svg>">
 </head>
 <body>
   <div id="app"></div>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,26 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
+    <AppSidebar
+      :brand="t('nav.companyName')"
+      :nav-items="navItems"
+      :collapse-label="t('nav.collapseSidebar')"
+      :expand-label="t('nav.expandSidebar')"
+    >
+      <template #footer>
         <LanguageSwitcher />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
-      </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+      </template>
+    </AppSidebar>
+
+    <div class="app-main">
+      <FilterBar />
+      <main class="content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -59,6 +43,7 @@ import { ref, onMounted, computed } from 'vue'
 import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
+import AppSidebar from './components/AppSidebar.vue'
 import FilterBar from './components/FilterBar.vue'
 import ProfileMenu from './components/ProfileMenu.vue'
 import ProfileDetailsModal from './components/ProfileDetailsModal.vue'
@@ -68,6 +53,7 @@ import LanguageSwitcher from './components/LanguageSwitcher.vue'
 export default {
   name: 'App',
   components: {
+    AppSidebar,
     FilterBar,
     ProfileMenu,
     ProfileDetailsModal,
@@ -77,6 +63,19 @@ export default {
   setup() {
     const { currentUser } = useAuth()
     const { t } = useI18n()
+
+    // Sidebar navigation model — same destinations/labels as the old top nav, kept
+    // reactive (via t) so labels follow the active locale. Order preserved from the
+    // original top-nav bar.
+    const navItems = computed(() => [
+      { to: '/', label: t('nav.overview'), icon: 'dashboard' },
+      { to: '/inventory', label: t('nav.inventory'), icon: 'box' },
+      { to: '/orders', label: t('nav.orders'), icon: 'cart' },
+      { to: '/spending', label: t('nav.finance'), icon: 'dollar' },
+      { to: '/demand', label: t('nav.demandForecast'), icon: 'trending' },
+      { to: '/restocking', label: t('nav.restocking'), icon: 'refresh' },
+      { to: '/reports', label: t('nav.reports'), icon: 'chart' }
+    ])
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
@@ -150,6 +149,7 @@ export default {
 
     return {
       t,
+      navItems,
       showProfileDetails,
       showTasks,
       tasks,
@@ -178,100 +178,24 @@ body {
 
 .app {
   display: flex;
-  flex-direction: column;
   min-height: 100vh;
+  background: var(--color-bg);
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  padding: 0 2rem;
-  height: 70px;
-}
-
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.logo h1 {
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
-}
-
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
-}
-
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
-}
-
-.main-content {
+/* Main column sits beside the fixed sidebar; min-width:0 keeps wide tables from overflowing. */
+.app-main {
   flex: 1;
-  max-width: 1600px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  flex: 1;
   width: 100%;
+  max-width: 1400px;
   margin: 0 auto;
-  padding: 1.5rem 2rem;
+  padding: var(--space-5) var(--space-6);
 }
 
 .page-header {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -43,6 +43,16 @@ export const api = {
     return response.data
   },
 
+  async submitRestockOrder(payload) {
+    const response = await axios.post(`${API_BASE_URL}/restock-orders`, payload)
+    return response.data
+  },
+
+  async getRestockOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restock-orders`)
+    return response.data
+  },
+
   async getDashboardSummary(filters = {}) {
     const params = new URLSearchParams()
     if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)

--- a/client/src/components/AppSidebar.vue
+++ b/client/src/components/AppSidebar.vue
@@ -1,0 +1,211 @@
+<!--
+  AppSidebar.vue — collapsible left navigation rail for the SaaS shell.
+  Brand at top, scrollable nav, a collapse toggle, and a #footer slot pinned to the
+  bottom for account/language widgets. Icons are decorative inline SVG (no emojis).
+
+  Collapse behaviour:
+  - Below the breakpoint the rail is FORCED to icons-only (small screens get the
+    compact layout regardless of preference).
+  - On larger screens the user can toggle it, and the choice is persisted.
+  - When collapsed, labels are hidden and each item shows a native tooltip (title)
+    so destinations stay discoverable.
+-->
+<template>
+  <aside class="sidebar" :class="{ collapsed }">
+    <div class="sidebar-brand">
+      <span class="brand-mark" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+      </span>
+      <span class="brand-name">{{ brand }}</span>
+    </div>
+
+    <nav class="sidebar-nav" aria-label="Primary">
+      <router-link
+        v-for="item in navItems"
+        :key="item.to"
+        :to="item.to"
+        class="nav-item"
+        :class="{ active: isActive(item.to) }"
+        :aria-current="isActive(item.to) ? 'page' : null"
+        :title="collapsed ? item.label : null"
+      >
+        <span class="nav-icon" aria-hidden="true" v-html="ICON[item.icon]"></span>
+        <span class="nav-label">{{ item.label }}</span>
+      </router-link>
+    </nav>
+
+    <!-- Toggle only matters on larger screens; small screens are forced to icons-only. -->
+    <button
+      v-if="!isSmall"
+      type="button"
+      class="sidebar-toggle"
+      :aria-label="collapsed ? expandLabel : collapseLabel"
+      :aria-expanded="!collapsed"
+      @click="toggleCollapsed"
+    >
+      <span class="toggle-icon" aria-hidden="true">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+      </span>
+      <span class="toggle-label">{{ collapseLabel }}</span>
+    </button>
+
+    <div class="sidebar-footer">
+      <slot name="footer" />
+    </div>
+  </aside>
+</template>
+
+<script>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute } from 'vue-router'
+
+const COLLAPSE_BREAKPOINT = '(max-width: 1024px)'
+const STORAGE_KEY = 'sidebar-collapsed'
+
+// Stroke-based inline SVG icons (20px), one per destination. Decorative only.
+const ICON = {
+  dashboard: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>',
+  box: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>',
+  cart: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>',
+  trending: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>',
+  refresh: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>',
+  dollar: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>',
+  chart: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>'
+}
+
+export default {
+  name: 'AppSidebar',
+  props: {
+    brand: { type: String, default: 'Product' },
+    navItems: { type: Array, required: true }, // [{ to, label, icon }]
+    collapseLabel: { type: String, default: 'Collapse sidebar' },
+    expandLabel: { type: String, default: 'Expand sidebar' }
+  },
+  setup() {
+    const route = useRoute()
+    const isActive = (to) => (to === '/' ? route.path === '/' : route.path.startsWith(to))
+
+    const manualCollapsed = ref(localStorage.getItem(STORAGE_KEY) === 'true')
+    const isSmall = ref(false)
+
+    // Small screens force icons-only; otherwise honor the user's saved preference.
+    const collapsed = computed(() => isSmall.value || manualCollapsed.value)
+
+    const toggleCollapsed = () => {
+      manualCollapsed.value = !manualCollapsed.value
+      localStorage.setItem(STORAGE_KEY, String(manualCollapsed.value))
+    }
+
+    let mq
+    const onMqChange = (e) => { isSmall.value = e.matches }
+    onMounted(() => {
+      mq = window.matchMedia(COLLAPSE_BREAKPOINT)
+      isSmall.value = mq.matches
+      mq.addEventListener('change', onMqChange)
+    })
+    onBeforeUnmount(() => { if (mq) mq.removeEventListener('change', onMqChange) })
+
+    return { isActive, ICON, collapsed, isSmall, toggleCollapsed }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  transition: width 0.18s ease;
+}
+.sidebar.collapsed { width: var(--sidebar-width-collapsed); }
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-4);
+  color: var(--color-text);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.02em;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+  overflow: hidden;
+}
+.brand-mark { display: inline-flex; color: var(--color-accent); flex-shrink: 0; }
+.sidebar.collapsed .sidebar-brand { justify-content: center; padding-left: 0; padding-right: 0; }
+
+.sidebar-nav {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-3);
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.nav-item:hover { background: var(--color-surface-alt); color: var(--color-text); }
+.nav-item.active { background: var(--color-accent-weak); color: var(--color-accent); }
+.nav-icon { display: inline-flex; flex-shrink: 0; }
+.sidebar.collapsed .nav-item { justify-content: center; padding-left: 0; padding-right: 0; }
+
+/* Hide text in collapsed mode but keep it in the a11y tree-free tooltip via title. */
+.sidebar.collapsed .brand-name,
+.sidebar.collapsed .nav-label,
+.sidebar.collapsed .toggle-label { display: none; }
+
+.sidebar-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0 var(--space-3) var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.sidebar-toggle:hover { background: var(--color-surface-alt); color: var(--color-text); }
+.sidebar.collapsed .sidebar-toggle { justify-content: center; margin-left: 0; margin-right: 0; padding-left: 0; padding-right: 0; }
+.toggle-icon { display: inline-flex; transition: transform 0.18s ease; }
+/* Chevron points left to collapse; flip it when already collapsed (points right to expand). */
+.sidebar.collapsed .toggle-icon { transform: rotate(180deg); }
+
+.sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+.sidebar.collapsed .sidebar-footer {
+  flex-direction: column;
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+}
+</style>

--- a/client/src/components/PurchaseOrderModal.vue
+++ b/client/src/components/PurchaseOrderModal.vue
@@ -1,0 +1,478 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="isOpen && backlogItem" class="modal-overlay" @click="close">
+        <div class="modal-container" @click.stop>
+          <div class="modal-header">
+            <h3 class="modal-title">
+              {{ mode === 'create' ? 'Create Purchase Order' : 'Purchase Order Details' }}
+            </h3>
+            <button class="close-button" @click="close">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+
+          <div class="modal-body">
+            <div class="item-header">
+              <div class="item-info">
+                <h4 class="item-name">{{ backlogItem.item_name }}</h4>
+                <span class="item-sku">SKU: {{ backlogItem.item_sku }}</span>
+              </div>
+              <span class="shortage-badge">
+                {{ backlogItem.quantity_needed - backlogItem.quantity_available }} units short
+              </span>
+            </div>
+
+            <form v-if="mode === 'create'" class="po-form" @submit.prevent="submit">
+              <div class="form-group">
+                <label for="po-supplier">Supplier Name</label>
+                <input
+                  id="po-supplier"
+                  v-model="form.supplier_name"
+                  type="text"
+                  required
+                  placeholder="Enter supplier name"
+                  class="form-input"
+                />
+              </div>
+              <div class="form-row">
+                <div class="form-group">
+                  <label for="po-qty">Quantity</label>
+                  <input
+                    id="po-qty"
+                    v-model.number="form.quantity"
+                    type="number"
+                    required
+                    min="1"
+                    class="form-input"
+                  />
+                </div>
+                <div class="form-group">
+                  <label for="po-cost">Unit Cost ($)</label>
+                  <input
+                    id="po-cost"
+                    v-model.number="form.unit_cost"
+                    type="number"
+                    required
+                    min="0"
+                    step="0.01"
+                    class="form-input"
+                  />
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="po-delivery">Expected Delivery Date</label>
+                <input
+                  id="po-delivery"
+                  v-model="form.expected_delivery_date"
+                  type="date"
+                  required
+                  class="form-input"
+                />
+              </div>
+              <div class="form-group">
+                <label for="po-notes">Notes <span class="optional">(optional)</span></label>
+                <textarea
+                  id="po-notes"
+                  v-model="form.notes"
+                  rows="3"
+                  placeholder="Add notes..."
+                  class="form-input"
+                ></textarea>
+              </div>
+              <div v-if="submitError" class="form-error">{{ submitError }}</div>
+            </form>
+
+            <div v-else class="po-view">
+              <p v-if="!poData && !loadError" class="loading-text">Loading...</p>
+              <p v-if="loadError" class="form-error">{{ loadError }}</p>
+              <div v-if="poData" class="info-grid">
+                <div class="info-item">
+                  <div class="info-label">Supplier</div>
+                  <div class="info-value">{{ poData.supplier_name }}</div>
+                </div>
+                <div class="info-item">
+                  <div class="info-label">Quantity</div>
+                  <div class="info-value">{{ poData.quantity }} units</div>
+                </div>
+                <div class="info-item">
+                  <div class="info-label">Unit Cost</div>
+                  <div class="info-value">${{ poData.unit_cost.toFixed(2) }}</div>
+                </div>
+                <div class="info-item">
+                  <div class="info-label">Total Cost</div>
+                  <div class="info-value">${{ (poData.quantity * poData.unit_cost).toFixed(2) }}</div>
+                </div>
+                <div class="info-item">
+                  <div class="info-label">Expected Delivery</div>
+                  <div class="info-value">{{ formatDate(poData.expected_delivery_date) }}</div>
+                </div>
+                <div class="info-item">
+                  <div class="info-label">Status</div>
+                  <div class="info-value"><span class="badge info">{{ poData.status }}</span></div>
+                </div>
+                <div v-if="poData.notes" class="info-item full-width">
+                  <div class="info-label">Notes</div>
+                  <div class="info-value">{{ poData.notes }}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button class="btn-secondary" @click="close">
+              {{ mode === 'create' ? 'Cancel' : 'Close' }}
+            </button>
+            <button
+              v-if="mode === 'create'"
+              class="btn-primary"
+              :disabled="submitting"
+              @click="submit"
+            >
+              {{ submitting ? 'Creating...' : 'Create PO' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { api } from '../api'
+
+const props = defineProps({
+  isOpen: { type: Boolean, default: false },
+  backlogItem: { type: Object, default: null },
+  mode: { type: String, default: 'create' }
+})
+
+const emit = defineEmits(['close', 'po-created'])
+
+const form = ref({ supplier_name: '', quantity: 0, unit_cost: 0, expected_delivery_date: '', notes: '' })
+const submitting = ref(false)
+const submitError = ref(null)
+const poData = ref(null)
+const loadError = ref(null)
+
+watch(
+  () => [props.isOpen, props.backlogItem, props.mode],
+  ([open, item, mode]) => {
+    if (!open || !item) return
+    submitError.value = null
+    loadError.value = null
+    if (mode === 'create') {
+      const shortage = Math.max(item.quantity_needed - item.quantity_available, 1)
+      form.value = { supplier_name: '', quantity: shortage, unit_cost: 0, expected_delivery_date: '', notes: '' }
+    } else {
+      loadPOData(item.id)
+    }
+  },
+  { immediate: true }
+)
+
+const loadPOData = async (backlogItemId) => {
+  poData.value = null
+  try {
+    poData.value = await api.getPurchaseOrderByBacklogItem(backlogItemId)
+  } catch {
+    loadError.value = 'Could not load purchase order details.'
+  }
+}
+
+const submit = async () => {
+  submitting.value = true
+  submitError.value = null
+  try {
+    const created = await api.createPurchaseOrder({
+      backlog_item_id: props.backlogItem.id,
+      ...form.value
+    })
+    emit('po-created', created)
+  } catch (err) {
+    submitError.value = err.response?.data?.detail || 'Failed to create purchase order.'
+  } finally {
+    submitting.value = false
+  }
+}
+
+const close = () => emit('close')
+
+const formatDate = (dateString) => {
+  if (!dateString) return 'N/A'
+  return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 1rem;
+}
+
+.modal-container {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+  max-width: 560px;
+  width: 100%;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modal-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+}
+
+.close-button:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 1.5rem;
+}
+
+.item-name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.25rem 0;
+}
+
+.item-sku {
+  font-size: 0.813rem;
+  color: #64748b;
+  font-family: 'Monaco', 'Courier New', monospace;
+}
+
+.shortage-badge {
+  padding: 0.375rem 0.75rem;
+  background: #fef2f2;
+  color: #dc2626;
+  border-radius: 6px;
+  font-size: 0.813rem;
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.po-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-group label {
+  font-size: 0.813rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.optional {
+  font-weight: 400;
+  color: #94a3b8;
+}
+
+.form-input {
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: #0f172a;
+  font-family: inherit;
+  transition: border-color 0.15s ease;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+textarea.form-input {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.form-error {
+  padding: 0.75rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.info-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.info-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.info-value {
+  font-size: 0.938rem;
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.loading-text {
+  color: #64748b;
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.modal-footer {
+  padding: 1.25rem 1.5rem;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.btn-secondary {
+  padding: 0.625rem 1.25rem;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #334155;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
+}
+
+.btn-secondary:hover {
+  background: #e2e8f0;
+}
+
+.btn-primary {
+  padding: 0.625rem 1.25rem;
+  background: #3b82f6;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: white;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.badge.info {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active .modal-container,
+.modal-leave-active .modal-container {
+  transition: transform 0.2s ease;
+}
+
+.modal-enter-from .modal-container,
+.modal-leave-to .modal-container {
+  transform: scale(0.95);
+}
+</style>

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,8 +6,42 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
+    reports: 'Reports',
+    collapseSidebar: 'Collapse sidebar',
+    expandSidebar: 'Expand sidebar',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Set a budget and order recommended restock items based on the demand forecast',
+    budgetLabel: 'Available Budget',
+    budgetHelp: 'Drag to set how much you can spend. Recommendations update automatically.',
+    recommended: 'Recommended Items',
+    noRecommendations: 'No items fit this budget. Increase the budget to see recommendations.',
+    summary: {
+      budget: 'Budget',
+      items: 'Items',
+      totalCost: 'Total Cost',
+      remaining: 'Remaining'
+    },
+    table: {
+      sku: 'SKU',
+      itemName: 'Item Name',
+      trend: 'Trend',
+      restockQty: 'Restock Qty',
+      unitCost: 'Unit Cost',
+      lineCost: 'Line Cost',
+      leadTime: 'Lead Time'
+    },
+    placeOrder: 'Place Order',
+    placing: 'Placing order...',
+    successMessage: 'Restock order {orderNumber} submitted. View it in the Orders tab.',
+    errorMessage: 'Failed to submit restock order: {error}',
+    days: 'days'
   },
 
   // Dashboard
@@ -106,6 +140,7 @@ export default {
     title: 'Orders',
     description: 'View and manage customer orders',
     allOrders: 'All Orders',
+    submittedOrders: 'Submitted Orders',
     totalOrders: 'Total Orders',
     totalRevenue: 'Total Revenue',
     avgOrderValue: 'Avg Order Value',
@@ -125,7 +160,8 @@ export default {
       totalValue: 'Total Value',
       status: 'Status',
       expectedDelivery: 'Expected Delivery',
-      actualDelivery: 'Actual Delivery'
+      actualDelivery: 'Actual Delivery',
+      leadTime: 'Lead Time'
     }
   },
 
@@ -204,6 +240,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    submitted: 'Submitted',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,8 +6,42 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '再入荷',
+    reports: 'レポート',
+    collapseSidebar: 'サイドバーを折りたたむ',
+    expandSidebar: 'サイドバーを展開',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
+  },
+
+  // Restocking
+  restocking: {
+    title: '再入荷',
+    description: '予算を設定し、需要予測に基づく推奨再入荷品目を発注します',
+    budgetLabel: '利用可能予算',
+    budgetHelp: 'スライダーで支出可能額を設定すると、推奨が自動更新されます。',
+    recommended: '推奨品目',
+    noRecommendations: 'この予算に収まる品目がありません。予算を増やしてください。',
+    summary: {
+      budget: '予算',
+      items: '品目数',
+      totalCost: '合計費用',
+      remaining: '残り'
+    },
+    table: {
+      sku: 'SKU',
+      itemName: '品名',
+      trend: '傾向',
+      restockQty: '再入荷数量',
+      unitCost: '単価',
+      lineCost: '小計',
+      leadTime: 'リードタイム'
+    },
+    placeOrder: '発注する',
+    placing: '発注中...',
+    successMessage: '再入荷注文 {orderNumber} を送信しました。注文タブで確認できます。',
+    errorMessage: '再入荷注文の送信に失敗しました: {error}',
+    days: '日'
   },
 
   // Dashboard
@@ -106,6 +140,7 @@ export default {
     title: '注文',
     description: '顧客注文の表示と管理',
     allOrders: 'すべての注文',
+    submittedOrders: '送信済み注文',
     totalOrders: '総注文数',
     totalRevenue: '総収益',
     avgOrderValue: '平均注文額',
@@ -125,7 +160,8 @@ export default {
       totalValue: '合計金額',
       status: 'ステータス',
       expectedDelivery: '予定配達日',
-      actualDelivery: '実際の配達日'
+      actualDelivery: '実際の配達日',
+      leadTime: 'リードタイム'
     }
   },
 
@@ -204,6 +240,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    submitted: '送信済み',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,10 +1,12 @@
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
+import './styles/design-tokens.css'
 import App from './App.vue'
 import Dashboard from './views/Dashboard.vue'
 import Inventory from './views/Inventory.vue'
 import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
+import Restocking from './views/Restocking.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
 
@@ -15,6 +17,7 @@ const router = createRouter({
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
+    { path: '/restocking', component: Restocking },
     { path: '/spending', component: Spending },
     { path: '/reports', component: Reports }
   ]

--- a/client/src/styles/design-tokens.css
+++ b/client/src/styles/design-tokens.css
@@ -1,0 +1,51 @@
+/*
+ * design-tokens.css — design-token layer for the SaaS redesign.
+ * Color values are seeded from the app's existing slate palette so the redesign
+ * changes structure and consistency without a jarring repaint. Imported once in main.js.
+ */
+:root {
+  /* Color roles (seeded from the app's existing palette) */
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f1f5f9;
+  --color-border: #e2e8f0;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+
+  --color-accent: #2563eb;
+  --color-accent-weak: #eff6ff;
+  --color-accent-strong: #1d4ed8;
+
+  --color-success: #059669;
+  --color-warning: #ea580c;
+  --color-danger: #dc2626;
+  --color-info: #2563eb;
+
+  /* Spacing scale (4px base) */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
+  --space-5: 24px; --space-6: 32px; --space-7: 48px; --space-8: 64px;
+
+  /* Radius */
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08);
+
+  /* Typography */
+  --text-xs: 12px; --text-sm: 14px; --text-base: 15px;
+  --text-lg: 18px; --text-xl: 24px; --text-2xl: 30px;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Shell dimensions */
+  --sidebar-width: 248px;
+  --sidebar-width-collapsed: 68px;
+}
+
+/* Accessibility: a consistent, visible focus ring on interactive elements. */
+:where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -304,12 +304,14 @@ import { useI18n } from '../composables/useI18n'
 import { formatCurrency } from '../utils/currency'
 import ProductDetailModal from '../components/ProductDetailModal.vue'
 import BacklogDetailModal from '../components/BacklogDetailModal.vue'
+import PurchaseOrderModal from '../components/PurchaseOrderModal.vue'
 
 export default {
   name: 'Dashboard',
   components: {
     ProductDetailModal,
     BacklogDetailModal,
+    PurchaseOrderModal,
   },
   setup() {
     const { t, currentCurrency, translateProductName, translateWarehouse } = useI18n()

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -25,11 +25,64 @@
           <div class="stat-label">{{ t('status.backordered') }}</div>
           <div class="stat-value">{{ getOrdersByStatus('Backordered').length }}</div>
         </div>
+        <div class="stat-card info">
+          <div class="stat-label">{{ t('status.submitted') }}</div>
+          <div class="stat-value">{{ submittedOrders.length }}</div>
+        </div>
+      </div>
+
+      <!-- Submitted restock orders surface here with their delivery lead time -->
+      <div v-if="submittedOrders.length" class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('orders.submittedOrders') }} ({{ submittedOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-items">{{ t('orders.table.items') }}</th>
+                <th class="col-status">{{ t('orders.table.status') }}</th>
+                <th class="col-date">{{ t('orders.table.orderDate') }}</th>
+                <th class="col-date">{{ t('orders.table.leadTime') }}</th>
+                <th class="col-date">{{ t('orders.table.expectedDelivery') }}</th>
+                <th class="col-value">{{ t('orders.table.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_price }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-status">
+                  <span :class="['badge', getOrderStatusClass(order.status)]">
+                    {{ t(`status.${order.status.toLowerCase()}`) }}
+                  </span>
+                </td>
+                <td class="col-date">{{ formatDate(order.order_date) }}</td>
+                <td class="col-date">{{ orderLeadTime(order) }} {{ t('restocking.days') }}</td>
+                <td class="col-date">{{ formatDate(order.expected_delivery) }}</td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
+          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ regularOrders.length }})</h3>
         </div>
         <div class="table-container">
           <table class="orders-table">
@@ -45,7 +98,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="order in orders" :key="order.id">
+              <tr v-for="order in regularOrders" :key="order.id">
                 <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
                 <td class="col-customer">{{ translateCustomerName(order.customer) }}</td>
                 <td class="col-items">
@@ -133,12 +186,35 @@ export default {
       return orders.value.filter(order => order.status === status)
     }
 
+    // Submitted restock orders get their own section; keep them out of the main list to avoid duplication.
+    const submittedOrders = computed(() =>
+      orders.value
+        .filter(order => order.status === 'Submitted')
+        .sort((a, b) => new Date(b.order_date) - new Date(a.order_date)) // newest first
+    )
+
+    const regularOrders = computed(() =>
+      orders.value.filter(order => order.status !== 'Submitted')
+    )
+
+    // Order-level lead time = the slowest line, since the order is only complete once its last item arrives.
+    const orderLeadTime = (order) => {
+      const leads = (order.items || [])
+        .map(item => item.lead_time_days)
+        .filter(n => typeof n === 'number')
+      if (leads.length) return Math.max(...leads)
+      // Fallback for orders without per-line lead time: derive from the date span.
+      const days = Math.round((new Date(order.expected_delivery) - new Date(order.order_date)) / 86400000)
+      return Number.isFinite(days) ? days : 0
+    }
+
     const getOrderStatusClass = (status) => {
       const statusMap = {
         'Delivered': 'success',
         'Shipped': 'info',
         'Processing': 'warning',
-        'Backordered': 'danger'
+        'Backordered': 'danger',
+        'Submitted': 'info'
       }
       return statusMap[status] || 'info'
     }
@@ -160,6 +236,9 @@ export default {
       loading,
       error,
       orders,
+      submittedOrders,
+      regularOrders,
+      orderLeadTime,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,331 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Budget control -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.budgetLabel') }}</h3>
+          <div class="budget-readout">{{ formatCurrency(budget) }}</div>
+        </div>
+        <input
+          type="range"
+          class="budget-slider"
+          min="0"
+          :max="maxBudget"
+          :step="sliderStep"
+          v-model.number="budget"
+        />
+        <div class="slider-scale">
+          <span>{{ formatCurrency(0) }}</span>
+          <span>{{ formatCurrency(maxBudget) }}</span>
+        </div>
+        <p class="budget-help">{{ t('restocking.budgetHelp') }}</p>
+      </div>
+
+      <!-- Summary -->
+      <div class="stats-grid">
+        <div class="stat-card info">
+          <div class="stat-label">{{ t('restocking.summary.budget') }}</div>
+          <div class="stat-value">{{ formatCurrency(budget) }}</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">{{ t('restocking.summary.items') }}</div>
+          <div class="stat-value">{{ recommendations.length }}</div>
+        </div>
+        <div class="stat-card warning">
+          <div class="stat-label">{{ t('restocking.summary.totalCost') }}</div>
+          <div class="stat-value">{{ formatCurrency(totalCost) }}</div>
+        </div>
+        <div class="stat-card success">
+          <div class="stat-label">{{ t('restocking.summary.remaining') }}</div>
+          <div class="stat-value">{{ formatCurrency(remaining) }}</div>
+        </div>
+      </div>
+
+      <!-- Recommendations -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.recommended') }} ({{ recommendations.length }})</h3>
+        </div>
+
+        <div v-if="recommendations.length === 0" class="empty-state">
+          {{ t('restocking.noRecommendations') }}
+        </div>
+
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>{{ t('restocking.table.sku') }}</th>
+                <th>{{ t('restocking.table.itemName') }}</th>
+                <th>{{ t('restocking.table.trend') }}</th>
+                <th>{{ t('restocking.table.restockQty') }}</th>
+                <th>{{ t('restocking.table.unitCost') }}</th>
+                <th>{{ t('restocking.table.lineCost') }}</th>
+                <th>{{ t('restocking.table.leadTime') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendations" :key="item.id">
+                <td><strong>{{ item.sku }}</strong></td>
+                <td>{{ item.name }}</td>
+                <td>
+                  <span :class="['badge', item.trend]">{{ t(`trends.${item.trend}`) }}</span>
+                </td>
+                <td><strong>{{ item.gap.toLocaleString() }}</strong></td>
+                <td>{{ formatCurrency(item.unitCost) }}</td>
+                <td>{{ formatCurrency(item.lineCost) }}</td>
+                <td>{{ item.leadTimeDays }} {{ t('restocking.days') }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Place order -->
+      <div class="order-actions">
+        <div v-if="successMessage" class="success-banner">
+          {{ successMessage }}
+          <router-link to="/orders" class="success-link">{{ t('nav.orders') }} →</router-link>
+        </div>
+        <div v-if="submitError" class="error">{{ submitError }}</div>
+        <button
+          class="place-order-btn"
+          :disabled="recommendations.length === 0 || submitting"
+          @click="placeOrder"
+        >
+          {{ submitting ? t('restocking.placing') : t('restocking.placeOrder') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+// Lead time (days) by demand trend — mirrors the backend's authoritative mapping so the
+// table can preview delivery speed before the order is actually submitted.
+const LEAD_TIME_BY_TREND = { increasing: 7, stable: 14, decreasing: 21 }
+const DEFAULT_LEAD_TIME_DAYS = 14
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency } = useI18n()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const allForecasts = ref([])
+    const budget = ref(0)
+    const submitting = ref(false)
+    const successMessage = ref('')
+    const submitError = ref('')
+
+    const currencySymbol = computed(() => (currentCurrency.value === 'JPY' ? '¥' : '$'))
+    const formatCurrency = (n) => `${currencySymbol.value}${Math.round(n || 0).toLocaleString()}`
+
+    // Candidate restock lines: only items whose forecast exceeds current demand (a real shortfall).
+    // Restock quantity is the gap; line cost prices the gap at the forecast item's unit_cost.
+    const candidates = computed(() => {
+      return allForecasts.value
+        .filter((f) => f.forecasted_demand > f.current_demand)
+        .map((f) => {
+          const gap = f.forecasted_demand - f.current_demand
+          return {
+            id: f.id,
+            sku: f.item_sku,
+            name: f.item_name,
+            trend: f.trend,
+            gap,
+            unitCost: f.unit_cost,
+            lineCost: gap * f.unit_cost,
+            leadTimeDays: LEAD_TIME_BY_TREND[f.trend] ?? DEFAULT_LEAD_TIME_DAYS
+          }
+        })
+        .sort((a, b) => b.gap - a.gap) // biggest shortfall first
+    })
+
+    // Full cost to cover every shortfall — used as the slider's upper bound.
+    const maxBudget = computed(() =>
+      Math.ceil(candidates.value.reduce((sum, c) => sum + c.lineCost, 0))
+    )
+
+    // Round the slider step so dragging lands on tidy numbers regardless of total size.
+    const sliderStep = computed(() => Math.max(100, Math.round(maxBudget.value / 100)))
+
+    // Greedy fit: walk candidates (biggest shortfall first) and take each whole line that
+    // still fits the remaining budget. Whole lines only — no partial quantities.
+    const recommendations = computed(() => {
+      const picked = []
+      let spent = 0
+      for (const c of candidates.value) {
+        if (spent + c.lineCost <= budget.value) {
+          picked.push(c)
+          spent += c.lineCost
+        }
+      }
+      return picked
+    })
+
+    const totalCost = computed(() => recommendations.value.reduce((sum, r) => sum + r.lineCost, 0))
+    const remaining = computed(() => budget.value - totalCost.value)
+
+    const loadForecasts = async () => {
+      try {
+        loading.value = true
+        allForecasts.value = await api.getDemandForecasts()
+        // Start at half the full-coverage cost so the page opens with a meaningful recommendation.
+        budget.value = Math.round(maxBudget.value / 2)
+      } catch (err) {
+        error.value = 'Failed to load demand forecasts: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const placeOrder = async () => {
+      if (recommendations.value.length === 0) return
+      try {
+        submitting.value = true
+        submitError.value = ''
+        successMessage.value = ''
+        const payload = {
+          budget: budget.value,
+          items: recommendations.value.map((r) => ({
+            sku: r.sku,
+            name: r.name,
+            quantity: r.gap,
+            unit_price: r.unitCost,
+            trend: r.trend
+          }))
+        }
+        const order = await api.submitRestockOrder(payload)
+        successMessage.value = t('restocking.successMessage', { orderNumber: order.order_number })
+      } catch (err) {
+        submitError.value = t('restocking.errorMessage', { error: err.message })
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    onMounted(loadForecasts)
+
+    return {
+      t,
+      loading,
+      error,
+      budget,
+      maxBudget,
+      sliderStep,
+      recommendations,
+      totalCost,
+      remaining,
+      submitting,
+      successMessage,
+      submitError,
+      formatCurrency,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-readout {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2563eb;
+  letter-spacing: -0.025em;
+}
+
+.budget-slider {
+  width: 100%;
+  margin: 0.5rem 0 0.25rem;
+  accent-color: #2563eb;
+  cursor: pointer;
+}
+
+.slider-scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.budget-help {
+  margin-top: 0.75rem;
+  font-size: 0.813rem;
+  color: #64748b;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+.order-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.place-order-btn {
+  padding: 0.75rem 1.75rem;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.938rem;
+  cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+.place-order-btn:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.place-order-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.success-banner {
+  width: 100%;
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  color: #065f46;
+  padding: 0.875rem 1rem;
+  border-radius: 8px;
+  font-size: 0.938rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.success-link {
+  color: #047857;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.success-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecture — Factory Inventory Management System</title>
+<style>
+  /* Design system mirrors the app's CLAUDE.md: slate palette, status colors, no emojis. */
+  :root{
+    --ink:#0f172a; --muted:#64748b; --line:#e2e8f0; --bg:#f8fafc; --panel:#ffffff;
+    --green:#16a34a; --blue:#2563eb; --amber:#d97706; --red:#dc2626;
+    --green-bg:#ecfdf5; --blue-bg:#eff6ff; --amber-bg:#fffbeb; --slate-bg:#f1f5f9;
+    --radius:10px;
+    --mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;font-size:15px}
+  .wrap{max-width:1080px;margin:0 auto;padding:48px 24px 80px}
+  header.page{border-bottom:1px solid var(--line);padding-bottom:24px;margin-bottom:40px}
+  header.page .eyebrow{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-weight:600}
+  header.page h1{margin:8px 0 6px;font-size:30px;letter-spacing:-.02em}
+  header.page p{margin:0;color:var(--muted);max-width:70ch}
+  .ports{margin-top:16px;display:flex;gap:10px;flex-wrap:wrap}
+  .pill{font-family:var(--mono);font-size:12px;padding:4px 10px;border-radius:999px;border:1px solid var(--line);background:var(--panel);color:var(--muted)}
+  .pill b{color:var(--ink)}
+
+  section{margin:0 0 44px}
+  h2{font-size:13px;letter-spacing:.10em;text-transform:uppercase;color:var(--muted);font-weight:700;margin:0 0 16px;padding-bottom:8px;border-bottom:1px solid var(--line)}
+  h3{font-size:15px;margin:0 0 8px}
+
+  .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+  .grid2{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}
+  @media(max-width:820px){.grid3,.grid2{grid-template-columns:1fr}}
+
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:18px}
+  .card .tag{font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+  .card ul{margin:10px 0 0;padding-left:0;list-style:none}
+  .card li{display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-top:1px solid var(--line);font-size:14px}
+  .card li:first-child{border-top:none}
+  .card li span.k{color:var(--ink);font-weight:500}
+  .card li span.v{color:var(--muted);font-family:var(--mono);font-size:12.5px;text-align:right}
+
+  /* architecture diagram */
+  .diagram{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:28px}
+  .tier{border:1px solid var(--line);border-radius:8px;padding:14px 16px;background:var(--slate-bg)}
+  .tier .tt{font-weight:600;font-size:14px}
+  .tier .td{color:var(--muted);font-size:12.5px;margin-top:3px;font-family:var(--mono)}
+  .tier.client{background:var(--blue-bg);border-color:#bfdbfe}
+  .tier.server{background:var(--green-bg);border-color:#bbf7d0}
+  .tier.data{background:var(--amber-bg);border-color:#fde68a}
+  .arrow{display:flex;flex-direction:column;align-items:center;color:var(--muted);font-size:11px;font-family:var(--mono);padding:8px 0}
+  .arrow .ln{font-size:18px;line-height:1}
+  .stack-col{display:flex;flex-direction:column}
+  .sub{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px}
+  @media(max-width:820px){.sub{grid-template-columns:1fr}}
+  .chip{font-family:var(--mono);font-size:11.5px;background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:6px 8px;color:var(--ink)}
+
+  /* data flow */
+  ol.flow{counter-reset:step;list-style:none;margin:0;padding:0}
+  ol.flow li{position:relative;padding:12px 14px 12px 46px;border:1px solid var(--line);border-radius:8px;background:var(--panel);margin-bottom:10px}
+  ol.flow li::before{counter-increment:step;content:counter(step);position:absolute;left:12px;top:11px;width:22px;height:22px;border-radius:50%;background:var(--ink);color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center}
+  ol.flow code{font-family:var(--mono);font-size:12.5px;background:var(--slate-bg);padding:1px 5px;border-radius:4px}
+
+  table{width:100%;border-collapse:collapse;background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;font-size:13.5px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{background:var(--slate-bg);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted)}
+  tr:last-child td{border-bottom:none}
+  td code,.path{font-family:var(--mono);font-size:12.5px}
+  .m{font-family:var(--mono);font-size:11px;font-weight:700;padding:2px 7px;border-radius:5px}
+  .m.get{background:var(--blue-bg);color:var(--blue)} .m.post{background:var(--green-bg);color:var(--green)}
+  .m.del{background:var(--amber-bg);color:var(--red)} .m.patch{background:var(--amber-bg);color:var(--amber)}
+
+  .notes{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
+  @media(max-width:820px){.notes{grid-template-columns:1fr}}
+  .note{border:1px solid var(--line);border-left:3px solid var(--muted);border-radius:8px;padding:12px 14px;background:var(--panel)}
+  .note.g{border-left-color:var(--green)} .note.b{border-left-color:var(--blue)}
+  .note.a{border-left-color:var(--amber)} .note.r{border-left-color:var(--red)}
+  .note b{font-size:14px} .note p{margin:4px 0 0;color:var(--muted);font-size:13px}
+
+  footer{margin-top:56px;padding-top:20px;border-top:1px solid var(--line);color:var(--muted);font-size:12.5px}
+  footer code{font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="page">
+    <div class="eyebrow">System Architecture</div>
+    <h1>Factory Inventory Management System</h1>
+    <p>Full-stack demo: a Vue 3 single-page app talking to a Python FastAPI service over a REST API,
+       served from in-memory JSON mock data (no database, no authentication, no persistence).</p>
+    <div class="ports">
+      <span class="pill">Frontend <b>localhost:3000</b></span>
+      <span class="pill">Backend <b>localhost:8001</b></span>
+      <span class="pill">API docs <b>:8001/docs</b></span>
+    </div>
+  </header>
+
+  <!-- 1. TECH STACK -->
+  <section>
+    <h2>Tech stack</h2>
+    <div class="grid3">
+      <div class="card">
+        <div class="tag" style="color:var(--blue)">Frontend · client/</div>
+        <ul>
+          <li><span class="k">Framework</span><span class="v">Vue 3 (Composition API)</span></li>
+          <li><span class="k">Routing</span><span class="v">Vue Router 4</span></li>
+          <li><span class="k">HTTP client</span><span class="v">Axios</span></li>
+          <li><span class="k">Build tool</span><span class="v">Vite 5</span></li>
+          <li><span class="k">State</span><span class="v">composables (no Pinia)</span></li>
+          <li><span class="k">i18n</span><span class="v">en / ja</span></li>
+          <li><span class="k">Dev port</span><span class="v">3000</span></li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="tag" style="color:var(--green)">Backend · server/</div>
+        <ul>
+          <li><span class="k">Framework</span><span class="v">FastAPI</span></li>
+          <li><span class="k">ASGI server</span><span class="v">Uvicorn</span></li>
+          <li><span class="k">Validation</span><span class="v">Pydantic v2</span></li>
+          <li><span class="k">Language</span><span class="v">Python ≥ 3.11</span></li>
+          <li><span class="k">CORS</span><span class="v">allow_origins ["*"]</span></li>
+          <li><span class="k">Run port</span><span class="v">8001</span></li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="tag" style="color:var(--amber)">Data &amp; tooling</div>
+        <ul>
+          <li><span class="k">Store</span><span class="v">JSON files, in-memory</span></li>
+          <li><span class="k">Loader</span><span class="v">mock_data.py</span></li>
+          <li><span class="k">Location</span><span class="v">server/data/*.json</span></li>
+          <li><span class="k">Tests</span><span class="v">pytest + TestClient</span></li>
+          <li><span class="k">Pkg mgrs</span><span class="v">npm · uv</span></li>
+          <li><span class="k">MCP</span><span class="v">playwright · github</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2. ARCHITECTURE DIAGRAM -->
+  <section>
+    <h2>System architecture</h2>
+    <div class="diagram">
+      <div class="stack-col">
+
+        <div class="tier">
+          <div class="tt">Browser</div>
+          <div class="td">user · loads the SPA</div>
+        </div>
+
+        <div class="arrow"><span class="ln">&#8595;</span><span>loads</span></div>
+
+        <div class="tier client">
+          <div class="tt">Vue 3 SPA &nbsp;·&nbsp; Vite dev server :3000</div>
+          <div class="td">main.js → App.vue → &lt;router-view&gt; · 6 routed views · modals</div>
+          <div class="sub">
+            <div class="chip">composables: useFilters · useAuth · useI18n</div>
+            <div class="chip">client/src/api.js (Axios)</div>
+          </div>
+        </div>
+
+        <div class="arrow">
+          <span class="ln">&#8595;</span>
+          <span>HTTP GET/POST/PATCH/DELETE · JSON · CORS *</span>
+          <span>base: http://localhost:8001/api</span>
+        </div>
+
+        <div class="tier server">
+          <div class="tt">FastAPI application &nbsp;·&nbsp; Uvicorn :8001</div>
+          <div class="td">server/main.py — route handlers + CORS middleware</div>
+          <div class="sub">
+            <div class="chip">filter layer: apply_filters() · filter_by_month() (QUARTER_MAP)</div>
+            <div class="chip">Pydantic models — response validation</div>
+          </div>
+        </div>
+
+        <div class="arrow"><span class="ln">&#8595;</span><span>reads in-memory lists</span></div>
+
+        <div class="tier data">
+          <div class="tt">mock_data.py &nbsp;·&nbsp; loaded once at startup</div>
+          <div class="td">server/data/*.json → inventory · orders · demand_forecasts · backlog_items · spending · transactions · purchase_orders</div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. DATA FLOW -->
+  <section>
+    <h2>Data flow — a filtered request</h2>
+    <ol class="flow">
+      <li>A view (e.g. <code>Orders.vue</code>) reads the global filter state from <code>useFilters()</code> — warehouse, category, status, period.</li>
+      <li>It calls an <code>api.js</code> function (e.g. <code>getOrders(filters)</code>), which serializes filters into a query string.</li>
+      <li>Axios sends an HTTP request to <code>http://localhost:8001/api/orders?warehouse=…&amp;status=…&amp;month=…</code>.</li>
+      <li>FastAPI matches the route in <code>main.py</code>; query params arrive as typed, optional arguments.</li>
+      <li>The handler runs <code>apply_filters()</code> then <code>filter_by_month()</code> over the in-memory list (plain list comprehensions; quarters expand via <code>QUARTER_MAP</code>).</li>
+      <li>The result is validated/serialized through a Pydantic <code>response_model</code> and returned as JSON.</li>
+      <li>The view stores raw data in <code>ref</code>s; derived values (totals, badges) come from <code>computed</code> properties and render in the table/charts.</li>
+    </ol>
+  </section>
+
+  <!-- 4. FRONTEND STRUCTURE -->
+  <section>
+    <h2>Frontend structure</h2>
+    <div class="grid3">
+      <div class="card">
+        <h3>Routed views</h3>
+        <p style="color:var(--muted);font-size:13px;margin:0 0 4px">client/src/views/*.vue</p>
+        <ul>
+          <li><span class="k">/</span><span class="v">Dashboard</span></li>
+          <li><span class="k">/inventory</span><span class="v">Inventory</span></li>
+          <li><span class="k">/orders</span><span class="v">Orders</span></li>
+          <li><span class="k">/demand</span><span class="v">Demand</span></li>
+          <li><span class="k">/spending</span><span class="v">Spending</span></li>
+          <li><span class="k">/reports</span><span class="v">Reports</span></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Composables (shared state)</h3>
+        <p style="color:var(--muted);font-size:13px;margin:0 0 4px">client/src/composables/</p>
+        <ul>
+          <li><span class="k">useFilters</span><span class="v">global filter refs</span></li>
+          <li><span class="k">useAuth</span><span class="v">mock user</span></li>
+          <li><span class="k">useI18n</span><span class="v">en/ja + currency</span></li>
+        </ul>
+        <p style="color:var(--muted);font-size:12.5px;margin:10px 0 0">Singleton refs shared across views — filters persist on navigation.</p>
+      </div>
+      <div class="card">
+        <h3>Components &amp; modals</h3>
+        <p style="color:var(--muted);font-size:13px;margin:0 0 4px">client/src/components/</p>
+        <ul>
+          <li><span class="k">FilterBar</span><span class="v">drives useFilters</span></li>
+          <li><span class="k">*DetailModal</span><span class="v">inventory · product · cost · backlog</span></li>
+          <li><span class="k">TasksModal</span><span class="v">task CRUD</span></li>
+          <li><span class="k">ProfileMenu</span><span class="v">nav · language</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5. BACKEND API -->
+  <section>
+    <h2>Backend API · server/main.py</h2>
+    <table>
+      <thead><tr><th>Method</th><th>Path</th><th>Filters / params</th><th>Returns</th></tr></thead>
+      <tbody>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/inventory</td><td>warehouse, category</td><td>List[InventoryItem]</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/inventory/{id}</td><td>—</td><td>InventoryItem (404 if missing)</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/orders</td><td>warehouse, category, status, month</td><td>List[Order]</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/orders/{id}</td><td>—</td><td>Order (404 if missing)</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/demand</td><td>—</td><td>List[DemandForecast]</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/backlog</td><td>—</td><td>List[BacklogItem] (+ has_purchase_order)</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/dashboard/summary</td><td>warehouse, category, status, month</td><td>summary KPIs (computed)</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/spending/{summary|monthly|categories|transactions}</td><td>—</td><td>spending datasets</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/reports/{quarterly|monthly-trends}</td><td>—</td><td>aggregated stats (computed)</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/tasks</td><td>—</td><td>List[Task]</td></tr>
+        <tr><td><span class="m post">POST</span></td><td class="path">/api/tasks</td><td>body</td><td>created Task</td></tr>
+        <tr><td><span class="m patch">PATCH</span></td><td class="path">/api/tasks/{id}</td><td>—</td><td>toggled Task</td></tr>
+        <tr><td><span class="m del">DELETE</span></td><td class="path">/api/tasks/{id}</td><td>—</td><td>deletion result</td></tr>
+        <tr><td><span class="m post">POST</span></td><td class="path">/api/purchase-orders</td><td>body</td><td>created PurchaseOrder</td></tr>
+        <tr><td><span class="m get">GET</span></td><td class="path">/api/purchase-orders/{backlogItemId}</td><td>—</td><td>PurchaseOrder for backlog item</td></tr>
+      </tbody>
+    </table>
+
+    <div style="height:16px"></div>
+
+    <h3>Data entities · server/data/*.json</h3>
+    <table>
+      <thead><tr><th>File</th><th>Entity</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td class="path">inventory.json</td><td>Inventory items</td><td>sku, category, warehouse, qty_on_hand, reorder_point, unit_cost</td></tr>
+        <tr><td class="path">orders.json</td><td>Customer orders</td><td>~500 records, 2025-01 → 2025-12; status, total_value, dates</td></tr>
+        <tr><td class="path">demand_forecasts.json</td><td>Demand forecasts</td><td>current vs forecasted demand, trend</td></tr>
+        <tr><td class="path">backlog_items.json</td><td>Backlog</td><td>qty needed/available, days_delayed, priority</td></tr>
+        <tr><td class="path">spending.json</td><td>Financials</td><td>summary + 12 months + categories</td></tr>
+        <tr><td class="path">transactions.json</td><td>Transactions</td><td>amount, vendor, type</td></tr>
+        <tr><td class="path">purchase_orders.json</td><td>Purchase orders</td><td>created at runtime (starts empty)</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- 6. KEY CHARACTERISTICS -->
+  <section>
+    <h2>Key characteristics</h2>
+    <div class="notes">
+      <div class="note a"><b>In-memory only</b><p>JSON loaded once at startup. Writes (tasks, purchase orders) live in process memory and reset on restart — no database.</p></div>
+      <div class="note r"><b>No authentication</b><p>All endpoints are public; <code>useAuth</code> returns a mock user. Not production-hardened.</p></div>
+      <div class="note b"><b>Direct API calls</b><p>No Vite proxy — the frontend hits a hardcoded <code>http://localhost:8001/api</code>; backend CORS is fully open.</p></div>
+      <div class="note g"><b>Computed at request time</b><p>Dashboard, reports and backlog flags are derived per request from the filtered lists, not stored.</p></div>
+    </div>
+  </section>
+
+  <footer>
+    Static architecture overview generated from source inspection ·
+    key sources: <code>client/src/main.js</code>, <code>client/src/api.js</code>,
+    <code>server/main.py</code>, <code>server/mock_data.py</code>, <code>server/data/</code>.
+    Self-contained HTML — no external dependencies; does not require the dev servers to be running.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -6,7 +6,8 @@
     "current_demand": 300,
     "forecasted_demand": 450,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 12.50
   },
   {
     "id": "2",
@@ -15,7 +16,8 @@
     "current_demand": 150,
     "forecasted_demand": 152,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 34.00
   },
   {
     "id": "3",
@@ -24,7 +26,8 @@
     "current_demand": 500,
     "forecasted_demand": 600,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 8.75
   },
   {
     "id": "4",
@@ -33,7 +36,8 @@
     "current_demand": 50,
     "forecasted_demand": 35,
     "trend": "decreasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 245.00
   },
   {
     "id": "5",
@@ -42,7 +46,8 @@
     "current_demand": 800,
     "forecasted_demand": 950,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 6.25
   },
   {
     "id": "6",
@@ -51,7 +56,8 @@
     "current_demand": 120,
     "forecasted_demand": 121,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 52.00
   },
   {
     "id": "7",
@@ -60,7 +66,8 @@
     "current_demand": 250,
     "forecasted_demand": 252,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 18.99
   },
   {
     "id": "8",
@@ -69,7 +76,8 @@
     "current_demand": 180,
     "forecasted_demand": 182,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 89.50
   },
   {
     "id": "9",
@@ -78,6 +86,7 @@
     "current_demand": 95,
     "forecasted_demand": 96,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 47.00
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -1,10 +1,16 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
+from datetime import datetime, timedelta
 from pydantic import BaseModel
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
+
+# Delivery lead time (days) by demand trend — hot items ship faster, declining items wait longer.
+# Used to derive each restock line's lead time and the order's expected delivery date.
+LEAD_TIME_BY_TREND = {"increasing": 7, "stable": 14, "decreasing": 21}
+DEFAULT_LEAD_TIME_DAYS = 14
 
 # Quarter mapping for date filtering
 QUARTER_MAP = {
@@ -89,6 +95,7 @@ class DemandForecast(BaseModel):
     forecasted_demand: int
     trend: str
     period: str
+    unit_cost: float
 
 class BacklogItem(BaseModel):
     id: str
@@ -119,6 +126,18 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_price: float
+    trend: Optional[str] = None
+
+class CreateRestockOrderRequest(BaseModel):
+    items: List[RestockOrderItem]
+    budget: Optional[float] = None
+    warehouse: Optional[str] = None
 
 # API endpoints
 @app.get("/")
@@ -165,6 +184,60 @@ def get_order(order_id: str):
 def get_demand_forecasts():
     """Get demand forecasts"""
     return demand_forecasts
+
+@app.post("/api/restock-orders", response_model=Order)
+def create_restock_order(request: CreateRestockOrderRequest):
+    """Submit a restocking order built from budget-fitted recommendations.
+
+    Appends a new order (status 'Submitted') to the in-memory orders list so it
+    surfaces in GET /api/orders. Lead time varies by each line's demand trend; the
+    order's expected delivery uses the longest line lead time (the order is only
+    complete once its slowest item arrives).
+    """
+    if not request.items:
+        raise HTTPException(status_code=400, detail="No items to order")
+
+    now = datetime.now()
+
+    # Per-line lead time from trend; the order ships fully only when the slowest line lands.
+    max_lead_days = DEFAULT_LEAD_TIME_DAYS
+    order_items = []
+    for line in request.items:
+        lead_days = LEAD_TIME_BY_TREND.get(line.trend, DEFAULT_LEAD_TIME_DAYS)
+        max_lead_days = max(max_lead_days, lead_days)
+        order_items.append({
+            "sku": line.sku,
+            "name": line.name,
+            "quantity": line.quantity,
+            "unit_price": line.unit_price,
+            "lead_time_days": lead_days,
+        })
+
+    total_value = round(sum(line.quantity * line.unit_price for line in request.items), 2)
+
+    # Sequence restock orders independently of seeded orders so numbers stay readable.
+    restock_count = sum(1 for o in orders if o.get("order_number", "").startswith("RST-")) + 1
+
+    new_order = {
+        "id": f"restock-{now.strftime('%Y%m%d%H%M%S')}-{restock_count}",
+        "order_number": f"RST-2025-{restock_count:04d}",
+        "customer": "Internal Restock",
+        "items": order_items,
+        "status": "Submitted",
+        "order_date": now.isoformat(timespec="seconds"),
+        "expected_delivery": (now + timedelta(days=max_lead_days)).isoformat(timespec="seconds"),
+        "total_value": total_value,
+        "actual_delivery": None,
+        "warehouse": request.warehouse,
+        "category": "Restock",
+    }
+    orders.append(new_order)
+    return new_order
+
+@app.get("/api/restock-orders", response_model=List[Order])
+def get_restock_orders():
+    """Get submitted restock orders (status 'Submitted')."""
+    return [o for o in orders if o.get("status") == "Submitted"]
 
 @app.get("/api/backlog", response_model=List[BacklogItem])
 def get_backlog():
@@ -303,6 +376,80 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+# In-memory tasks store
+tasks_store = []
+_task_counter = [1]  # mutable list so it can be mutated from nested scope
+
+class Task(BaseModel):
+    id: str
+    title: str
+    priority: Optional[str] = "medium"
+    status: str = "pending"
+
+class CreateTaskRequest(BaseModel):
+    title: str
+    priority: Optional[str] = "medium"
+
+@app.get("/api/tasks", response_model=List[Task])
+def get_tasks():
+    return tasks_store
+
+@app.post("/api/tasks", response_model=Task)
+def create_task(task: CreateTaskRequest):
+    new_task = {
+        "id": f"task-{_task_counter[0]}",
+        "title": task.title,
+        "priority": task.priority or "medium",
+        "status": "pending",
+    }
+    _task_counter[0] += 1
+    tasks_store.append(new_task)
+    return new_task
+
+@app.delete("/api/tasks/{task_id}")
+def delete_task(task_id: str):
+    task = next((t for t in tasks_store if t["id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    tasks_store.remove(task)
+    return {"success": True}
+
+@app.patch("/api/tasks/{task_id}", response_model=Task)
+def toggle_task(task_id: str):
+    task = next((t for t in tasks_store if t["id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task["status"] = "completed" if task["status"] == "pending" else "pending"
+    return task
+
+@app.post("/api/purchase-orders", response_model=PurchaseOrder)
+def create_purchase_order(request: CreatePurchaseOrderRequest):
+    backlog_item = next((item for item in backlog_items if item["id"] == request.backlog_item_id), None)
+    if not backlog_item:
+        raise HTTPException(status_code=404, detail="Backlog item not found")
+
+    now = datetime.now()
+    new_po = {
+        "id": f"po-{now.strftime('%Y%m%d%H%M%S')}-{len(purchase_orders) + 1}",
+        "backlog_item_id": request.backlog_item_id,
+        "supplier_name": request.supplier_name,
+        "quantity": request.quantity,
+        "unit_cost": request.unit_cost,
+        "expected_delivery_date": request.expected_delivery_date,
+        "status": "Pending",
+        "created_date": now.isoformat(timespec="seconds"),
+        "notes": request.notes,
+    }
+    purchase_orders.append(new_po)
+    return new_po
+
+@app.get("/api/purchase-orders/{backlog_item_id}", response_model=PurchaseOrder)
+def get_purchase_order_by_backlog_item(backlog_item_id: str):
+    po = next((po for po in purchase_orders if po["backlog_item_id"] == backlog_item_id), None)
+    if not po:
+        raise HTTPException(status_code=404, detail="Purchase order not found")
+    return po
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/backend/test_restock.py
+++ b/tests/backend/test_restock.py
@@ -1,0 +1,54 @@
+"""
+Tests for the restocking-order endpoints (POST/GET /api/restock-orders).
+"""
+
+
+def _payload():
+    """Two restock lines with different trends to exercise lead-time selection."""
+    return {
+        "budget": 5000,
+        "items": [
+            {"sku": "WDG-001", "name": "Industrial Widget Type A",
+             "quantity": 150, "unit_price": 12.50, "trend": "increasing"},
+            {"sku": "GSK-203", "name": "High-Temperature Gasket",
+             "quantity": 100, "unit_price": 8.75, "trend": "stable"},
+        ],
+    }
+
+
+def test_demand_forecast_includes_unit_cost(client):
+    """Forecast items now carry unit_cost so the frontend can budget against them."""
+    resp = client.get("/api/demand")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) > 0
+    assert all("unit_cost" in item for item in data)
+
+
+def test_submit_restock_order(client):
+    resp = client.post("/api/restock-orders", json=_payload())
+    assert resp.status_code == 200
+    order = resp.json()
+
+    assert order["status"] == "Submitted"
+    assert order["order_number"].startswith("RST-")
+    # total_value = sum(qty * unit_price): 150*12.50 + 100*8.75 = 1875 + 875 = 2750
+    assert order["total_value"] == 2750.0
+    # Order completes with the slowest line: stable (14d) beats increasing (7d).
+    assert "lead_time_days" in order["items"][0]
+    assert max(i["lead_time_days"] for i in order["items"]) == 14
+
+
+def test_submitted_order_appears_in_orders(client):
+    """A submitted order is appended to the in-memory orders list and shows in GET /api/orders."""
+    created = client.post("/api/restock-orders", json=_payload()).json()
+    all_orders = client.get("/api/orders").json()
+    assert any(o["id"] == created["id"] and o["status"] == "Submitted" for o in all_orders)
+
+    submitted = client.get("/api/restock-orders").json()
+    assert any(o["id"] == created["id"] for o in submitted)
+
+
+def test_submit_empty_order_rejected(client):
+    resp = client.post("/api/restock-orders", json={"items": [], "budget": 1000})
+    assert resp.status_code == 400


### PR DESCRIPTION
- Replace top nav bar with collapsible AppSidebar component backed by design tokens; layout switches to a side-by-side flex model
- Add /restocking route and Restocking.vue: budget-slider-driven view that filters demand-forecast recommendations and submits restock orders
- Backend: POST/GET /api/restock-orders (lead time by trend), CRUD for /api/tasks, POST/GET /api/purchase-orders
- Orders view gains a dedicated Submitted section with lead-time column; regular orders stay in their own table
- Add unit_cost to demand_forecasts.json so the Restocking view can compute line costs without a separate price lookup
- i18n: full EN + JA strings for restocking, sidebar labels, new statuses
- Add PurchaseOrderModal, design-tokens.css, architecture docs, and backend restock tests