### PR TITLE
Add budget-based restocking feature and architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,11 @@ npm install && npm run dev
 - Status: green/blue/yellow/red
 - Charts: Custom SVG, CSS Grid for layouts
 - No emojis in UI
+
+## Restocking Feature (New)
+- Route: `/restocking` → `client/src/views/Restocking.vue`
+- Budget slider ($0–$500K, step $5K) drives demand-based recommendations
+- Algorithm: matches demand_forecasts SKUs to inventory unit_cost, greedy fill within budget, sorts by trend (increasing > stable > decreasing)
+- Backend endpoints: `GET /api/restocking/recommendations?budget=N`, `POST /api/restocking/orders`, `GET /api/restocking/orders`
+- Submitted orders stored in-memory (`mock_data.restocking_orders`), shown in Orders tab under "Submitted Restocking Orders" section with 14-day lead time
+- API methods in `client/src/api.js`: `getRestockingRecommendations`, `placeRestockingOrder`, `getRestockingOrders`

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,6 +25,9 @@
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            Restocking
+          </router-link>
         </nav>
         <LanguageSwitcher />
         <ProfileMenu

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -23,7 +23,7 @@
             {{ t('nav.demandForecast') }}
           </router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
+            {{ t('nav.reports') }}
           </router-link>
           <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
             Restocking

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -102,5 +102,20 @@ export const api = {
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data
+  },
+
+  async getRestockingRecommendations(budget = 0) {
+    const response = await axios.get(`${API_BASE_URL}/restocking/recommendations?budget=${budget}`)
+    return response.data
+  },
+
+  async placeRestockingOrder(items, budget) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/orders`, { items, budget })
+    return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/orders`)
+    return response.data
   }
 }

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -38,6 +38,22 @@ export const api = {
     return response.data
   },
 
+  async getQuarterlyReports(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    const response = await axios.get(`${API_BASE_URL}/reports/quarterly?${params.toString()}`)
+    return response.data
+  },
+
+  async getMonthlyTrends(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+    const response = await axios.get(`${API_BASE_URL}/reports/monthly-trends?${params.toString()}`)
+    return response.data
+  },
+
   async getBacklog() {
     const response = await axios.get(`${API_BASE_URL}/backlog`)
     return response.data

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,8 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    reports: 'Reports',
+    backlog: 'Backlog',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -309,6 +311,55 @@ export default {
     english: 'English',
     japanese: 'Japanese',
     selectLanguage: 'Select Language'
+  },
+
+  // Reports
+  reports: {
+    title: 'Performance Reports',
+    description: 'View quarterly performance metrics and monthly trends',
+    quarterlyPerformance: 'Quarterly Performance',
+    monthlyRevenueTrend: 'Monthly Revenue Trend',
+    monthOverMonth: 'Month-over-Month Analysis',
+    totalRevenueYTD: 'Total Revenue (YTD)',
+    avgMonthlyRevenue: 'Avg Monthly Revenue',
+    totalOrdersYTD: 'Total Orders (YTD)',
+    bestQuarter: 'Best Performing Quarter',
+    table: {
+      quarter: 'Quarter',
+      totalOrders: 'Total Orders',
+      totalRevenue: 'Total Revenue',
+      avgOrderValue: 'Avg Order Value',
+      fulfillmentRate: 'Fulfillment Rate',
+      month: 'Month',
+      orders: 'Orders',
+      revenue: 'Revenue',
+      change: 'Change',
+      growthRate: 'Growth Rate'
+    }
+  },
+
+  // Backlog
+  backlog: {
+    title: 'Backlog Management',
+    description: 'Track and resolve inventory shortages',
+    highPriority: 'High Priority',
+    mediumPriority: 'Medium Priority',
+    lowPriority: 'Low Priority',
+    totalItems: 'Total Backlog Items',
+    backlogItems: 'Backlog Items',
+    noBacklog: 'No backlog items - all orders can be fulfilled!',
+    unitsShort: 'units short',
+    days: 'days',
+    table: {
+      orderId: 'Order ID',
+      sku: 'SKU',
+      itemName: 'Item Name',
+      quantityNeeded: 'Quantity Needed',
+      quantityAvailable: 'Quantity Available',
+      shortage: 'Shortage',
+      daysDelayed: 'Days Delayed',
+      priority: 'Priority'
+    }
   },
 
   // Common

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,8 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    reports: 'レポート',
+    backlog: 'バックログ',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -309,6 +311,55 @@ export default {
     english: 'English',
     japanese: '日本語',
     selectLanguage: '言語を選択'
+  },
+
+  // Reports
+  reports: {
+    title: 'パフォーマンスレポート',
+    description: '四半期パフォーマンス指標と月次トレンドを表示',
+    quarterlyPerformance: '四半期パフォーマンス',
+    monthlyRevenueTrend: '月次収益トレンド',
+    monthOverMonth: '前月比分析',
+    totalRevenueYTD: '総収益（年初来）',
+    avgMonthlyRevenue: '平均月次収益',
+    totalOrdersYTD: '総注文数（年初来）',
+    bestQuarter: '最高業績四半期',
+    table: {
+      quarter: '四半期',
+      totalOrders: '総注文数',
+      totalRevenue: '総収益',
+      avgOrderValue: '平均注文額',
+      fulfillmentRate: '履行率',
+      month: '月',
+      orders: '注文数',
+      revenue: '収益',
+      change: '変化',
+      growthRate: '成長率'
+    }
+  },
+
+  // Backlog
+  backlog: {
+    title: 'バックログ管理',
+    description: '在庫不足の追跡と解決',
+    highPriority: '高優先度',
+    mediumPriority: '中優先度',
+    lowPriority: '低優先度',
+    totalItems: 'バックログ総数',
+    backlogItems: 'バックログ品目',
+    noBacklog: 'バックログなし - すべての注文を履行できます！',
+    unitsShort: '単位不足',
+    days: '日',
+    table: {
+      orderId: '注文ID',
+      sku: 'SKU',
+      itemName: '品目名',
+      quantityNeeded: '必要数量',
+      quantityAvailable: '在庫数量',
+      shortage: '不足',
+      daysDelayed: '遅延日数',
+      priority: '優先度'
+    }
   },
 
   // Common

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -1,53 +1,53 @@
 <template>
   <div class="backlog">
     <div class="page-header">
-      <h2>Backlog Management</h2>
-      <p>Track and resolve inventory shortages</p>
+      <h2>{{ t('backlog.title') }}</h2>
+      <p>{{ t('backlog.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading backlog...</div>
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <div class="stats-grid">
         <div class="stat-card danger">
-          <div class="stat-label">High Priority</div>
+          <div class="stat-label">{{ t('backlog.highPriority') }}</div>
           <div class="stat-value">{{ getBacklogByPriority('high').length }}</div>
         </div>
         <div class="stat-card warning">
-          <div class="stat-label">Medium Priority</div>
+          <div class="stat-label">{{ t('backlog.mediumPriority') }}</div>
           <div class="stat-value">{{ getBacklogByPriority('medium').length }}</div>
         </div>
         <div class="stat-card info">
-          <div class="stat-label">Low Priority</div>
+          <div class="stat-label">{{ t('backlog.lowPriority') }}</div>
           <div class="stat-value">{{ getBacklogByPriority('low').length }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Backlog Items</div>
+          <div class="stat-label">{{ t('backlog.totalItems') }}</div>
           <div class="stat-value">{{ backlogItems.length }}</div>
         </div>
       </div>
 
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Backlog Items</h3>
+          <h3 class="card-title">{{ t('backlog.backlogItems') }}</h3>
         </div>
         <div v-if="backlogItems.length === 0" style="padding: 3rem; text-align: center;">
           <p style="font-size: 1.125rem; color: #10b981; font-weight: 600;">
-            ✓ No backlog items - all orders can be fulfilled!
+            {{ t('backlog.noBacklog') }}
           </p>
         </div>
         <div v-else class="table-container">
           <table>
             <thead>
               <tr>
-                <th>Order ID</th>
-                <th>SKU</th>
-                <th>Item Name</th>
-                <th>Quantity Needed</th>
-                <th>Quantity Available</th>
-                <th>Shortage</th>
-                <th>Days Delayed</th>
-                <th>Priority</th>
+                <th>{{ t('backlog.table.orderId') }}</th>
+                <th>{{ t('backlog.table.sku') }}</th>
+                <th>{{ t('backlog.table.itemName') }}</th>
+                <th>{{ t('backlog.table.quantityNeeded') }}</th>
+                <th>{{ t('backlog.table.quantityAvailable') }}</th>
+                <th>{{ t('backlog.table.shortage') }}</th>
+                <th>{{ t('backlog.table.daysDelayed') }}</th>
+                <th>{{ t('backlog.table.priority') }}</th>
               </tr>
             </thead>
             <tbody>
@@ -59,17 +59,17 @@
                 <td>{{ item.quantity_available }}</td>
                 <td>
                   <span class="badge danger">
-                    {{ item.quantity_needed - item.quantity_available }} units short
+                    {{ item.quantity_needed - item.quantity_available }} {{ t('backlog.unitsShort') }}
                   </span>
                 </td>
                 <td>
                   <span :style="{ color: item.days_delayed > 7 ? '#ef4444' : '#f59e0b' }">
-                    {{ item.days_delayed }} days
+                    {{ item.days_delayed }} {{ t('backlog.days') }}
                   </span>
                 </td>
                 <td>
                   <span :class="['badge', item.priority]">
-                    {{ item.priority }}
+                    {{ t(`priority.${item.priority}`) }}
                   </span>
                 </td>
               </tr>
@@ -85,25 +85,23 @@
 import { ref, onMounted, watch, computed } from 'vue'
 import { api } from '../api'
 import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
 
 export default {
   name: 'Backlog',
   setup() {
+    const { t } = useI18n()
     const loading = ref(true)
     const error = ref(null)
     const allBacklogItems = ref([])
     const inventoryItems = ref([])
 
-    // Use shared filters
     const { selectedLocation, selectedCategory, getCurrentFilters } = useFilters()
 
-    // Filter backlog based on inventory filters
     const backlogItems = computed(() => {
       if (selectedLocation.value === 'all' && selectedCategory.value === 'all') {
         return allBacklogItems.value
       }
-
-      // Get SKUs of items that match the filters
       const validSkus = new Set(inventoryItems.value.map(item => item.sku))
       return allBacklogItems.value.filter(b => validSkus.has(b.item_sku))
     })
@@ -112,15 +110,10 @@ export default {
       try {
         loading.value = true
         const filters = getCurrentFilters()
-
         const [backlogData, inventoryData] = await Promise.all([
           api.getBacklog(),
-          api.getInventory({
-            warehouse: filters.warehouse,
-            category: filters.category
-          })
+          api.getInventory({ warehouse: filters.warehouse, category: filters.category })
         ])
-
         allBacklogItems.value = backlogData
         inventoryItems.value = inventoryData
       } catch (err) {
@@ -130,18 +123,14 @@ export default {
       }
     }
 
-    const getBacklogByPriority = (priority) => {
-      return backlogItems.value.filter(item => item.priority === priority)
-    }
+    const getBacklogByPriority = (priority) =>
+      backlogItems.value.filter(item => item.priority === priority)
 
-    // Watch for filter changes and reload data
-    watch([selectedLocation, selectedCategory], () => {
-      loadBacklog()
-    })
-
+    watch([selectedLocation, selectedCategory], loadBacklog)
     onMounted(loadBacklog)
 
     return {
+      t,
       loading,
       error,
       backlogItems,

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -74,6 +74,47 @@
           </table>
         </div>
       </div>
+      <div class="card" v-if="restockingOrders.length > 0">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Restocking Orders ({{ restockingOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Order ID</th>
+                <th>Items</th>
+                <th>Total Cost</th>
+                <th>Status</th>
+                <th>Order Date</th>
+                <th>Expected Delivery</th>
+                <th>Lead Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="ro in restockingOrders" :key="ro.id">
+                <td><strong>{{ ro.id.slice(0, 8).toUpperCase() }}</strong></td>
+                <td>
+                  <details class="items-details">
+                    <summary class="items-summary">{{ ro.items.length }} item(s)</summary>
+                    <div class="items-dropdown">
+                      <div v-for="item in ro.items" :key="item.sku" class="item-entry">
+                        <span class="item-name">{{ item.item_name }}</span>
+                        <span class="item-meta">{{ item.sku }} &middot; Qty: {{ item.quantity }} @ ${{ item.unit_cost }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td><strong>${{ ro.total_cost.toLocaleString() }}</strong></td>
+                <td><span class="badge warning">{{ ro.status }}</span></td>
+                <td>{{ ro.created_date }}</td>
+                <td>{{ ro.expected_delivery }}</td>
+                <td>{{ ro.delivery_lead_days }} days</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -95,6 +136,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -153,13 +195,25 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    const loadRestockingOrders = async () => {
+      try {
+        restockingOrders.value = await api.getRestockingOrders()
+      } catch (err) {
+        console.error('Failed to load restocking orders:', err)
+      }
+    }
+
+    onMounted(() => {
+      loadOrders()
+      loadRestockingOrders()
+    })
 
     return {
       t,
       loading,
       error,
       orders,
+      restockingOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,

--- a/client/src/views/Reports.vue
+++ b/client/src/views/Reports.vue
@@ -1,31 +1,31 @@
 <template>
   <div class="reports">
     <div class="page-header">
-      <h2>Performance Reports</h2>
-      <p>View quarterly performance metrics and monthly trends</p>
+      <h2>{{ t('reports.title') }}</h2>
+      <p>{{ t('reports.description') }}</p>
     </div>
 
-    <div v-if="loading" class="loading">Loading reports...</div>
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else>
       <!-- Quarterly Performance -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Quarterly Performance</h3>
+          <h3 class="card-title">{{ t('reports.quarterlyPerformance') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Quarter</th>
-                <th>Total Orders</th>
-                <th>Total Revenue</th>
-                <th>Avg Order Value</th>
-                <th>Fulfillment Rate</th>
+                <th>{{ t('reports.table.quarter') }}</th>
+                <th>{{ t('reports.table.totalOrders') }}</th>
+                <th>{{ t('reports.table.totalRevenue') }}</th>
+                <th>{{ t('reports.table.avgOrderValue') }}</th>
+                <th>{{ t('reports.table.fulfillmentRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(q, index) in quarterlyData" :key="index">
+              <tr v-for="q in quarterlyData" :key="q.quarter">
                 <td><strong>{{ q.quarter }}</strong></td>
                 <td>{{ q.total_orders }}</td>
                 <td>${{ formatNumber(q.total_revenue) }}</td>
@@ -44,11 +44,11 @@
       <!-- Monthly Trends Chart -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Monthly Revenue Trend</h3>
+          <h3 class="card-title">{{ t('reports.monthlyRevenueTrend') }}</h3>
         </div>
         <div class="chart-container">
           <div class="bar-chart">
-            <div v-for="(month, index) in monthlyData" :key="index" class="bar-wrapper">
+            <div v-for="month in monthlyData" :key="month.month" class="bar-wrapper">
               <div class="bar-container">
                 <div
                   class="bar"
@@ -65,21 +65,21 @@
       <!-- Month-over-Month Comparison -->
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Month-over-Month Analysis</h3>
+          <h3 class="card-title">{{ t('reports.monthOverMonth') }}</h3>
         </div>
         <div class="table-container">
           <table class="reports-table">
             <thead>
               <tr>
-                <th>Month</th>
-                <th>Orders</th>
-                <th>Revenue</th>
-                <th>Change</th>
-                <th>Growth Rate</th>
+                <th>{{ t('reports.table.month') }}</th>
+                <th>{{ t('reports.table.orders') }}</th>
+                <th>{{ t('reports.table.revenue') }}</th>
+                <th>{{ t('reports.table.change') }}</th>
+                <th>{{ t('reports.table.growthRate') }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(month, index) in monthlyData" :key="index">
+              <tr v-for="(month, index) in monthlyData" :key="month.month">
                 <td><strong>{{ formatMonth(month.month) }}</strong></td>
                 <td>{{ month.order_count }}</td>
                 <td>${{ formatNumber(month.revenue) }}</td>
@@ -104,19 +104,19 @@
       <!-- Summary Stats -->
       <div class="stats-grid">
         <div class="stat-card">
-          <div class="stat-label">Total Revenue (YTD)</div>
+          <div class="stat-label">{{ t('reports.totalRevenueYTD') }}</div>
           <div class="stat-value">${{ formatNumber(totalRevenue) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Avg Monthly Revenue</div>
+          <div class="stat-label">{{ t('reports.avgMonthlyRevenue') }}</div>
           <div class="stat-value">${{ formatNumber(avgMonthlyRevenue) }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Total Orders (YTD)</div>
+          <div class="stat-label">{{ t('reports.totalOrdersYTD') }}</div>
           <div class="stat-value">{{ totalOrders }}</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Best Performing Quarter</div>
+          <div class="stat-label">{{ t('reports.bestQuarter') }}</div>
           <div class="stat-value">{{ bestQuarter }}</div>
         </div>
       </div>
@@ -125,192 +125,126 @@
 </template>
 
 <script>
-import axios from 'axios'
+import { ref, computed, onMounted, watch } from 'vue'
+import { api } from '../api'
+import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
 
 export default {
   name: 'Reports',
-  data() {
-    return {
-      loading: true,
-      error: null,
-      quarterlyData: [],
-      monthlyData: [],
-      totalRevenue: 0,
-      avgMonthlyRevenue: 0,
-      totalOrders: 0,
-      bestQuarter: ''
-    }
-  },
-  mounted() {
-    console.log('Reports component mounted')
-    this.loadData()
-  },
-  methods: {
-    async loadData() {
-      console.log('Loading reports data...')
+  setup() {
+    const { t } = useI18n()
+    const { selectedPeriod, selectedLocation, selectedCategory, getCurrentFilters } = useFilters()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const quarterlyData = ref([])
+    const monthlyData = ref([])
+
+    const totalRevenue = computed(() =>
+      monthlyData.value.reduce((sum, m) => sum + m.revenue, 0)
+    )
+
+    const avgMonthlyRevenue = computed(() =>
+      monthlyData.value.length ? totalRevenue.value / monthlyData.value.length : 0
+    )
+
+    const totalOrders = computed(() =>
+      monthlyData.value.reduce((sum, m) => sum + m.order_count, 0)
+    )
+
+    const bestQuarter = computed(() => {
+      if (!quarterlyData.value.length) return ''
+      return quarterlyData.value.reduce((best, q) =>
+        q.total_revenue > best.total_revenue ? q : best
+      ).quarter
+    })
+
+    const maxRevenue = computed(() =>
+      Math.max(...monthlyData.value.map(m => m.revenue), 0)
+    )
+
+    const loadData = async () => {
       try {
-        this.loading = true
-
-        // Fetch quarterly data
-        console.log('Fetching quarterly data...')
-        const quarterlyResponse = await axios.get('http://localhost:8001/api/reports/quarterly')
-        this.quarterlyData = quarterlyResponse.data
-        console.log('Quarterly data:', this.quarterlyData)
-
-        // Fetch monthly data
-        console.log('Fetching monthly data...')
-        const monthlyResponse = await axios.get('http://localhost:8001/api/reports/monthly-trends')
-        this.monthlyData = monthlyResponse.data
-        console.log('Monthly data:', this.monthlyData)
-
-        // Calculate summary stats
-        console.log('Calculating summary stats...')
-        this.calculateSummaryStats()
-        console.log('Summary stats calculated')
-
+        loading.value = true
+        error.value = null
+        const filters = getCurrentFilters()
+        const [quarterly, monthly] = await Promise.all([
+          api.getQuarterlyReports(filters),
+          api.getMonthlyTrends(filters)
+        ])
+        quarterlyData.value = quarterly
+        monthlyData.value = monthly
       } catch (err) {
-        console.log('Error loading reports:', err)
-        this.error = 'Failed to load reports: ' + err.message
+        error.value = 'Failed to load reports: ' + err.message
+        console.error('Failed to load reports:', err)
       } finally {
-        this.loading = false
-        console.log('Loading complete')
+        loading.value = false
       }
-    },
+    }
 
-    calculateSummaryStats() {
-      // Calculate total revenue
-      var total = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        total = total + this.monthlyData[i].revenue
-      }
-      this.totalRevenue = total
+    watch([selectedPeriod, selectedLocation, selectedCategory], loadData)
+    onMounted(loadData)
 
-      // Calculate average monthly revenue
-      if (this.monthlyData.length > 0) {
-        this.avgMonthlyRevenue = total / this.monthlyData.length
-      } else {
-        this.avgMonthlyRevenue = 0
-      }
+    const formatNumber = (num) => {
+      if (num === undefined || num === null) return '0.00'
+      return num.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    }
 
-      // Calculate total orders
-      var orders = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        orders = orders + this.monthlyData[i].order_count
-      }
-      this.totalOrders = orders
+    const formatMonth = (monthStr) => {
+      const [year, month] = monthStr.split('-')
+      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+      return monthNames[parseInt(month) - 1] + ' ' + year
+    }
 
-      // Find best quarter
-      var bestQ = ''
-      var bestRevenue = 0
-      for (var i = 0; i < this.quarterlyData.length; i++) {
-        if (this.quarterlyData[i].total_revenue > bestRevenue) {
-          bestRevenue = this.quarterlyData[i].total_revenue
-          bestQ = this.quarterlyData[i].quarter
-        }
-      }
-      this.bestQuarter = bestQ
-    },
+    const getBarHeight = (revenue) => {
+      if (maxRevenue.value === 0) return 0
+      return (revenue / maxRevenue.value) * 200
+    }
 
-    formatNumber(num) {
-      console.log('Formatting number:', num)
-      // Format number with commas
-      var str = num.toString()
-      var parts = str.split('.')
-      var intPart = parts[0]
-      var decPart = parts.length > 1 ? parts[1] : '00'
+    const getFulfillmentClass = (rate) => {
+      if (rate >= 90) return 'badge success'
+      if (rate >= 75) return 'badge warning'
+      return 'badge danger'
+    }
 
-      var formatted = ''
-      var count = 0
-      for (var i = intPart.length - 1; i >= 0; i--) {
-        if (count > 0 && count % 3 === 0) {
-          formatted = ',' + formatted
-        }
-        formatted = intPart[i] + formatted
-        count++
-      }
+    const getChangeValue = (current, previous) => {
+      const change = current - previous
+      if (change > 0) return '+$' + formatNumber(change)
+      if (change < 0) return '-$' + formatNumber(Math.abs(change))
+      return '$0.00'
+    }
 
-      if (decPart.length === 1) {
-        decPart = decPart + '0'
-      }
-      if (decPart.length > 2) {
-        decPart = decPart.substring(0, 2)
-      }
+    const getChangeClass = (current, previous) => {
+      const change = current - previous
+      if (change > 0) return 'positive-change'
+      if (change < 0) return 'negative-change'
+      return ''
+    }
 
-      return formatted + '.' + decPart
-    },
+    const getGrowthRate = (current, previous) => {
+      if (previous === 0) return 'N/A'
+      const rate = ((current - previous) / previous) * 100
+      return (rate > 0 ? '+' : '') + rate.toFixed(1) + '%'
+    }
 
-    formatMonth(monthStr) {
-      console.log('Formatting month:', monthStr)
-      // Convert YYYY-MM to readable format
-      var parts = monthStr.split('-')
-      var year = parts[0]
-      var month = parts[1]
-
-      var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-      var monthIndex = parseInt(month) - 1
-
-      return monthNames[monthIndex] + ' ' + year
-    },
-
-    getBarHeight(revenue) {
-      console.log('Calculating bar height for revenue:', revenue)
-      // Calculate bar height (max height 200px)
-      var maxRevenue = 0
-      for (var i = 0; i < this.monthlyData.length; i++) {
-        if (this.monthlyData[i].revenue > maxRevenue) {
-          maxRevenue = this.monthlyData[i].revenue
-        }
-      }
-
-      if (maxRevenue === 0) {
-        return 0
-      }
-
-      var height = (revenue / maxRevenue) * 200
-      return height
-    },
-
-    getFulfillmentClass(rate) {
-      if (rate >= 90) {
-        return 'badge success'
-      } else if (rate >= 75) {
-        return 'badge warning'
-      } else {
-        return 'badge danger'
-      }
-    },
-
-    getChangeValue(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return '+$' + this.formatNumber(change)
-      } else if (change < 0) {
-        return '-$' + this.formatNumber(Math.abs(change))
-      } else {
-        return '$0.00'
-      }
-    },
-
-    getChangeClass(current, previous) {
-      var change = current - previous
-      if (change > 0) {
-        return 'positive-change'
-      } else if (change < 0) {
-        return 'negative-change'
-      } else {
-        return ''
-      }
-    },
-
-    getGrowthRate(current, previous) {
-      if (previous === 0) {
-        return 'N/A'
-      }
-
-      var rate = ((current - previous) / previous) * 100
-      var sign = rate > 0 ? '+' : ''
-
-      return sign + rate.toFixed(1) + '%'
+    return {
+      t,
+      loading,
+      error,
+      quarterlyData,
+      monthlyData,
+      totalRevenue,
+      avgMonthlyRevenue,
+      totalOrders,
+      bestQuarter,
+      formatNumber,
+      formatMonth,
+      getBarHeight,
+      getFulfillmentClass,
+      getChangeValue,
+      getChangeClass,
+      getGrowthRate
     }
   }
 }
@@ -404,13 +338,12 @@ export default {
 }
 
 .bar-label {
-  margin-top: 0.5rem;
+  margin-top: 1.5rem;
   font-size: 0.75rem;
   color: #64748b;
   text-align: center;
   transform: rotate(-45deg);
   white-space: nowrap;
-  margin-top: 1.5rem;
 }
 
 .stats-grid {

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,273 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>Set a budget and get smart restocking recommendations based on demand forecasts.</p>
+    </div>
+
+    <div class="card budget-card">
+      <div class="card-header">
+        <h3 class="card-title">Budget Allocation</h3>
+        <span class="budget-display">${{ budget.toLocaleString() }}</span>
+      </div>
+      <div class="slider-section">
+        <div class="slider-labels">
+          <span>$0</span>
+          <span>$500K</span>
+        </div>
+        <input
+          type="range"
+          class="budget-slider"
+          min="0"
+          max="500000"
+          step="5000"
+          v-model.number="budget"
+        />
+      </div>
+      <div class="budget-meta">
+        <span>Estimated spend: <strong>${{ estimatedSpend.toLocaleString() }}</strong></span>
+        <span>Items covered: <strong>{{ recommendations.length }}</strong></span>
+        <span>Remaining: <strong>${{ remaining.toLocaleString() }}</strong></span>
+      </div>
+    </div>
+
+    <div v-if="loading" class="loading">Loading recommendations...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Recommended Items ({{ recommendations.length }})</h3>
+          <button
+            class="btn-primary"
+            :disabled="recommendations.length === 0 || placing"
+            @click="placeOrder"
+          >
+            {{ placing ? 'Placing Order...' : 'Place Order' }}
+          </button>
+        </div>
+
+        <div v-if="recommendations.length === 0" class="empty-state">
+          <p>No items can be restocked within this budget. Try increasing the budget.</p>
+        </div>
+
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Item Name</th>
+                <th>Current Stock</th>
+                <th>Forecasted Demand</th>
+                <th>Restock Qty</th>
+                <th>Unit Cost</th>
+                <th>Total Cost</th>
+                <th>Trend</th>
+                <th>Priority</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in recommendations" :key="item.sku">
+                <td><strong>{{ item.sku }}</strong></td>
+                <td>{{ item.item_name }}</td>
+                <td>{{ item.current_stock.toLocaleString() }}</td>
+                <td>{{ item.forecasted_demand.toLocaleString() }}</td>
+                <td><strong>{{ item.restock_quantity.toLocaleString() }}</strong></td>
+                <td>${{ item.unit_cost.toFixed(2) }}</td>
+                <td><strong>${{ item.total_cost.toLocaleString() }}</strong></td>
+                <td>
+                  <span :class="['badge', trendClass(item.trend)]">{{ item.trend }}</span>
+                </td>
+                <td>
+                  <span :class="['badge', item.priority]">{{ item.priority }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div v-if="successMessage" class="success-banner">
+        {{ successMessage }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch } from 'vue'
+import { api } from '../api'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const budget = ref(100000)
+    const recommendations = ref([])
+    const loading = ref(false)
+    const error = ref(null)
+    const placing = ref(false)
+    const successMessage = ref('')
+
+    const estimatedSpend = computed(() =>
+      recommendations.value.reduce((sum, r) => sum + r.total_cost, 0)
+    )
+
+    const remaining = computed(() => Math.max(0, budget.value - estimatedSpend.value))
+
+    const loadRecommendations = async () => {
+      try {
+        loading.value = true
+        error.value = null
+        recommendations.value = await api.getRestockingRecommendations(budget.value)
+      } catch (err) {
+        error.value = 'Failed to load recommendations: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    let debounceTimer = null
+    watch(budget, () => {
+      clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(loadRecommendations, 300)
+    }, { immediate: true })
+
+    const trendClass = (trend) => {
+      return { increasing: 'increasing', stable: 'stable', decreasing: 'decreasing' }[trend] || 'info'
+    }
+
+    const placeOrder = async () => {
+      try {
+        placing.value = true
+        successMessage.value = ''
+        const items = recommendations.value.map(r => ({
+          sku: r.sku,
+          item_name: r.item_name,
+          quantity: r.restock_quantity,
+          unit_cost: r.unit_cost
+        }))
+        await api.placeRestockingOrder(items, budget.value)
+        successMessage.value = `Order placed for ${items.length} item(s) totaling $${estimatedSpend.value.toLocaleString()}. Check the Orders tab for delivery details.`
+      } catch (err) {
+        error.value = 'Failed to place order: ' + err.message
+      } finally {
+        placing.value = false
+      }
+    }
+
+    return {
+      budget,
+      recommendations,
+      loading,
+      error,
+      placing,
+      successMessage,
+      estimatedSpend,
+      remaining,
+      trendClass,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-card {
+  margin-bottom: 1.25rem;
+}
+
+.budget-display {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.slider-section {
+  padding: 0.5rem 0 0.75rem;
+}
+
+.slider-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.813rem;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.budget-slider {
+  width: 100%;
+  height: 6px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: #e2e8f0;
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.4);
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  border: none;
+}
+
+.budget-meta {
+  display: flex;
+  gap: 2rem;
+  font-size: 0.875rem;
+  color: #475569;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f1f5f9;
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.empty-state {
+  padding: 2.5rem;
+  text-align: center;
+  color: #64748b;
+}
+
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 0.875rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-top: 1rem;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventory Management — Architecture</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8fafc; color: #1e293b; }
+    header { background: #0f172a; color: white; padding: 2rem 3rem; }
+    header h1 { font-size: 1.75rem; font-weight: 700; letter-spacing: -0.025em; }
+    header p { color: #94a3b8; margin-top: 0.375rem; font-size: 0.938rem; }
+    .page { max-width: 1200px; margin: 0 auto; padding: 2.5rem 2rem; }
+    h2 { font-size: 1.25rem; font-weight: 700; color: #0f172a; margin-bottom: 1.25rem; padding-bottom: 0.5rem; border-bottom: 2px solid #e2e8f0; }
+    .section { margin-bottom: 2.5rem; }
+
+    /* Stack diagram */
+    .stack-diagram { display: flex; align-items: stretch; gap: 0; border: 1px solid #e2e8f0; border-radius: 12px; overflow: hidden; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
+    .stack-layer { flex: 1; padding: 1.5rem; border-right: 1px solid #e2e8f0; }
+    .stack-layer:last-child { border-right: none; }
+    .layer-label { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem; }
+    .layer-name { font-size: 1.125rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .layer-tech { font-size: 0.813rem; color: #64748b; margin-bottom: 0.875rem; }
+    .tag { display: inline-block; padding: 0.25rem 0.625rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; margin: 0.2rem 0.2rem 0 0; }
+    .tag-blue { background: #dbeafe; color: #1e40af; }
+    .tag-green { background: #d1fae5; color: #065f46; }
+    .tag-orange { background: #fed7aa; color: #92400e; }
+    .tag-purple { background: #ede9fe; color: #5b21b6; }
+    .tag-slate { background: #f1f5f9; color: #475569; }
+    .layer-browser { background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%); }
+    .layer-api { background: linear-gradient(135deg, #f0fdf4 0%, #d1fae5 100%); }
+    .layer-data { background: linear-gradient(135deg, #fefce8 0%, #fef3c7 100%); }
+
+    /* Data flow */
+    .flow { display: flex; align-items: center; gap: 0; background: white; border: 1px solid #e2e8f0; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
+    .flow-step { flex: 1; padding: 1.25rem 1rem; text-align: center; font-size: 0.875rem; }
+    .flow-step strong { display: block; font-size: 0.938rem; margin-bottom: 0.25rem; color: #0f172a; }
+    .flow-step span { color: #64748b; font-size: 0.813rem; }
+    .flow-arrow { color: #94a3b8; font-size: 1.25rem; flex-shrink: 0; padding: 0 0.25rem; }
+    .flow-step.highlight { background: #eff6ff; }
+
+    /* API endpoints grid */
+    .endpoints-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1rem; }
+    .endpoint-group { background: white; border: 1px solid #e2e8f0; border-radius: 10px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
+    .endpoint-group h4 { font-size: 0.875rem; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.75rem; }
+    .endpoint { display: flex; align-items: baseline; gap: 0.625rem; padding: 0.375rem 0; border-bottom: 1px solid #f8fafc; font-size: 0.813rem; }
+    .endpoint:last-child { border-bottom: none; }
+    .method { font-weight: 700; font-size: 0.688rem; padding: 0.188rem 0.5rem; border-radius: 3px; flex-shrink: 0; }
+    .get { background: #d1fae5; color: #065f46; }
+    .post { background: #dbeafe; color: #1e40af; }
+    .patch { background: #ede9fe; color: #5b21b6; }
+    .delete { background: #fecaca; color: #991b1b; }
+    .endpoint-path { font-family: monospace; color: #0f172a; }
+    .endpoint-desc { color: #64748b; font-size: 0.75rem; margin-left: auto; }
+
+    /* Views grid */
+    .views-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+    .view-card { background: white; border: 1px solid #e2e8f0; border-radius: 10px; padding: 1.125rem; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
+    .view-card .route { font-family: monospace; font-size: 0.813rem; color: #2563eb; font-weight: 600; margin-bottom: 0.375rem; }
+    .view-card .view-name { font-weight: 700; font-size: 0.938rem; margin-bottom: 0.25rem; }
+    .view-card .view-desc { font-size: 0.813rem; color: #64748b; }
+    .view-card.new { border-color: #86efac; background: #f0fdf4; }
+    .new-badge { display: inline-block; font-size: 0.688rem; font-weight: 700; background: #16a34a; color: white; padding: 0.125rem 0.5rem; border-radius: 10px; margin-left: 0.375rem; vertical-align: middle; }
+
+    /* File tree */
+    .file-tree { background: #0f172a; color: #e2e8f0; border-radius: 10px; padding: 1.5rem; font-family: monospace; font-size: 0.813rem; line-height: 1.8; }
+    .tree-dir { color: #7dd3fc; font-weight: 600; }
+    .tree-file { color: #e2e8f0; }
+    .tree-new { color: #86efac; }
+    .tree-indent { display: inline-block; }
+
+    footer { background: #0f172a; color: #475569; text-align: center; padding: 1.5rem; font-size: 0.813rem; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+<header>
+  <h1>Factory Inventory Management System</h1>
+  <p>Architecture Overview &mdash; Tech Stack, Data Flow &amp; API Reference</p>
+</header>
+
+<div class="page">
+
+  <!-- Tech Stack -->
+  <div class="section">
+    <h2>Tech Stack</h2>
+    <div class="stack-diagram">
+      <div class="stack-layer layer-browser">
+        <div class="layer-label" style="color:#2563eb">Frontend</div>
+        <div class="layer-name">Vue 3 Client</div>
+        <div class="layer-tech">Runs on <strong>localhost:3000</strong></div>
+        <span class="tag tag-blue">Vue 3</span>
+        <span class="tag tag-blue">Composition API</span>
+        <span class="tag tag-blue">Vite</span>
+        <span class="tag tag-blue">Vue Router</span>
+        <span class="tag tag-blue">Axios</span>
+      </div>
+      <div class="stack-layer layer-api">
+        <div class="layer-label" style="color:#059669">Backend</div>
+        <div class="layer-name">FastAPI Server</div>
+        <div class="layer-tech">Runs on <strong>localhost:8001</strong></div>
+        <span class="tag tag-green">Python 3.14</span>
+        <span class="tag tag-green">FastAPI</span>
+        <span class="tag tag-green">Uvicorn</span>
+        <span class="tag tag-green">Pydantic v2</span>
+        <span class="tag tag-green">uv</span>
+      </div>
+      <div class="stack-layer layer-data">
+        <div class="layer-label" style="color:#d97706">Data Layer</div>
+        <div class="layer-name">JSON Mock Data</div>
+        <div class="layer-tech">In-memory at startup</div>
+        <span class="tag tag-orange">inventory.json</span>
+        <span class="tag tag-orange">orders.json</span>
+        <span class="tag tag-orange">demand_forecasts.json</span>
+        <span class="tag tag-orange">backlog_items.json</span>
+        <span class="tag tag-orange">spending.json</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Data Flow -->
+  <div class="section">
+    <h2>Request Data Flow</h2>
+    <div class="flow">
+      <div class="flow-step">
+        <strong>User Interaction</strong>
+        <span>Filter bar / button click</span>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step highlight">
+        <strong>Vue Component</strong>
+        <span>Reactive ref / computed</span>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <strong>api.js</strong>
+        <span>Axios HTTP call</span>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step highlight">
+        <strong>FastAPI Endpoint</strong>
+        <span>Filter + validate</span>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <strong>mock_data.py</strong>
+        <span>In-memory lists</span>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step highlight">
+        <strong>Pydantic Model</strong>
+        <span>Serialise &amp; return JSON</span>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <strong>Vue Template</strong>
+        <span>Render UI</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Frontend Views -->
+  <div class="section">
+    <h2>Frontend Views</h2>
+    <div class="views-grid">
+      <div class="view-card">
+        <div class="route">/</div>
+        <div class="view-name">Dashboard</div>
+        <div class="view-desc">KPI summary cards, inventory value, pending orders, backlog count</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/inventory</div>
+        <div class="view-name">Inventory</div>
+        <div class="view-desc">Stock levels, reorder points, warehouse & category filters</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/orders</div>
+        <div class="view-name">Orders</div>
+        <div class="view-desc">All orders by status; submitted restocking orders with lead times</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/spending</div>
+        <div class="view-name">Spending</div>
+        <div class="view-desc">Monthly spend, category breakdown, recent transactions</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/demand</div>
+        <div class="view-name">Demand Forecast</div>
+        <div class="view-desc">Forecasted vs current demand per SKU, trend indicators</div>
+      </div>
+      <div class="view-card">
+        <div class="route">/reports</div>
+        <div class="view-name">Reports</div>
+        <div class="view-desc">Quarterly performance, monthly trends</div>
+      </div>
+      <div class="view-card new">
+        <div class="route">/restocking <span class="new-badge">NEW</span></div>
+        <div class="view-name">Restocking</div>
+        <div class="view-desc">Budget slider, demand-driven restock recommendations, place orders</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- API Endpoints -->
+  <div class="section">
+    <h2>API Endpoints (localhost:8001)</h2>
+    <div class="endpoints-grid">
+      <div class="endpoint-group">
+        <h4>Inventory</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/inventory</span><span class="endpoint-desc">?warehouse &amp; category</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/inventory/{id}</span></div>
+      </div>
+      <div class="endpoint-group">
+        <h4>Orders</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/orders</span><span class="endpoint-desc">?warehouse, category, status, month</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/orders/{id}</span></div>
+      </div>
+      <div class="endpoint-group">
+        <h4>Dashboard &amp; Demand</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/dashboard/summary</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/demand</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/backlog</span></div>
+      </div>
+      <div class="endpoint-group">
+        <h4>Spending</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/spending/summary</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/spending/monthly</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/spending/categories</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/spending/transactions</span></div>
+      </div>
+      <div class="endpoint-group">
+        <h4>Reports</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/reports/quarterly</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/reports/monthly-trends</span></div>
+      </div>
+      <div class="endpoint-group" style="border-color:#86efac; background:#f0fdf4">
+        <h4 style="color:#16a34a">Restocking (NEW)</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/restocking/recommendations</span><span class="endpoint-desc">?budget=N</span></div>
+        <div class="endpoint"><span class="method post">POST</span><span class="endpoint-path">/api/restocking/orders</span></div>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/restocking/orders</span></div>
+      </div>
+      <div class="endpoint-group">
+        <h4>Tasks &amp; Purchase Orders</h4>
+        <div class="endpoint"><span class="method get">GET</span><span class="endpoint-path">/api/tasks</span></div>
+        <div class="endpoint"><span class="method post">POST</span><span class="endpoint-path">/api/tasks</span></div>
+        <div class="endpoint"><span class="method patch">PATCH</span><span class="endpoint-path">/api/tasks/{id}</span></div>
+        <div class="endpoint"><span class="method delete">DEL</span><span class="endpoint-path">/api/tasks/{id}</span></div>
+        <div class="endpoint"><span class="method post">POST</span><span class="endpoint-path">/api/purchase-orders</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- File Structure -->
+  <div class="section">
+    <h2>Project File Structure</h2>
+    <div class="file-tree">
+<span class="tree-dir">inventory-management/</span>
+├── <span class="tree-dir">client/</span>                     <span style="color:#475569"># Vue 3 + Vite frontend</span>
+│   └── <span class="tree-dir">src/</span>
+│       ├── <span class="tree-dir">views/</span>               <span style="color:#475569"># Page-level components</span>
+│       │   ├── <span class="tree-file">Dashboard.vue</span>
+│       │   ├── <span class="tree-file">Inventory.vue</span>
+│       │   ├── <span class="tree-file">Orders.vue</span>        <span style="color:#475569"># + Submitted Restocking Orders section</span>
+│       │   ├── <span class="tree-file">Demand.vue</span>
+│       │   ├── <span class="tree-file">Spending.vue</span>
+│       │   ├── <span class="tree-file">Reports.vue</span>
+│       │   └── <span class="tree-new">Restocking.vue       ← NEW</span>
+│       ├── <span class="tree-dir">components/</span>          <span style="color:#475569"># Reusable UI components</span>
+│       ├── <span class="tree-dir">composables/</span>         <span style="color:#475569"># useFilters, useAuth, useI18n</span>
+│       ├── <span class="tree-file">api.js</span>               <span style="color:#475569"># Axios API client (+ restocking methods)</span>
+│       └── <span class="tree-file">main.js</span>              <span style="color:#475569"># Router + app mount (+ /restocking route)</span>
+├── <span class="tree-dir">server/</span>                     <span style="color:#475569"># FastAPI backend</span>
+│   ├── <span class="tree-file">main.py</span>                 <span style="color:#475569"># All API endpoints (+ restocking endpoints)</span>
+│   ├── <span class="tree-file">mock_data.py</span>            <span style="color:#475569"># JSON loaders + in-memory restocking_orders</span>
+│   └── <span class="tree-dir">data/</span>                  <span style="color:#475569"># JSON source files</span>
+│       ├── <span class="tree-file">inventory.json</span>
+│       ├── <span class="tree-file">orders.json</span>
+│       ├── <span class="tree-file">demand_forecasts.json</span>
+│       ├── <span class="tree-file">backlog_items.json</span>
+│       ├── <span class="tree-file">spending.json</span>
+│       └── <span class="tree-file">transactions.json</span>
+├── <span class="tree-file">CLAUDE.md</span>                   <span style="color:#475569"># Project context for Claude Code</span>
+└── <span class="tree-new">docs/architecture.html       ← THIS FILE</span>
+    </div>
+  </div>
+
+</div>
+<footer>Factory Inventory Management System &mdash; Architecture Overview</footer>
+</body>
+</html>

--- a/server/main.py
+++ b/server/main.py
@@ -228,12 +228,15 @@ def get_recent_transactions():
     return recent_transactions
 
 @app.get("/api/reports/quarterly")
-def get_quarterly_reports():
+def get_quarterly_reports(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None
+):
     """Get quarterly performance reports"""
-    # Calculate quarterly statistics from orders
+    filtered = apply_filters(orders, warehouse, category)
     quarters = {}
 
-    for order in orders:
+    for order in filtered:
         order_date = order.get('order_date', '')
         # Determine quarter
         if '2025-01' in order_date or '2025-02' in order_date or '2025-03' in order_date:
@@ -274,11 +277,15 @@ def get_quarterly_reports():
     return result
 
 @app.get("/api/reports/monthly-trends")
-def get_monthly_trends():
+def get_monthly_trends(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None
+):
     """Get month-over-month trends"""
+    filtered = apply_filters(orders, warehouse, category)
     months = {}
 
-    for order in orders:
+    for order in filtered:
         order_date = order.get('order_date', '')
         if not order_date:
             continue

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
-from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders, restocking_orders
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -303,6 +303,131 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+class RestockingRecommendation(BaseModel):
+    sku: str
+    item_name: str
+    current_stock: int
+    forecasted_demand: int
+    restock_quantity: int
+    unit_cost: float
+    total_cost: float
+    trend: str
+    priority: str
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    item_name: str
+    quantity: int
+    unit_cost: float
+    total_cost: float
+
+class RestockingOrder(BaseModel):
+    id: str
+    items: List[RestockingOrderItem]
+    total_cost: float
+    delivery_lead_days: int
+    status: str
+    created_date: str
+    expected_delivery: str
+
+class PlaceRestockingOrderRequest(BaseModel):
+    items: List[dict]
+    budget: float
+
+@app.get("/api/restocking/recommendations", response_model=List[RestockingRecommendation])
+def get_restocking_recommendations(budget: float = 0):
+    """Get restocking recommendations based on demand forecasts within a budget."""
+    inventory_by_sku = {item["sku"]: item for item in inventory_items}
+    recommendations = []
+
+    for forecast in demand_forecasts:
+        sku = forecast["item_sku"]
+        inv = inventory_by_sku.get(sku)
+        if not inv:
+            continue
+
+        current_stock = inv["quantity_on_hand"]
+        forecasted = forecast["forecasted_demand"]
+        restock_qty = max(0, forecasted - current_stock)
+        if restock_qty <= 0:
+            continue
+
+        unit_cost = inv["unit_cost"]
+        total_cost = round(restock_qty * unit_cost, 2)
+        trend = forecast["trend"]
+        priority = "high" if trend == "increasing" else ("medium" if trend == "stable" else "low")
+
+        recommendations.append({
+            "sku": sku,
+            "item_name": forecast["item_name"],
+            "current_stock": current_stock,
+            "forecasted_demand": forecasted,
+            "restock_quantity": restock_qty,
+            "unit_cost": unit_cost,
+            "total_cost": total_cost,
+            "trend": trend,
+            "priority": priority
+        })
+
+    # Sort by priority: increasing > stable > decreasing
+    priority_order = {"high": 0, "medium": 1, "low": 2}
+    recommendations.sort(key=lambda x: priority_order.get(x["priority"], 3))
+
+    if budget <= 0:
+        return recommendations
+
+    # Return items that fit within budget (greedy)
+    result = []
+    remaining = budget
+    for rec in recommendations:
+        if rec["total_cost"] <= remaining:
+            result.append(rec)
+            remaining -= rec["total_cost"]
+    return result
+
+@app.post("/api/restocking/orders", response_model=RestockingOrder)
+def place_restocking_order(request: PlaceRestockingOrderRequest):
+    """Place a restocking order for selected items."""
+    import uuid
+    from datetime import datetime, timedelta
+
+    if not request.items:
+        raise HTTPException(status_code=400, detail="No items provided")
+
+    order_items = []
+    total_cost = 0.0
+    for item in request.items:
+        item_total = round(item["quantity"] * item["unit_cost"], 2)
+        total_cost += item_total
+        order_items.append({
+            "sku": item["sku"],
+            "item_name": item["item_name"],
+            "quantity": item["quantity"],
+            "unit_cost": item["unit_cost"],
+            "total_cost": item_total
+        })
+
+    delivery_lead_days = 14
+    now = datetime.now()
+    expected = now + timedelta(days=delivery_lead_days)
+
+    order = {
+        "id": str(uuid.uuid4()),
+        "items": order_items,
+        "total_cost": round(total_cost, 2),
+        "delivery_lead_days": delivery_lead_days,
+        "status": "Processing",
+        "created_date": now.strftime("%Y-%m-%d"),
+        "expected_delivery": expected.strftime("%Y-%m-%d")
+    }
+    restocking_orders.append(order)
+    return order
+
+@app.get("/api/restocking/orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all submitted restocking orders."""
+    return restocking_orders
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/mock_data.py
+++ b/server/mock_data.py
@@ -37,3 +37,6 @@ purchase_orders = load_json_file('purchase_orders.json')
 
 # All data is now loaded from JSON files in the data/ directory
 # This allows for easier maintenance and updates of the sample data
+
+# In-memory restocking orders (not persisted to file)
+restocking_orders = []


### PR DESCRIPTION
## Summary
- New Restocking tab with budget slider ($0-$500K) and demand-driven recommendation engine prioritising high-trend SKUs
- Place Order submits restocking orders shown in Orders tab with 14-day delivery lead time
- Three new FastAPI endpoints: GET/POST /api/restocking/orders and GET /api/restocking/recommendations
- HTML architecture visualization (docs/architecture.html) covering stack, data flow, API endpoints, and file structure
- Updated CLAUDE.md with restocking feature context; Playwright MCP configured

## Test plan
- [ ] Open http://localhost:3000/restocking, drag budget slider and verify recommendations update
- [ ] Click Place Order and confirm order appears in Orders tab with lead time
- [ ] Verify GET /api/restocking/recommendations?budget=50000 returns JSON
- [ ] Open docs/architecture.html and verify all sections render correctly

Generated with Claude Code