### PR TITLE
Add SaaS sidebar redesign, Restocking feature, and supporting changes

### DIFF
--- a/.claude/skills/saas-redesign/SKILL.md
+++ b/.claude/skills/saas-redesign/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: saas-redesign
+description: Redesign this Factory Inventory Management app's UI into a modern SaaS-style interface with a left vertical navigation sidebar (replacing the top nav bar), a consistent design-token system, an 8px spacing rhythm, and a polished professional look. Use when asked to modernize, redesign, restyle, or "make the UI look like a SaaS product," add/convert to a sidebar, or improve visual consistency across the Vue 3 frontend.
+---
+
+# SaaS UI Redesign
+
+Transform the current top-nav layout into a modern SaaS shell: a fixed left sidebar for navigation, a clean top bar for global controls, and content pages built on a single, consistent design-token system. This skill is specific to **this** app (Vue 3 + Composition API, Vite, the slate/gray palette). It ships concrete tokens — use them verbatim so the result is cohesive, not approximate.
+
+## Non-negotiable rules
+
+1. **Delegate every `.vue` change to `vue-expert`.** CLAUDE.md mandates it: "ANY time you need to create or significantly modify a .vue file, you MUST delegate to vue-expert." This skill is the design spec; vue-expert does the editing. Paste the relevant token table + component spec into the delegation prompt.
+2. **Do not change behavior.** This is a visual/layout redesign only. Routes, `setup()` logic, API calls, i18n keys, and component props/events stay identical. The 7 routes in `client/src/main.js` and their `t('nav.*')` labels must all remain reachable.
+3. **No emojis in the UI** (per CLAUDE.md design system). Use inline SVG icons for sidebar items.
+4. **Document non-obvious CSS** with a short comment explaining the *why* (e.g. why a `grid-template-columns` value, why a sticky offset).
+5. **Verify in the browser** before declaring done (see Verification). The dev servers run on `:3000` (frontend) and `:8001` (API) — use the `start` skill if they're down.
+
+## Where things live
+
+| Concern | File | Notes |
+|---|---|---|
+| App shell + **global** styles | `client/src/App.vue` | The `<style>` block here is **unscoped/global** — it defines `.card`, `.stat-card`, `table`, `.badge`, `.page-header`, etc. used by every view. This is where the token `:root` block and the new layout go. |
+| Nav links (source of truth) | `client/src/App.vue` template (`.nav-tabs`) + `client/src/main.js` routes | 7 links: `/` Overview, `/inventory`, `/orders`, `/spending` (Finance), `/demand`, `/restocking`, `/reports`. |
+| Global controls | `client/src/components/LanguageSwitcher.vue`, `ProfileMenu.vue` | Currently live in the top nav. They move to the new top bar. |
+| Sub-nav under header | `client/src/components/FilterBar.vue` | The 4-filter bar. Keep it directly under the top bar, inside the content column. |
+| Per-page content | `client/src/views/*.vue` | Use scoped styles; consume the global tokens. Don't redefine colors/spacing locally. |
+
+## Design tokens (bake these in verbatim)
+
+Add this `:root` block to the **top** of the global `<style>` in `App.vue`, then refactor existing hardcoded hex values to reference the tokens. The color values are seeded from the app's current palette so nothing shifts unexpectedly — you're formalizing what's already there, then building the sidebar on top.
+
+```css
+:root {
+  /* Color — neutrals (slate) */
+  --bg-app: #f8fafc;        /* page background */
+  --bg-surface: #ffffff;    /* cards, sidebar, top bar */
+  --bg-subtle: #f1f5f9;     /* hover fills, table thead */
+  --bg-muted: #f8fafc;      /* zebra / inset surfaces */
+  --border: #e2e8f0;        /* default 1px borders */
+  --border-strong: #cbd5e1; /* hover borders */
+  --border-faint: #f1f5f9;  /* table row dividers */
+
+  /* Color — text */
+  --text-strong: #0f172a;   /* headings, values */
+  --text-body: #334155;     /* table cells, body copy */
+  --text-muted: #64748b;    /* labels, secondary */
+  --text-subtle: #475569;   /* table headers */
+
+  /* Color — brand / primary */
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --primary-soft: #eff6ff;  /* active nav fill */
+  --primary-softer: #dbeafe;
+
+  /* Color — status (text / soft-bg pairs) */
+  --success: #059669;  --success-bg: #d1fae5;  --success-fg: #065f46;
+  --warning: #ea580c;  --warning-bg: #fed7aa;  --warning-fg: #92400e;
+  --danger:  #dc2626;  --danger-bg:  #fecaca;  --danger-fg:  #991b1b;
+  --info:    #2563eb;  --info-bg:    #dbeafe;  --info-fg:    #1e40af;
+
+  /* Spacing — strict 8px rhythm (use ONLY these steps) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-8: 48px;
+
+  /* Radius */
+  --radius-sm: 6px;   /* badges, nav items, buttons */
+  --radius-md: 8px;   /* inputs, banners */
+  --radius-lg: 10px;  /* cards, stat cards */
+
+  /* Elevation */
+  --shadow-sm: 0 1px 3px 0 rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.06);
+
+  /* Typography scale */
+  --text-xs: 0.75rem;    /* table headers, badges */
+  --text-sm: 0.875rem;   /* body, table cells */
+  --text-base: 0.938rem; /* nav, buttons, descriptions */
+  --text-lg: 1.125rem;   /* card titles */
+  --text-xl: 1.375rem;   /* logo */
+  --text-2xl: 1.875rem;  /* page H2 */
+  --text-3xl: 2.25rem;   /* stat values */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  /* Layout */
+  --sidebar-w: 248px;
+  --topbar-h: 64px;
+  --content-max: 1440px;
+}
+```
+
+**Spacing rule:** every margin/padding/gap must be a `--space-*` step. No ad-hoc `0.625rem`/`0.813rem` values for layout. (Font sizes use the type scale; only *spacing* is locked to the 8px steps.)
+
+## The structural transformation
+
+### Before (current `App.vue`)
+```
+.app (flex column)
+ ├─ header.top-nav (sticky)  ← logo · nav-tabs · LanguageSwitcher · ProfileMenu
+ ├─ FilterBar
+ └─ main.main-content        ← router-view, max-width 1600px centered
+```
+
+### After (target shell)
+```
+.app (flex ROW, min-height 100vh)
+ ├─ aside.sidebar (fixed width var(--sidebar-w), full height, sticky)
+ │    ├─ .sidebar-brand     ← logo + subtitle (stacked)
+ │    └─ nav.sidebar-nav    ← 7 router-links, each = icon + label, vertical
+ └─ .app-body (flex column, flex:1, min-width:0)
+      ├─ header.topbar (sticky, height var(--topbar-h))  ← page context (left) · LanguageSwitcher · ProfileMenu (right)
+      ├─ FilterBar
+      └─ main.main-content   ← router-view, max-width var(--content-max)
+```
+
+Key template moves in `App.vue`:
+- Change `.app` from `flex-direction: column` to `flex-direction: row`.
+- Replace `<header class="top-nav">…</header>` with `<aside class="sidebar">` (brand + vertical nav) **and** a new `<header class="topbar">` placed inside a new `.app-body` wrapper.
+- Move `<LanguageSwitcher />` and `<ProfileMenu>` into `.topbar`.
+- Keep `<FilterBar />`, `<router-view />`, and all three modals exactly as-is.
+- The `setup()` script and all imports stay byte-for-byte unchanged.
+
+### Sidebar spec
+- Width `var(--sidebar-w)`; `background: var(--bg-surface)`; `border-right: 1px solid var(--border)`.
+- `position: sticky; top: 0; height: 100vh; align-self: flex-start; overflow-y: auto;` so it stays put while content scrolls.
+- Brand block: padding `var(--space-5)`; `h1` at `--text-xl`, weight 700, `--text-strong`, `letter-spacing: -0.025em`; subtitle at `--text-xs`, `--text-muted`, stacked below (not inline).
+- Nav items: vertical stack, gap `var(--space-1)`, padding `var(--space-3) var(--space-4)`, `--radius-sm`, `--text-base`, `--text-muted`, `gap: var(--space-3)` between icon and label.
+  - Hover: `background: var(--bg-subtle); color: var(--text-strong)`.
+  - Active (`router-link-active` / current `:class` pattern): `background: var(--primary-soft); color: var(--primary)`; **left** accent bar `3px` `var(--primary)` (replace the old bottom `::after` underline — accent moves to the inline-start edge for a sidebar).
+- Each item gets a 20px inline SVG icon (stroke `currentColor`, `stroke-width: 1.75`) so it tints with the text color. Suggested icons: Overview=grid, Inventory=box, Orders=clipboard/cart, Finance=dollar/chart, Demand=trending-up, Restocking=refresh, Reports=document.
+
+### Top bar spec
+- `height: var(--topbar-h)`; `background: var(--bg-surface)`; `border-bottom: 1px solid var(--border)`; `position: sticky; top: 0; z-index: 100`.
+- Flex row, `align-items: center`, padding `0 var(--space-6)`, gap `var(--space-4)`; controls (`LanguageSwitcher`, `ProfileMenu`) pushed right with `margin-left: auto`.
+
+## Polish pass (apply to global primitives in `App.vue`)
+Refactor the existing primitives to tokens and tighten rhythm:
+- `.card` / `.stat-card`: `padding: var(--space-5)`, `--radius-lg`, `1px var(--border)`, hover → `--border-strong` + `--shadow-md`.
+- `.stats-grid`: `gap: var(--space-5)`; keep `repeat(auto-fit, minmax(280px, 1fr))`.
+- `.page-header`: `margin-bottom: var(--space-5)`; H2 `--text-2xl`/700/`--text-strong`; p `--text-base`/`--text-muted`.
+- Tables: `th` `--text-xs`/uppercase/`--text-subtle`; `td` `--text-sm`/`--text-body`; row hover `--bg-muted`; dividers `--border-faint`.
+- `.badge.*`, `.stat-card.*` status colors → the `--*-bg`/`--*-fg` token pairs.
+- Buttons (`.btn-primary` etc.): `--primary` → hover `--primary-hover`, `--radius-sm`, padding `var(--space-2) var(--space-5)`.
+
+## Process
+
+1. **Read first.** `App.vue` (shell + global styles), `main.js` (routes), `FilterBar.vue`, `ProfileMenu.vue`, `LanguageSwitcher.vue`. Confirm the current nav links and that styles in `App.vue` are global.
+2. **Delegate to `vue-expert`** with: (a) this token `:root` block, (b) the before/after shell, (c) the sidebar + top-bar specs. Have it edit `App.vue` only for the shell + tokens + primitives. Views usually need no changes because they consume global classes — touch a view only if it hardcodes layout that fights the new shell.
+3. **Responsive:** below ~768px the sidebar should collapse (off-canvas or icon-only rail). If out of scope for the request, say so explicitly rather than leaving it half-done.
+4. **Verify** (below), then summarize what changed.
+
+## Verification checklist
+- [ ] All 7 nav links render in the sidebar, each with an icon, and route correctly.
+- [ ] Active route shows the left accent + `--primary-soft` fill; only one item active at a time.
+- [ ] `LanguageSwitcher` and `ProfileMenu` work from the top bar; switching to `ja` still flows (currency `¥`, translated labels).
+- [ ] `FilterBar` and all pages (Dashboard, Inventory, Orders, Spending, Demand, Restocking, Reports) render with no layout breakage; content respects `--content-max`.
+- [ ] No hardcoded spacing outside the `--space-*` scale in changed CSS; no emojis added.
+- [ ] No console errors; no `setup()`/API/i18n behavior changed.
+- [ ] Sidebar stays fixed while the content column scrolls.
+
+**How to verify in-browser:** ensure servers are up (`start` skill), open `http://localhost:3000`, click through every nav item, toggle the language switcher, and resize the window to check the responsive behavior. If the Playwright MCP is connected, use it to snapshot each route; otherwise open the routes manually and inspect.

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,5 @@ npm install && npm run dev
 - Status: green/blue/yellow/red
 - Charts: Custom SVG, CSS Grid for layouts
 - No emojis in UI
+
+# Always document non-obvious logic changes with comments

--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecture · Factory Inventory Management System</title>
+<style>
+  :root {
+    --ink: #0f172a;
+    --slate: #475569;
+    --muted: #64748b;
+    --line: #e2e8f0;
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --vue: #42b883;
+    --py: #3b82f6;
+    --data: #d97706;
+    --green: #16a34a;
+    --blue: #2563eb;
+    --yellow: #ca8a04;
+    --red: #dc2626;
+    --radius: 10px;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 48px 24px 80px; }
+  header.page {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 24px;
+    margin-bottom: 40px;
+  }
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--muted);
+    margin: 0 0 8px;
+  }
+  h1 { font-size: 30px; margin: 0 0 8px; letter-spacing: -.01em; }
+  .lead { color: var(--slate); font-size: 16px; margin: 0; max-width: 70ch; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+  .pill {
+    font-size: 12px; font-weight: 600;
+    padding: 4px 10px; border-radius: 999px;
+    background: #f1f5f9; color: var(--slate); border: 1px solid var(--line);
+  }
+  h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: .1em;
+    color: var(--muted); margin: 48px 0 16px; font-weight: 700;
+  }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 22px;
+  }
+
+  /* Architecture stack */
+  .stack { display: grid; gap: 14px; }
+  .layer {
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+    overflow: hidden;
+  }
+  .layer-head {
+    display: flex; align-items: center; gap: 12px;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--line);
+  }
+  .dot { width: 10px; height: 10px; border-radius: 50%; flex: none; }
+  .layer-title { font-weight: 700; font-size: 15px; }
+  .layer-sub { color: var(--muted); font-size: 13px; margin-left: auto; }
+  .layer-body { padding: 16px 18px; display: grid; gap: 10px; }
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+  .chip {
+    font-size: 13px; font-weight: 500;
+    padding: 6px 11px; border-radius: 7px;
+    background: #f8fafc; border: 1px solid var(--line); color: var(--slate);
+  }
+  .chip b { color: var(--ink); font-weight: 600; }
+  .connector {
+    text-align: center; color: var(--muted); font-size: 20px; line-height: 1;
+    height: 4px; position: relative;
+  }
+  .connector span {
+    position: relative; top: -10px; background: var(--bg); padding: 0 10px;
+    font-size: 12px; letter-spacing: .04em;
+  }
+
+  .vue-edge { border-left: 4px solid var(--vue); }
+  .py-edge { border-left: 4px solid var(--py); }
+  .data-edge { border-left: 4px solid var(--data); }
+
+  /* Two column */
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  @media (max-width: 720px){ .grid2 { grid-template-columns: 1fr; } }
+
+  .kv { display: grid; grid-template-columns: auto 1fr; gap: 6px 16px; font-size: 14px; }
+  .kv dt { color: var(--muted); font-weight: 600; }
+  .kv dd { margin: 0; color: var(--ink); }
+
+  table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--line); }
+  th { color: var(--muted); font-weight: 700; text-transform: uppercase; font-size: 11px; letter-spacing: .06em; }
+  td code, .mono {
+    font-family: "SF Mono", "Cascadia Code", Consolas, monospace;
+    font-size: 12.5px; color: var(--ink);
+    background: #f1f5f9; padding: 2px 6px; border-radius: 5px;
+  }
+  .method {
+    font-family: "SF Mono", Consolas, monospace; font-size: 11px; font-weight: 700;
+    padding: 2px 7px; border-radius: 5px; color: #fff; background: var(--green);
+  }
+  tr:last-child td { border-bottom: none; }
+
+  /* Data flow */
+  .flow { display: grid; gap: 0; }
+  .flow-step { display: grid; grid-template-columns: 40px 1fr; gap: 16px; }
+  .flow-rail { display: flex; flex-direction: column; align-items: center; }
+  .flow-num {
+    width: 30px; height: 30px; border-radius: 50%;
+    background: var(--ink); color: #fff; font-size: 13px; font-weight: 700;
+    display: flex; align-items: center; justify-content: center; flex: none;
+  }
+  .flow-line { width: 2px; flex: 1; background: var(--line); margin: 4px 0; min-height: 14px; }
+  .flow-step:last-child .flow-line { display: none; }
+  .flow-content { padding-bottom: 22px; }
+  .flow-content h3 { margin: 4px 0 4px; font-size: 15px; }
+  .flow-content p { margin: 0; color: var(--slate); font-size: 14px; }
+  .flow-content .tag { font-size: 12px; color: var(--muted); }
+  .flow-content .mono { font-size: 12px; }
+
+  .note {
+    margin-top: 16px; padding: 14px 16px; border-radius: 8px;
+    background: #fffbeb; border: 1px solid #fde68a; color: #92400e; font-size: 13.5px;
+  }
+  .note b { color: #78350f; }
+
+  footer.page {
+    margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line);
+    color: var(--muted); font-size: 12.5px; display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px;
+  }
+  .legend { display: flex; gap: 18px; flex-wrap: wrap; margin: 4px 0 0; }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--slate); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="page">
+    <p class="eyebrow">System Architecture</p>
+    <h1>Factory Inventory Management System</h1>
+    <p class="lead">A full-stack inventory and operations demo: a Vue 3 single-page application backed by a Python FastAPI service that serves in-memory mock data loaded from JSON files. No database — all state lives in process memory for the lifetime of the server.</p>
+    <div class="meta-row">
+      <span class="pill">Vue 3 SPA · port 3000</span>
+      <span class="pill">FastAPI · port 8001</span>
+      <span class="pill">In-memory JSON data</span>
+      <span class="pill">REST over HTTP</span>
+    </div>
+    <div class="legend">
+      <span><span class="dot" style="background:var(--vue)"></span> Frontend</span>
+      <span><span class="dot" style="background:var(--py)"></span> Backend</span>
+      <span><span class="dot" style="background:var(--data)"></span> Data</span>
+    </div>
+  </header>
+
+  <!-- ARCHITECTURE STACK -->
+  <h2>System Architecture</h2>
+  <div class="stack">
+
+    <div class="layer vue-edge">
+      <div class="layer-head">
+        <span class="dot" style="background:var(--vue)"></span>
+        <span class="layer-title">Browser — Vue 3 Single-Page Application</span>
+        <span class="layer-sub">Vite dev server · :3000</span>
+      </div>
+      <div class="layer-body">
+        <div class="tag" style="font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;">Views (router pages)</div>
+        <div class="chips">
+          <span class="chip"><b>Dashboard</b> /</span>
+          <span class="chip"><b>Inventory</b> /inventory</span>
+          <span class="chip"><b>Orders</b> /orders</span>
+          <span class="chip"><b>Demand</b> /demand</span>
+          <span class="chip"><b>Spending</b> /spending</span>
+          <span class="chip"><b>Reports</b> /reports</span>
+        </div>
+        <div class="tag" style="font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;margin-top:4px;">Composables (shared logic) &amp; Components</div>
+        <div class="chips">
+          <span class="chip">useFilters <i style="color:var(--muted)">— singleton filter state</i></span>
+          <span class="chip">useAuth</span>
+          <span class="chip">useI18n <i style="color:var(--muted)">— en / ja</i></span>
+          <span class="chip">FilterBar</span>
+          <span class="chip">Detail modals ×6</span>
+        </div>
+        <div class="tag" style="font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;margin-top:4px;">API client</div>
+        <div class="chips">
+          <span class="chip"><b>api.js</b> — Axios wrapper, base <span class="mono">http://localhost:8001/api</span></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="connector"><span>HTTP / REST · JSON · CORS (allow all origins)</span></div>
+
+    <div class="layer py-edge">
+      <div class="layer-head">
+        <span class="dot" style="background:var(--py)"></span>
+        <span class="layer-title">FastAPI Application</span>
+        <span class="layer-sub">Uvicorn · :8001</span>
+      </div>
+      <div class="layer-body">
+        <div class="tag" style="font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;">Request handling</div>
+        <div class="chips">
+          <span class="chip">Route handlers <i style="color:var(--muted)">— main.py</i></span>
+          <span class="chip"><b>apply_filters()</b> — warehouse / category / status</span>
+          <span class="chip"><b>filter_by_month()</b> — month &amp; quarter</span>
+        </div>
+        <div class="tag" style="font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;margin-top:4px;">Validation</div>
+        <div class="chips">
+          <span class="chip">Pydantic models <i style="color:var(--muted)">— InventoryItem, Order, DemandForecast, BacklogItem, PurchaseOrder</i></span>
+          <span class="chip"><b>response_model</b> enforces output shape</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="connector"><span>module import · load at startup</span></div>
+
+    <div class="layer data-edge">
+      <div class="layer-head">
+        <span class="dot" style="background:var(--data)"></span>
+        <span class="layer-title">In-Memory Data Layer</span>
+        <span class="layer-sub">server/data/*.json</span>
+      </div>
+      <div class="layer-body">
+        <div class="chips">
+          <span class="chip"><b>mock_data.py</b> — loads JSON into Python lists/dicts at import</span>
+        </div>
+        <div class="chips">
+          <span class="chip">inventory.json</span>
+          <span class="chip">orders.json</span>
+          <span class="chip">demand_forecasts.json</span>
+          <span class="chip">backlog_items.json</span>
+          <span class="chip">purchase_orders.json</span>
+          <span class="chip">spending.json</span>
+          <span class="chip">transactions.json</span>
+        </div>
+        <div class="tag" style="font-size:13px;color:var(--slate);margin-top:4px;">Read-only at runtime. Mutations don't persist — restarting the server reloads from disk.</div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- TECH STACK -->
+  <h2>Tech Stack</h2>
+  <div class="grid2">
+    <div class="card">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+        <span class="dot" style="background:var(--vue)"></span>
+        <strong>Frontend</strong>
+      </div>
+      <dl class="kv">
+        <dt>Framework</dt><dd>Vue 3.4 (Composition API)</dd>
+        <dt>Routing</dt><dd>Vue Router 4.3 (history mode)</dd>
+        <dt>HTTP</dt><dd>Axios 1.6</dd>
+        <dt>Build</dt><dd>Vite 5.2 + @vitejs/plugin-vue</dd>
+        <dt>i18n</dt><dd>Custom composable (English / Japanese)</dd>
+        <dt>Charts</dt><dd>Hand-rolled SVG + CSS Grid</dd>
+        <dt>Runtime</dt><dd>Node 18+ required (Vite 5)</dd>
+      </dl>
+    </div>
+    <div class="card">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+        <span class="dot" style="background:var(--py)"></span>
+        <strong>Backend</strong>
+      </div>
+      <dl class="kv">
+        <dt>Framework</dt><dd>FastAPI ≥ 0.110</dd>
+        <dt>Server</dt><dd>Uvicorn ≥ 0.24</dd>
+        <dt>Validation</dt><dd>Pydantic 2.5+</dd>
+        <dt>Language</dt><dd>Python (3.11+ preferred)</dd>
+        <dt>Data store</dt><dd>JSON files → in-memory lists</dd>
+        <dt>Auth</dt><dd>None (demo only)</dd>
+        <dt>CORS</dt><dd>All origins allowed (dev)</dd>
+      </dl>
+    </div>
+  </div>
+
+  <!-- API SURFACE -->
+  <h2>Backend API Surface</h2>
+  <div class="card" style="padding:6px 6px 4px;">
+    <table>
+      <thead>
+        <tr><th>Method</th><th>Endpoint</th><th>Filters</th><th>Purpose</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><span class="method">GET</span></td><td><code>/api/inventory</code></td><td>warehouse, category</td><td>List inventory items</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/inventory/{id}</code></td><td>—</td><td>Single item (404 if missing)</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/orders</code></td><td>warehouse, category, status, month</td><td>List orders</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/orders/{id}</code></td><td>—</td><td>Single order</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/demand</code></td><td>—</td><td>Demand forecasts</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/backlog</code></td><td>—</td><td>Backlog + has_purchase_order flag</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/dashboard/summary</code></td><td>warehouse, category, status, month</td><td>Aggregated KPIs</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/spending/summary</code></td><td>—</td><td>Spending totals</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/spending/monthly</code></td><td>—</td><td>Monthly spend breakdown</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/spending/categories</code></td><td>—</td><td>Spend by category</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/spending/transactions</code></td><td>—</td><td>Recent transactions</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/reports/quarterly</code></td><td>—</td><td>Computed quarterly performance</td></tr>
+        <tr><td><span class="method">GET</span></td><td><code>/api/reports/monthly-trends</code></td><td>—</td><td>Computed month-over-month trends</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="note">
+    <b>Note:</b> The frontend <span class="mono">api.js</span> also references <span class="mono">/api/tasks</span> and <span class="mono">POST /api/purchase-orders</span> endpoints that are not yet implemented in <span class="mono">main.py</span> on this branch — the client is ahead of the backend for those features.
+  </div>
+
+  <!-- DATA FLOW -->
+  <h2>Data Flow — A Filtered Request</h2>
+  <div class="card">
+    <div class="flow">
+
+      <div class="flow-step">
+        <div class="flow-rail"><div class="flow-num">1</div><div class="flow-line"></div></div>
+        <div class="flow-content">
+          <h3>User adjusts a filter</h3>
+          <p>One of four filters changes in the <span class="mono">FilterBar</span>: Time Period, Warehouse, Category, or Order Status.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="flow-rail"><div class="flow-num">2</div><div class="flow-line"></div></div>
+        <div class="flow-content">
+          <h3>Shared filter state updates</h3>
+          <p>The <span class="mono">useFilters</span> composable holds filter state as module-level refs (a singleton shared across all views). <span class="mono">getCurrentFilters()</span> maps Period → <span class="mono">month</span> and Location → <span class="mono">warehouse</span>.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="flow-rail"><div class="flow-num">3</div><div class="flow-line"></div></div>
+        <div class="flow-content">
+          <h3>API client builds the request</h3>
+          <p><span class="mono">api.js</span> serializes active filters into query params (skipping any set to <span class="mono">'all'</span>) and issues an Axios <span class="mono">GET</span>.</p>
+          <p class="tag">e.g. <span class="mono">GET /api/orders?warehouse=East&amp;status=Processing&amp;month=Q3-2025</span></p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="flow-rail"><div class="flow-num">4</div><div class="flow-line"></div></div>
+        <div class="flow-content">
+          <h3>FastAPI filters in memory</h3>
+          <p>The route handler runs <span class="mono">apply_filters()</span> (warehouse / category / status) and <span class="mono">filter_by_month()</span> (direct month or quarter expansion) over the in-memory lists — case-insensitive, non-mutating.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="flow-rail"><div class="flow-num">5</div><div class="flow-line"></div></div>
+        <div class="flow-content">
+          <h3>Pydantic validates the response</h3>
+          <p>The declared <span class="mono">response_model</span> coerces and validates the output shape before it leaves the server.</p>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="flow-rail"><div class="flow-num">6</div><div class="flow-line"></div></div>
+        <div class="flow-content">
+          <h3>Vue stores raw data, derives the rest</h3>
+          <p>The view stores the response in refs (e.g. <span class="mono">allOrders</span>, <span class="mono">inventoryItems</span>); <span class="mono">computed</span> properties derive sorted/aggregated views and the template re-renders reactively.</p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- FILTER SYSTEM -->
+  <h2>Cross-Cutting: The Filter System</h2>
+  <div class="card">
+    <p style="margin-top:0;color:var(--slate);">Four filters are defined once in <span class="mono">useFilters</span> and applied consistently across views and endpoints. Each defaults to <span class="mono">'all'</span> and is omitted from requests when inactive.</p>
+    <div class="chips">
+      <span class="chip"><b>Time Period</b> → <span class="mono">month</span> (e.g. 2025-09 or Q3-2025)</span>
+      <span class="chip"><b>Warehouse</b> → <span class="mono">warehouse</span></span>
+      <span class="chip"><b>Category</b> → <span class="mono">category</span></span>
+      <span class="chip"><b>Order Status</b> → <span class="mono">status</span></span>
+    </div>
+    <p style="margin-bottom:0;color:var(--muted);font-size:13.5px;">Inventory has no time dimension, so the month filter does not apply to <span class="mono">/api/inventory</span>.</p>
+  </div>
+
+  <footer class="page">
+    <span>Factory Inventory Management System — architecture overview</span>
+    <span>Generated from source · Vue 3 + FastAPI · in-memory mock data</span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,42 +1,89 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
-          <h1>{{ t('nav.companyName') }}</h1>
-          <span class="subtitle">{{ t('nav.subtitle') }}</span>
-        </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
-        <LanguageSwitcher />
-        <ProfileMenu
-          @show-profile-details="showProfileDetails = true"
-          @show-tasks="showTasks = true"
-        />
+    <!-- Sidebar: sticky vertical nav replacing the old horizontal top-nav -->
+    <aside class="sidebar">
+      <div class="sidebar-brand">
+        <h1>{{ t('nav.companyName') }}</h1>
+        <span class="subtitle">{{ t('nav.subtitle') }}</span>
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+      <nav class="sidebar-nav">
+        <router-link to="/" :class="{ active: $route.path === '/' }">
+          <!-- Grid / Overview icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
+          </svg>
+          <span>{{ t('nav.overview') }}</span>
+        </router-link>
+
+        <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
+          <!-- Box / package icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 16V8a2 2 0 0 0-1-1.73L13 2.27a2 2 0 0 0-2 0L4 6.27A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/>
+          </svg>
+          <span>{{ t('nav.inventory') }}</span>
+        </router-link>
+
+        <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
+          <!-- Clipboard / orders icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="13" y2="16"/>
+          </svg>
+          <span>{{ t('nav.orders') }}</span>
+        </router-link>
+
+        <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
+          <!-- Bar-chart / finance icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+          </svg>
+          <span>{{ t('nav.finance') }}</span>
+        </router-link>
+
+        <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
+          <!-- Trending-up icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
+          </svg>
+          <span>{{ t('nav.demandForecast') }}</span>
+        </router-link>
+
+        <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+          <!-- Refresh / restock icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="1 4 1 10 7 10"/><polyline points="23 20 23 14 17 14"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/>
+          </svg>
+          <span>{{ t('nav.restocking') }}</span>
+        </router-link>
+
+        <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
+          <!-- Document / reports icon -->
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+          </svg>
+          <span>Reports</span>
+        </router-link>
+      </nav>
+    </aside>
+
+    <!-- App body: topbar + filter bar + page content -->
+    <div class="app-body">
+      <header class="topbar">
+        <!-- Controls group pushed to the right via margin-left:auto -->
+        <div class="topbar-controls">
+          <LanguageSwitcher />
+          <ProfileMenu
+            @show-profile-details="showProfileDetails = true"
+            @show-tasks="showTasks = true"
+          />
+        </div>
+      </header>
+
+      <FilterBar />
+
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -162,6 +209,85 @@ export default {
 </script>
 
 <style>
+/* ============================================================
+   DESIGN TOKENS
+   All hardcoded hex values and spacing throughout this file
+   reference these variables so a single edit propagates everywhere.
+   ============================================================ */
+:root {
+  /* Neutrals (slate) */
+  --bg-app: #f8fafc;
+  --bg-surface: #ffffff;
+  --bg-subtle: #f1f5f9;
+  --bg-muted: #f8fafc;
+  --border: #e2e8f0;
+  --border-strong: #cbd5e1;
+  --border-faint: #f1f5f9;
+
+  /* Text */
+  --text-strong: #0f172a;
+  --text-body: #334155;
+  --text-muted: #64748b;
+  --text-subtle: #475569;
+
+  /* Brand / primary — INDIGO/VIOLET (replaces old blue #2563eb) */
+  --primary: #4f46e5;
+  --primary-hover: #4338ca;
+  --primary-soft: #eef2ff;
+  --primary-softer: #e0e7ff;
+
+  /* Status */
+  --success: #059669;
+  --success-bg: #d1fae5;
+  --success-fg: #065f46;
+  --warning: #ea580c;
+  --warning-bg: #fed7aa;
+  --warning-fg: #92400e;
+  --danger: #dc2626;
+  --danger-bg: #fecaca;
+  --danger-fg: #991b1b;
+  /* Info retuned to indigo so it harmonizes with the new brand accent */
+  --info: #4f46e5;
+  --info-bg: #e0e7ff;
+  --info-fg: #3730a3;
+
+  /* Spacing — strict 8px rhythm */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-8: 48px;
+
+  /* Radius */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+
+  /* Type scale */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 0.938rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+  --text-2xl: 1.875rem;
+  --text-3xl: 2.25rem;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  /* Layout */
+  --sidebar-w: 248px;
+  --topbar-h: 64px;
+  --content-max: 1440px;
+}
+
+/* ============================================================
+   RESET
+   ============================================================ */
 * {
   margin: 0;
   padding: 0;
@@ -169,204 +295,289 @@ export default {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
+  font-family: var(--font-sans);
+  background: var(--bg-app);
+  color: var(--text-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ============================================================
+   APP SHELL — flex ROW so sidebar sits beside content
+   ============================================================ */
 .app {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+/* ============================================================
+   SIDEBAR
+   sticky + height:100vh so it stays fixed while content scrolls.
+   align-self:flex-start is required for position:sticky inside a
+   flex row — without it the sidebar stretches to full page height
+   and sticky has no room to activate.
+   ============================================================ */
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  align-self: flex-start;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Brand block at the top of the sidebar */
+.sidebar-brand {
+  padding: var(--space-5);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.sidebar-brand h1 {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--text-strong);
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+/* Subtitle sits directly below company name — no inline divider needed */
+.sidebar-brand .subtitle {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+/* Nav list inside the sidebar */
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  flex: 1;
+}
+
+/* Each nav link: icon + label side-by-side */
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  /* position:relative is needed for the ::before accent bar */
+  position: relative;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.sidebar-nav a svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.sidebar-nav a:hover {
+  background: var(--bg-subtle);
+  color: var(--text-strong);
+}
+
+/* Active state: indigo soft background + left accent bar */
+.sidebar-nav a.active {
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+/* Left accent bar replaces the old bottom ::after underline.
+   inset-inline-start (logical property) keeps it at the left edge.
+   Vertical inset (top/bottom 6px) gives it a "pill" look rather
+   than spanning the full height of the row. */
+.sidebar-nav a.active::before {
+  content: '';
+  position: absolute;
+  inset-inline-start: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  background: var(--primary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+/* ============================================================
+   APP BODY — flex column containing topbar, filter bar, main
+   min-width:0 prevents flex children from overflowing the row
+   when content is wider than available space.
+   ============================================================ */
+.app-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ============================================================
+   TOPBAR
+   sticky so it stays at the top of the scroll viewport.
+   The offset is 0 (not --topbar-h) because the sidebar is the
+   sibling of .app-body, not an ancestor — the topbar is the
+   first element that needs to stick.
+   ============================================================ */
+.topbar {
+  height: var(--topbar-h);
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
   position: sticky;
   top: 0;
   z-index: 100;
-}
-
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
   display: flex;
   align-items: center;
-  padding: 0 2rem;
-  height: 70px;
+  padding: 0 var(--space-6);
+  gap: var(--space-4);
 }
 
-.nav-container > .nav-tabs {
+/* Push LanguageSwitcher + ProfileMenu to the right */
+.topbar-controls {
   margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
+  align-items: center;
+  gap: var(--space-4);
 }
 
-.logo h1 {
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: #0f172a;
-  letter-spacing: -0.025em;
-}
-
-.subtitle {
-  font-size: 0.813rem;
-  color: #64748b;
-  font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
-}
-
-.nav-tabs {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
-}
-
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
-}
-
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
-}
-
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
-}
-
+/* ============================================================
+   MAIN CONTENT AREA
+   max-width keeps lines readable on ultra-wide displays.
+   margin:0 auto centers content within the remaining width once
+   the sidebar is accounted for.
+   ============================================================ */
 .main-content {
   flex: 1;
-  max-width: 1600px;
+  max-width: var(--content-max);
   width: 100%;
   margin: 0 auto;
-  padding: 1.5rem 2rem;
+  padding: var(--space-5) var(--space-6);
 }
 
+/* ============================================================
+   GLOBAL PRIMITIVES — refactored to design tokens
+   These classes are used by every view; class names are unchanged.
+   ============================================================ */
+
+/* Page header */
 .page-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
 }
 
 .page-header h2 {
-  font-size: 1.875rem;
+  font-size: var(--text-2xl);
   font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 0.375rem;
+  color: var(--text-strong);
+  margin-bottom: var(--space-1);
   letter-spacing: -0.025em;
 }
 
 .page-header p {
-  color: #64748b;
-  font-size: 0.938rem;
+  color: var(--text-muted);
+  font-size: var(--text-base);
 }
 
+/* Stats grid */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
 }
 
+/* Stat card */
 .stat-card {
-  background: white;
-  padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  transition: all 0.2s ease;
+  background: var(--bg-surface);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .stat-card:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-md);
 }
 
 .stat-label {
-  color: #64748b;
-  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 0.625rem;
+  margin-bottom: var(--space-2);
 }
 
 .stat-value {
-  font-size: 2.25rem;
+  font-size: var(--text-3xl);
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-strong);
   letter-spacing: -0.025em;
 }
 
 .stat-card.warning .stat-value {
-  color: #ea580c;
+  color: var(--warning);
 }
 
 .stat-card.success .stat-value {
-  color: #059669;
+  color: var(--success);
 }
 
 .stat-card.danger .stat-value {
-  color: #dc2626;
+  color: var(--danger);
 }
 
+/* Info stat value uses indigo brand token (retuned from old blue) */
 .stat-card.info .stat-value {
-  color: #2563eb;
+  color: var(--info);
 }
 
+/* Card */
 .card {
-  background: white;
-  border-radius: 10px;
-  padding: 1.25rem;
-  border: 1px solid #e2e8f0;
-  margin-bottom: 1.25rem;
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  margin-bottom: var(--space-5);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-md);
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 0.875rem;
-  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
 }
 
 .card-title {
-  font-size: 1.125rem;
+  font-size: var(--text-lg);
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-strong);
   letter-spacing: -0.025em;
 }
 
+/* Table */
 .table-container {
   overflow-x: auto;
 }
@@ -377,26 +588,27 @@ table {
 }
 
 thead {
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--bg-subtle);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 }
 
 th {
   text-align: left;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   font-weight: 600;
-  color: #475569;
-  font-size: 0.75rem;
+  color: var(--text-subtle);
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 td {
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid #f1f5f9;
-  color: #334155;
-  font-size: 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  /* faint border between rows rather than strong dividers */
+  border-top: 1px solid var(--border-faint);
+  color: var(--text-body);
+  font-size: var(--text-sm);
 }
 
 tbody tr {
@@ -404,83 +616,105 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background: #f8fafc;
+  background: var(--bg-muted);
 }
 
+/* Badges */
 .badge {
   display: inline-block;
-  padding: 0.313rem 0.75rem;
-  border-radius: 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.025em;
 }
 
 .badge.success {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--success-bg);
+  color: var(--success-fg);
 }
 
 .badge.warning {
-  background: #fed7aa;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--warning-fg);
 }
 
 .badge.danger {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--danger-bg);
+  color: var(--danger-fg);
 }
 
+/* Info badge retuned to indigo to harmonize with brand */
 .badge.info {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-fg);
 }
 
 .badge.increasing {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--success-bg);
+  color: var(--success-fg);
 }
 
 .badge.decreasing {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--danger-bg);
+  color: var(--danger-fg);
 }
 
+/* Stable badge uses indigo info tokens (was already e0e7ff/3730a3) */
 .badge.stable {
-  background: #e0e7ff;
-  color: #3730a3;
+  background: var(--info-bg);
+  color: var(--info-fg);
 }
 
 .badge.high {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--danger-bg);
+  color: var(--danger-fg);
 }
 
 .badge.medium {
-  background: #fed7aa;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--warning-fg);
 }
 
+/* Low badge kept as indigo info — matches old dbeafe/1e40af intent */
 .badge.low {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-fg);
 }
 
+/* Loading / error states */
 .loading {
   text-align: center;
-  padding: 3rem;
-  color: #64748b;
-  font-size: 0.938rem;
+  padding: var(--space-8);
+  color: var(--text-muted);
+  font-size: var(--text-base);
 }
 
 .error {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
-  font-size: 0.938rem;
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-bg);
+  color: var(--danger-fg);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+  font-size: var(--text-base);
+}
+
+/* Primary button — used by individual views */
+.btn-primary {
+  background: var(--primary);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover);
 }
 </style>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -99,6 +99,11 @@ export const api = {
     return response.data
   },
 
+  async submitRestockOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/orders/restock`, orderData)
+    return response.data
+  },
+
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
     return response.data

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -106,6 +107,7 @@ export default {
     title: 'Orders',
     description: 'View and manage customer orders',
     allOrders: 'All Orders',
+    submittedOrders: 'Submitted Orders',
     totalOrders: 'Total Orders',
     totalRevenue: 'Total Revenue',
     avgOrderValue: 'Avg Order Value',
@@ -125,8 +127,39 @@ export default {
       totalValue: 'Total Value',
       status: 'Status',
       expectedDelivery: 'Expected Delivery',
-      actualDelivery: 'Actual Delivery'
+      actualDelivery: 'Actual Delivery',
+      leadTime: 'Lead Time'
     }
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Set a budget and order recommended restock items from the demand forecast',
+    budgetCard: {
+      title: 'Available Budget',
+      label: 'Set your available budget',
+      help: 'Recommendations update as you adjust the budget'
+    },
+    recommendations: {
+      title: 'Recommended Restock',
+      empty: 'No items need restocking based on the current forecast.',
+      insufficient: 'Budget too low to fund any recommended item. Increase the budget to see recommendations.',
+      summaryItems: 'Items Recommended',
+      summarySpend: 'Recommended Spend',
+      summaryRemaining: 'Budget Remaining'
+    },
+    table: {
+      sku: 'SKU',
+      itemName: 'Item Name',
+      trend: 'Trend',
+      recommendedQty: 'Recommended Qty',
+      unitCost: 'Unit Cost',
+      lineTotal: 'Line Total'
+    },
+    placeOrder: 'Place Order',
+    placing: 'Placing Order...',
+    success: 'Restock order {orderNumber} submitted. View it in the Orders tab.'
   },
 
   // Finance/Spending
@@ -204,6 +237,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    submitted: 'Submitted',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -106,6 +107,7 @@ export default {
     title: '注文',
     description: '顧客注文の表示と管理',
     allOrders: 'すべての注文',
+    submittedOrders: '送信済み注文',
     totalOrders: '総注文数',
     totalRevenue: '総収益',
     avgOrderValue: '平均注文額',
@@ -125,8 +127,39 @@ export default {
       totalValue: '合計金額',
       status: 'ステータス',
       expectedDelivery: '予定配達日',
-      actualDelivery: '実際の配達日'
+      actualDelivery: '実際の配達日',
+      leadTime: 'リードタイム'
     }
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充',
+    description: '予算を設定し、需要予測から推奨される補充品目を発注します',
+    budgetCard: {
+      title: '利用可能予算',
+      label: '利用可能な予算を設定',
+      help: '予算を調整すると推奨内容が更新されます'
+    },
+    recommendations: {
+      title: '推奨補充',
+      empty: '現在の予測では補充が必要な品目はありません。',
+      insufficient: '予算が不足しているため、推奨品目を発注できません。予算を増やしてください。',
+      summaryItems: '推奨品目数',
+      summarySpend: '推奨支出額',
+      summaryRemaining: '残り予算'
+    },
+    table: {
+      sku: 'SKU',
+      itemName: '品目名',
+      trend: 'トレンド',
+      recommendedQty: '推奨数量',
+      unitCost: '単価',
+      lineTotal: '小計'
+    },
+    placeOrder: '発注する',
+    placing: '発注中...',
+    success: '補充注文 {orderNumber} を送信しました。注文タブで確認できます。'
   },
 
   // Finance/Spending
@@ -204,6 +237,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    submitted: '送信済み',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -15,6 +16,7 @@ const router = createRouter({
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
+    { path: '/restocking', component: Restocking },
     { path: '/spending', component: Spending },
     { path: '/reports', component: Reports }
   ]

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -27,9 +27,57 @@
         </div>
       </div>
 
+      <div v-if="submittedOrders.length > 0" class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('orders.submittedOrders') }} ({{ submittedOrders.length }})</h3>
+        </div>
+        <div class="table-container">
+          <table class="orders-table submitted-orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-items">{{ t('orders.table.items') }}</th>
+                <th class="col-status">{{ t('orders.table.status') }}</th>
+                <th class="col-date">{{ t('orders.table.orderDate') }}</th>
+                <th class="col-date">{{ t('orders.table.expectedDelivery') }}</th>
+                <th class="col-lead-time">{{ t('orders.table.leadTime') }}</th>
+                <th class="col-value">{{ t('orders.table.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_price }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-status">
+                  <span :class="['badge', getOrderStatusClass(order.status)]">
+                    {{ t(`status.${order.status.toLowerCase()}`) }}
+                  </span>
+                </td>
+                <td class="col-date">{{ formatDate(order.order_date) }}</td>
+                <td class="col-date">{{ formatDate(order.expected_delivery) }}</td>
+                <td class="col-lead-time">{{ order.lead_time_days }} {{ t('dashboard.inventoryShortages.days') }}</td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
+          <h3 class="card-title">{{ t('orders.allOrders') }} ({{ regularOrders.length }})</h3>
         </div>
         <div class="table-container">
           <table class="orders-table">
@@ -45,7 +93,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="order in orders" :key="order.id">
+              <tr v-for="order in regularOrders" :key="order.id">
                 <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
                 <td class="col-customer">{{ translateCustomerName(order.customer) }}</td>
                 <td class="col-items">
@@ -138,10 +186,15 @@ export default {
         'Delivered': 'success',
         'Shipped': 'info',
         'Processing': 'warning',
-        'Backordered': 'danger'
+        'Backordered': 'danger',
+        'Submitted': 'info'
       }
       return statusMap[status] || 'info'
     }
+
+    // Split orders into submitted restock orders and regular customer orders
+    const submittedOrders = computed(() => orders.value.filter(o => o.status === 'Submitted'))
+    const regularOrders = computed(() => orders.value.filter(o => o.status !== 'Submitted'))
 
     const formatDate = (dateString) => {
       const { currentLocale } = useI18n()
@@ -160,6 +213,8 @@ export default {
       loading,
       error,
       orders,
+      submittedOrders,
+      regularOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,
@@ -201,6 +256,15 @@ export default {
 
 .col-value {
   width: 120px;
+}
+
+.col-lead-time {
+  width: 110px;
+}
+
+/* Submitted orders table omits the customer column */
+.submitted-orders-table .col-items {
+  width: 220px;
 }
 
 /* Items details styling */

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,331 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+
+      <!-- Budget slider card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.budgetCard.title') }}</h3>
+        </div>
+        <div class="budget-controls">
+          <div class="budget-readout">{{ currencySymbol }}{{ budget.toLocaleString() }}</div>
+          <div class="slider-row">
+            <span class="slider-label">{{ currencySymbol }}10K</span>
+            <input
+              type="range"
+              class="budget-slider"
+              min="10000"
+              max="500000"
+              step="10000"
+              v-model.number="budget"
+            />
+            <span class="slider-label">{{ currencySymbol }}500K</span>
+          </div>
+          <p class="budget-help">{{ t('restocking.budgetCard.help') }}</p>
+        </div>
+      </div>
+
+      <!-- Recommendations card -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.recommendations.title') }}</h3>
+        </div>
+
+        <!-- Success banner: shown after a successful order placement -->
+        <div v-if="successMessage" class="success-banner">
+          {{ successMessage }}
+        </div>
+
+        <!-- Summary stat cards -->
+        <div class="stats-grid">
+          <div class="stat-card info">
+            <div class="stat-label">{{ t('restocking.recommendations.summaryItems') }}</div>
+            <div class="stat-value">{{ recommendations.length }}</div>
+          </div>
+          <div class="stat-card success">
+            <div class="stat-label">{{ t('restocking.recommendations.summarySpend') }}</div>
+            <div class="stat-value">{{ currencySymbol }}{{ totalSpend.toLocaleString() }}</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">{{ t('restocking.recommendations.summaryRemaining') }}</div>
+            <div class="stat-value">{{ currencySymbol }}{{ remainingBudget.toLocaleString() }}</div>
+          </div>
+        </div>
+
+        <!-- Empty / insufficient state -->
+        <div v-if="recommendations.length === 0" class="empty-state">
+          <span v-if="hasCandidates">{{ t('restocking.recommendations.insufficient') }}</span>
+          <span v-else>{{ t('restocking.recommendations.empty') }}</span>
+        </div>
+
+        <!-- Recommendations table -->
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>{{ t('restocking.table.sku') }}</th>
+                <th>{{ t('restocking.table.itemName') }}</th>
+                <th>{{ t('restocking.table.trend') }}</th>
+                <th>{{ t('restocking.table.recommendedQty') }}</th>
+                <th>{{ t('restocking.table.unitCost') }}</th>
+                <th>{{ t('restocking.table.lineTotal') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in recommendations" :key="row.sku">
+                <td><strong>{{ row.sku }}</strong></td>
+                <td>{{ row.name }}</td>
+                <td>
+                  <span :class="['badge', row.trend]">{{ t('trends.' + row.trend) }}</span>
+                </td>
+                <td>{{ row.qty }}</td>
+                <td>{{ currencySymbol }}{{ row.unit_cost.toLocaleString() }}</td>
+                <td><strong>{{ currencySymbol }}{{ row.lineTotal.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Place Order button -->
+        <div class="action-row">
+          <button
+            class="btn-primary"
+            :disabled="recommendations.length === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? t('restocking.placing') : t('restocking.placeOrder') }}
+          </button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, computed } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency } = useI18n()
+
+    // Mirror the currency symbol pattern from Orders.vue (lines 92-94)
+    const currencySymbol = computed(() => currentCurrency.value === 'JPY' ? '¥' : '$')
+
+    const loading = ref(true)
+    const error = ref(null)
+    const allForecasts = ref([])
+    const budget = ref(100000)
+    const submitting = ref(false)
+    const successMessage = ref('')
+
+    const loadForecasts = async () => {
+      try {
+        loading.value = true
+        error.value = null
+        allForecasts.value = await api.getDemandForecasts()
+      } catch (err) {
+        error.value = 'Failed to load demand forecasts: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    /**
+     * Greedy partial-fill algorithm:
+     * Sort candidates by demand gap (largest shortfall first) so the biggest
+     * needs get funded before the budget runs dry. For each candidate, take
+     * min(gap, floor(remaining / unit_cost)) so the budget visibly binds —
+     * a partially-affordable item still consumes as many units as the budget
+     * allows, and leftover budget can fund cheaper items further down the list.
+     */
+    const recommendations = computed(() => {
+      const candidates = allForecasts.value
+        .filter(item => (item.forecasted_demand - item.current_demand) > 0)
+        .map(item => ({
+          sku: item.item_sku,
+          name: item.item_name,
+          trend: item.trend,
+          unit_cost: item.unit_cost,
+          gap: item.forecasted_demand - item.current_demand
+        }))
+        .sort((a, b) => b.gap - a.gap) // largest shortfall first
+
+      let remaining = budget.value
+      const result = []
+
+      for (const candidate of candidates) {
+        // Affordable quantity: capped at the demand gap so we don't over-order
+        const qty = Math.min(candidate.gap, Math.floor(remaining / candidate.unit_cost))
+        if (qty >= 1) {
+          const lineTotal = qty * candidate.unit_cost
+          result.push({
+            sku: candidate.sku,
+            name: candidate.name,
+            trend: candidate.trend,
+            unit_cost: candidate.unit_cost,
+            qty,
+            lineTotal
+          })
+          remaining -= lineTotal
+        }
+      }
+
+      return result
+    })
+
+    // True if any forecast item has a positive demand gap (regardless of budget)
+    const hasCandidates = computed(() =>
+      allForecasts.value.some(item => (item.forecasted_demand - item.current_demand) > 0)
+    )
+
+    const totalSpend = computed(() =>
+      recommendations.value.reduce((sum, row) => sum + row.lineTotal, 0)
+    )
+
+    const remainingBudget = computed(() => budget.value - totalSpend.value)
+
+    const placeOrder = async () => {
+      submitting.value = true
+      successMessage.value = ''
+      try {
+        const items = recommendations.value.map(r => ({
+          sku: r.sku,
+          name: r.name,
+          quantity: r.qty,
+          unit_price: r.unit_cost
+        }))
+        const order = await api.submitRestockOrder({ items })
+        successMessage.value = t('restocking.success', { orderNumber: order.order_number })
+      } catch (err) {
+        error.value = 'Failed to place restock order: ' + err.message
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    onMounted(loadForecasts)
+
+    return {
+      t,
+      currencySymbol,
+      loading,
+      error,
+      budget,
+      submitting,
+      successMessage,
+      recommendations,
+      hasCandidates,
+      totalSpend,
+      remainingBudget,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* Budget slider section */
+.budget-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 0 0.5rem;
+}
+
+.budget-readout {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.025em;
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+.budget-slider {
+  flex: 1;
+  height: 6px;
+  accent-color: #2563eb;
+  cursor: pointer;
+}
+
+.slider-label {
+  font-size: 0.813rem;
+  color: #64748b;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.budget-help {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* Success banner */
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+  font-size: 0.938rem;
+  font-weight: 500;
+  margin-bottom: 1.25rem;
+}
+
+/* Empty / insufficient message */
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+/* Place Order button row */
+.action-row {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1.25rem;
+  border-top: 1px solid #e2e8f0;
+  margin-top: 1.25rem;
+}
+
+/* Primary button — mirrors #2563eb blue used throughout the app */
+.btn-primary {
+  background: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.625rem 1.5rem;
+  font-size: 0.938rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -4,80 +4,129 @@
     "item_sku": "WDG-001",
     "item_name": "Industrial Widget Type A",
     "current_demand": 300,
-    "forecasted_demand": 450,
+    "forecasted_demand": 600,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 85.0
   },
   {
     "id": "2",
     "item_sku": "BRG-102",
     "item_name": "Steel Bearing Assembly",
     "current_demand": 150,
-    "forecasted_demand": 152,
-    "trend": "stable",
-    "period": "Next 30 days"
+    "forecasted_demand": 600,
+    "trend": "increasing",
+    "period": "Next 30 days",
+    "unit_cost": 78.5
   },
   {
     "id": "3",
     "item_sku": "GSK-203",
     "item_name": "High-Temperature Gasket",
     "current_demand": 500,
-    "forecasted_demand": 600,
-    "trend": "increasing",
-    "period": "Next 30 days"
+    "forecasted_demand": 505,
+    "trend": "stable",
+    "period": "Next 30 days",
+    "unit_cost": 42.0
   },
   {
     "id": "4",
     "item_sku": "MTR-304",
     "item_name": "Electric Motor 5HP",
     "current_demand": 50,
-    "forecasted_demand": 35,
-    "trend": "decreasing",
-    "period": "Next 30 days"
+    "forecasted_demand": 260,
+    "trend": "increasing",
+    "period": "Next 30 days",
+    "unit_cost": 320.0
   },
   {
     "id": "5",
     "item_sku": "FLT-405",
     "item_name": "Oil Filter Cartridge",
     "current_demand": 800,
-    "forecasted_demand": 950,
+    "forecasted_demand": 1400,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 24.5
   },
   {
     "id": "6",
     "item_sku": "VLV-506",
     "item_name": "Pressure Relief Valve",
-    "current_demand": 120,
-    "forecasted_demand": 121,
+    "current_demand": 360,
+    "forecasted_demand": 363,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 64.0
   },
   {
     "id": "7",
     "item_sku": "PSU-501",
     "item_name": "5V 10A Switching Power Supply",
     "current_demand": 250,
-    "forecasted_demand": 252,
-    "trend": "stable",
-    "period": "Next 30 days"
+    "forecasted_demand": 900,
+    "trend": "increasing",
+    "period": "Next 30 days",
+    "unit_cost": 18.99
   },
   {
     "id": "8",
     "item_sku": "SNR-420",
     "item_name": "Temperature Sensor Module",
-    "current_demand": 180,
-    "forecasted_demand": 182,
+    "current_demand": 600,
+    "forecasted_demand": 605,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 89.5
   },
   {
     "id": "9",
     "item_sku": "CTL-330",
     "item_name": "Logic Controller Board",
-    "current_demand": 95,
-    "forecasted_demand": 96,
+    "current_demand": 480,
+    "forecasted_demand": 484,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 145.0
+  },
+  {
+    "id": "10",
+    "item_sku": "SRV-301",
+    "item_name": "Servo Motor Drive",
+    "current_demand": 20,
+    "forecasted_demand": 180,
+    "trend": "increasing",
+    "period": "Next 30 days",
+    "unit_cost": 445.0
+  },
+  {
+    "id": "11",
+    "item_sku": "STP-303",
+    "item_name": "Stepper Motor NEMA 23",
+    "current_demand": 40,
+    "forecasted_demand": 300,
+    "trend": "increasing",
+    "period": "Next 30 days",
+    "unit_cost": 285.0
+  },
+  {
+    "id": "12",
+    "item_sku": "CBL-210",
+    "item_name": "Shielded Signal Cable",
+    "current_demand": 300,
+    "forecasted_demand": 305,
+    "trend": "stable",
+    "period": "Next 30 days",
+    "unit_cost": 6.75
+  },
+  {
+    "id": "13",
+    "item_sku": "OBS-700",
+    "item_name": "Legacy Relay Module",
+    "current_demand": 200,
+    "forecasted_demand": 120,
+    "trend": "decreasing",
+    "period": "Next 30 days",
+    "unit_cost": 52.0
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -1,10 +1,14 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
+from datetime import datetime, timedelta
 from pydantic import BaseModel
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
+
+# Standard supplier lead time applied to every restock order (demo uses a single fixed value)
+RESTOCK_LEAD_TIME_DAYS = 14
 
 # Quarter mapping for date filtering
 QUARTER_MAP = {
@@ -80,6 +84,8 @@ class Order(BaseModel):
     actual_delivery: Optional[str] = None
     warehouse: Optional[str] = None
     category: Optional[str] = None
+    # Set only for restock orders; seeded orders leave this null
+    lead_time_days: Optional[int] = None
 
 class DemandForecast(BaseModel):
     id: str
@@ -89,6 +95,7 @@ class DemandForecast(BaseModel):
     forecasted_demand: int
     trend: str
     period: str
+    unit_cost: float
 
 class BacklogItem(BaseModel):
     id: str
@@ -118,6 +125,16 @@ class CreatePurchaseOrderRequest(BaseModel):
     quantity: int
     unit_cost: float
     expected_delivery_date: str
+    notes: Optional[str] = None
+
+class RestockOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_price: float
+
+class CreateRestockOrderRequest(BaseModel):
+    items: List[RestockOrderItem]
     notes: Optional[str] = None
 
 # API endpoints
@@ -160,6 +177,50 @@ def get_order(order_id: str):
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
     return order
+
+@app.post("/api/orders/restock", response_model=Order)
+def create_restock_order(request: CreateRestockOrderRequest):
+    """Create a restock order from budget-based recommendations.
+
+    The new order is appended to the in-memory `orders` list so it shows up in
+    GET /api/orders immediately. Like all demo data, it is not persisted to disk
+    and is lost on server restart.
+    """
+    if not request.items:
+        raise HTTPException(status_code=400, detail="A restock order must contain at least one item")
+
+    total_value = sum(item.quantity * item.unit_price for item in request.items)
+
+    # Derive the next sequential id and order number from existing orders so the
+    # new order slots in consistently with the seeded data (e.g. ORD-2025-0042).
+    max_id = max((int(o["id"]) for o in orders if str(o["id"]).isdigit()), default=0)
+    max_seq = max(
+        (int(o["order_number"].split("-")[-1]) for o in orders if o.get("order_number", "").split("-")[-1].isdigit()),
+        default=0,
+    )
+    new_id = str(max_id + 1)
+    order_number = f"ORD-2025-{max_seq + 1:04d}"
+
+    order_date = datetime.now()
+    expected_delivery = order_date + timedelta(days=RESTOCK_LEAD_TIME_DAYS)
+
+    new_order = {
+        "id": new_id,
+        "order_number": order_number,
+        "customer": "Internal Restock",
+        "items": [item.model_dump() for item in request.items],
+        "status": "Submitted",
+        "order_date": order_date.isoformat(timespec="seconds"),
+        "expected_delivery": expected_delivery.isoformat(timespec="seconds"),
+        "total_value": round(total_value, 2),
+        "actual_delivery": None,
+        "warehouse": None,
+        "category": None,
+        "lead_time_days": RESTOCK_LEAD_TIME_DAYS,
+    }
+
+    orders.append(new_order)
+    return new_order
 
 @app.get("/api/demand", response_model=List[DemandForecast])
 def get_demand_forecasts():

--- a/tests/backend/test_restock.py
+++ b/tests/backend/test_restock.py
@@ -1,0 +1,98 @@
+"""
+Tests for the restock order endpoint (POST /api/orders/restock) and the
+unit_cost field added to demand forecasts.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+
+
+class TestRestockOrderEndpoint:
+    """Test suite for the POST /api/orders/restock endpoint."""
+
+    def _sample_payload(self):
+        """A valid two-item restock request."""
+        return {
+            "items": [
+                {"sku": "WDG-001", "name": "Industrial Widget Type A", "quantity": 150, "unit_price": 85.0},
+                {"sku": "GSK-203", "name": "High-Temperature Gasket", "quantity": 100, "unit_price": 42.0},
+            ]
+        }
+
+    def test_create_restock_order_success(self, client):
+        """A valid restock order is created with Submitted status and a 14-day lead time."""
+        response = client.post("/api/orders/restock", json=self._sample_payload())
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["status"] == "Submitted"
+        assert order["customer"] == "Internal Restock"
+        assert order["lead_time_days"] == 14
+        assert order["order_number"].startswith("ORD-2025-")
+        assert len(order["items"]) == 2
+
+    def test_restock_order_total_value_calculation(self, client):
+        """total_value equals the sum of quantity * unit_price across items."""
+        payload = self._sample_payload()
+        response = client.post("/api/orders/restock", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        expected_total = sum(item["quantity"] * item["unit_price"] for item in payload["items"])
+        assert abs(order["total_value"] - expected_total) < 0.01
+
+    def test_restock_order_lead_time_matches_dates(self, client):
+        """expected_delivery is exactly 14 days after order_date."""
+        response = client.post("/api/orders/restock", json=self._sample_payload())
+        assert response.status_code == 200
+
+        order = response.json()
+        order_date = datetime.fromisoformat(order["order_date"])
+        expected_delivery = datetime.fromisoformat(order["expected_delivery"])
+        assert expected_delivery - order_date == timedelta(days=14)
+
+    def test_restock_order_appears_in_orders_list(self, client):
+        """A newly created restock order is returned by GET /api/orders."""
+        create_response = client.post("/api/orders/restock", json=self._sample_payload())
+        new_id = create_response.json()["id"]
+
+        list_response = client.get("/api/orders")
+        assert list_response.status_code == 200
+        all_ids = [order["id"] for order in list_response.json()]
+        assert new_id in all_ids
+
+    def test_restock_order_retrievable_by_id(self, client):
+        """A newly created restock order can be fetched by its id."""
+        new_id = client.post("/api/orders/restock", json=self._sample_payload()).json()["id"]
+
+        response = client.get(f"/api/orders/{new_id}")
+        assert response.status_code == 200
+        assert response.json()["id"] == new_id
+        assert response.json()["status"] == "Submitted"
+
+    def test_restock_order_empty_items_rejected(self, client):
+        """An order with no items returns a 400 error."""
+        response = client.post("/api/orders/restock", json={"items": []})
+        assert response.status_code == 400
+        assert "detail" in response.json()
+
+    def test_restock_order_missing_items_field(self, client):
+        """A malformed payload (missing required items) returns a 422 validation error."""
+        response = client.post("/api/orders/restock", json={"notes": "no items"})
+        assert response.status_code == 422
+
+
+class TestDemandForecastUnitCost:
+    """Verify the unit_cost field added to demand forecasts."""
+
+    def test_demand_forecasts_include_unit_cost(self, client):
+        """Every demand forecast item exposes a non-negative numeric unit_cost."""
+        response = client.get("/api/demand")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 0
+        for forecast in data:
+            assert "unit_cost" in forecast
+            assert isinstance(forecast["unit_cost"], (int, float))
+            assert forecast["unit_cost"] >= 0


### PR DESCRIPTION
- Redesign App.vue shell into a left-sidebar SaaS layout with an indigo accent and a consistent design-token system (saas-redesign skill)
- Add Restocking view with budget-driven recommendation flow, backed by a new POST /api/orders/restock endpoint and demand forecast data
- Update en/ja locales and routes for the new nav and Restocking tab
- Add backend test for the restock endpoint
- Pin public npm registry via root .npmrc; add architecture.html