### PR TITLE
Redesign client into SaaS-style UI with left sidebar navigation

### DIFF
--- a/.claude/skills/saas-ui-redesign/SKILL.md
+++ b/.claude/skills/saas-ui-redesign/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: saas-ui-redesign
+description: Redesign the Vue 3 client in client/ into a modern SaaS-style interface with a left vertical navigation sidebar (replacing the top nav bar), a design-token system, consistent spacing, and a polished professional look. Use this skill when the user asks to redesign, modernize, or polish the frontend UI; move navigation to a sidebar / vertical nav / left nav; give the app a "SaaS look"; improve spacing, layout, or visual consistency; or restyle App.vue and the shell.
+---
+
+# SaaS UI Redesign
+
+This skill converts the Factory Inventory Management client (`client/`, Vue 3 + Vite) from its
+current sticky **top nav bar** into a modern SaaS layout: a **left vertical sidebar** for
+navigation, a **CSS custom-property design-token system**, a **consistent spacing scale**, and
+a clean, professional finish. The existing slate/blue palette and Inter typeface are kept — this
+is about layout structure, consistency, and polish, not a new color scheme.
+
+## Operating rules (non-negotiable)
+
+- **Delegate every `.vue` edit to the `vue-expert` subagent.** Per this repo's CLAUDE.md, any
+  time you create or significantly modify a `.vue` file you MUST use the `vue-expert` subagent.
+  Give it the relevant reference file content and the preservation checklist below.
+- **Verify in a real browser with Playwright MCP** (`mcp__playwright__*`) against
+  `http://localhost:3000`. Start the servers with the `start` skill first.
+- **Preserve behavior.** This is a visual/layout redesign. Routing, data loading, i18n, filters,
+  and modals must work exactly as before (see the checklist in Phase 6).
+- **Document non-obvious changes with a brief comment** explaining the "why", matching the
+  surrounding style.
+
+## Target design language
+
+- **Left sidebar** (~248px): brand at top, vertical nav in the middle, `LanguageSwitcher` +
+  `ProfileMenu` in the footer. Collapses on narrow viewports.
+- **Token-driven** color, spacing, radius, shadow, and z-index — one source of truth on `:root`.
+- **8px spacing rhythm** so gaps, padding, and margins are consistent across cards, tables, and grids.
+- **Card-based surfaces** on a soft `--color-bg`, restrained shadows, clear active-nav state.
+
+## Reference files
+
+- `references/design-tokens.md` — the `:root` custom-property block to add to `App.vue`, plus a
+  literal→token refactor map. **Read this before Phase 1.**
+- `references/sidebar-layout.md` — the target `App.vue` template + shell CSS, FilterBar
+  repositioning, and dropdown notes. **Read this before Phase 2.**
+
+## Procedure
+
+Work in phases. After each phase that touches a `.vue` file, hand the change to `vue-expert`.
+
+### Phase 1 — Establish design tokens
+1. Read `references/design-tokens.md`.
+2. Have `vue-expert` add the `:root` token block to the top of the global `<style>` in
+   `client/src/App.vue` (before the `*` reset).
+3. Refactor the existing global rules to consume tokens using the mapping table. Snap arbitrary
+   rem values to the nearest spacing step. This is the foundation for "consistent spacing".
+
+### Phase 2 — Build the sidebar shell
+1. Read `references/sidebar-layout.md`.
+2. Have `vue-expert` restructure `App.vue`'s **template** from `.top-nav` (flex column) to the
+   two-column `.app` (flex row) → `aside.sidebar` + `.main`. Move the logo to `.sidebar-brand`,
+   the six `router-link`s into a vertical `.sidebar-nav`, and `LanguageSwitcher` + `ProfileMenu`
+   into `.sidebar-footer`.
+3. Add the shell CSS from the reference. The `<script>` block does not change.
+
+### Phase 3 — Reposition FilterBar & content
+1. `FilterBar` moves from `top: 70px` sticky to `top: 0` within the main column
+   (`client/src/components/FilterBar.vue`).
+2. Update `.main-content` to center at `--content-max` with token padding.
+
+### Phase 4 — Polish pass
+1. Sweep App.vue global styles for any remaining hardcoded colors/spacing and replace with tokens.
+2. Unify card / table / badge / stat-card padding and gaps to the spacing scale so every surface
+   shares the same rhythm. Confirm hover, focus-ring, and active states read as intentional.
+
+### Phase 5 — Responsive
+1. Add the sidebar collapse behavior (icon rail under `1024px`; consider off-canvas + a toggle on
+   mobile). The main column stays fluid with `min-width: 0` so wide tables don't overflow.
+
+### Phase 6 — Verify (Playwright MCP)
+1. Ensure servers run (`start` skill), then drive `http://localhost:3000`.
+2. Screenshot and check **every route**: `/`, `/inventory`, `/orders`, `/spending`, `/demand`,
+   `/reports`.
+3. Confirm the **preservation checklist** below all holds. Fix regressions before finishing.
+
+## Preservation checklist
+
+The redesign must keep all of this working:
+
+- **Routes & nav:** all six `router-link`s (`/`, `/inventory`, `/orders`, `/spending`, `/demand`,
+  `/reports`), their `t('nav.*')` i18n labels, and the manual
+  `:class="{ active: $route.path === '…' }"` active binding. Add `aria-current="page"` to the
+  active link.
+- **Profile & tasks:** `ProfileMenu` still emits `@show-profile-details` and `@show-tasks`;
+  `ProfileDetailsModal` and `TasksModal` keep their existing props and the
+  `add/delete/toggle-task` handlers.
+- **Filters:** `FilterBar` and its four filters behave exactly as before.
+- **i18n:** `LanguageSwitcher` still toggles locale/currency; no hardcoded strings introduced
+  (except the already-hardcoded "Reports" label).
+- **Layering:** modals (`--z-modal`) render above the sidebar; dropdowns
+  (`--z-dropdown`) above the sidebar but below modals; reposition sidebar-footer dropdowns to
+  open upward so they aren't clipped.
+- **Views untouched:** the 7 files in `client/src/views/` rely on `.main-content` padding — keep
+  that contract so views need no changes.
+
+## Done when
+
+Every route renders in the new sidebar layout with consistent token-driven spacing, the active
+nav item is clearly marked, the layout is responsive, and the full preservation checklist passes
+in Playwright with no console errors.

--- a/.claude/skills/saas-ui-redesign/references/design-tokens.md
+++ b/.claude/skills/saas-ui-redesign/references/design-tokens.md
@@ -1,0 +1,100 @@
+# Design Tokens
+
+The current client hardcodes every color, radius, and spacing value inline throughout
+`client/src/App.vue`'s global `<style>` block. The first step of the redesign is to introduce
+a single source of truth as CSS custom properties on `:root`, then refactor the existing rules
+to consume them.
+
+**Palette is preserved** — these tokens are lifted directly from the values already in
+App.vue (slate neutrals, `#2563eb` brand, semantic success/warning/danger/info). The point is
+consistency and a spacing scale, not a new color scheme.
+
+## The `:root` block
+
+Add this at the very top of the global `<style>` in `App.vue` (before the `*` reset). Then
+replace literal values elsewhere with `var(--token)`.
+
+```css
+:root {
+  /* ---- Neutrals (slate) ---- */
+  --color-bg:            #f8fafc;  /* app background, subtle surfaces */
+  --color-surface:       #ffffff;  /* cards, sidebar, nav */
+  --color-border:        #e2e8f0;  /* default borders / dividers */
+  --color-border-strong: #cbd5e1;  /* hover borders */
+  --color-text:          #334155;  /* body text */
+  --color-text-strong:   #0f172a;  /* headings */
+  --color-text-muted:    #64748b;  /* secondary / labels */
+  --color-text-subtle:   #475569;  /* table headers */
+
+  /* ---- Brand ---- */
+  --color-primary:       #2563eb;
+  --color-primary-dark:  #1e40af;
+  --color-primary-soft:  #eff6ff;  /* active nav background */
+  --color-focus-ring:    rgba(59, 130, 246, 0.1);
+
+  /* ---- Semantic (text on tinted bg) ---- */
+  --color-success:     #059669;  --color-success-bg:  #d1fae5;  --color-success-ink: #065f46;
+  --color-warning:     #ea580c;  --color-warning-bg:  #fed7aa;  --color-warning-ink: #92400e;
+  --color-danger:      #dc2626;  --color-danger-bg:   #fecaca;  --color-danger-ink:  #991b1b;
+  --color-info:        #2563eb;  --color-info-bg:     #dbeafe;  --color-info-ink:    #1e40af;
+
+  /* ---- Spacing scale (4px base, 8px rhythm) ---- */
+  --space-1: 0.25rem;  /*  4px */
+  --space-2: 0.5rem;   /*  8px */
+  --space-3: 0.75rem;  /* 12px */
+  --space-4: 1rem;     /* 16px */
+  --space-5: 1.25rem;  /* 20px */
+  --space-6: 1.5rem;   /* 24px */
+  --space-8: 2rem;     /* 32px */
+  --space-12: 3rem;    /* 48px */
+
+  /* ---- Radius ---- */
+  --radius-sm: 6px;    /* buttons, inputs, badges */
+  --radius-md: 10px;   /* cards, panels */
+  --radius-full: 9999px;
+
+  /* ---- Shadows ---- */
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
+
+  /* ---- Typography ---- */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+               Ubuntu, Cantarell, sans-serif;
+
+  /* ---- Layout ---- */
+  --sidebar-width: 248px;
+  --sidebar-width-collapsed: 68px;
+  --content-max: 1440px;
+
+  /* ---- Z-index scale ---- */
+  --z-sidebar: 50;
+  --z-filterbar: 40;
+  --z-dropdown: 200;
+  --z-modal: 1000;
+}
+```
+
+## Refactor guidance
+
+When applying tokens, map the existing literals like this (non-exhaustive):
+
+| Current literal | Token |
+|---|---|
+| `background: #f8fafc` (body) | `var(--color-bg)` |
+| `#ffffff` card/nav backgrounds | `var(--color-surface)` |
+| `#e2e8f0` borders | `var(--color-border)` |
+| `#0f172a` headings | `var(--color-text-strong)` |
+| `#64748b` labels/subtitles | `var(--color-text-muted)` |
+| `#2563eb` active/brand | `var(--color-primary)` |
+| `padding: 1.25rem` (cards) | `var(--space-5)` |
+| `padding: 1.5rem 2rem` (main) | `var(--space-6) var(--space-8)` |
+| `gap: 1.25rem` (grids) | `var(--space-5)` |
+| `border-radius: 10px` | `var(--radius-md)` |
+| `border-radius: 6px` | `var(--radius-sm)` |
+| header `box-shadow` | `var(--shadow-sm)` |
+
+**Consistency rule:** after refactoring, no spacing value in App.vue's global styles should be
+an arbitrary rem literal — round each to the nearest step on the scale (`--space-1`…`--space-12`).
+Snap odd values (`0.313rem`, `0.375rem`, `0.625rem`, `0.813rem`, `0.938rem`) to the nearest token;
+prefer `--space-2`/`--space-3` over reintroducing one-off decimals.

--- a/.claude/skills/saas-ui-redesign/references/sidebar-layout.md
+++ b/.claude/skills/saas-ui-redesign/references/sidebar-layout.md
@@ -1,0 +1,217 @@
+# Sidebar Layout — target App.vue shell
+
+This is the reference target for converting `client/src/App.vue` from a sticky **top nav** to a
+**left vertical sidebar** SaaS layout. It is a template to adapt, not a verbatim paste — preserve
+the app's real component wiring, i18n keys, and events (see the preservation checklist in SKILL.md).
+
+## Current shell (what you are replacing)
+
+```
+.app (flex column)
+├── header.top-nav (sticky top:0, z 100)  →  .nav-container (max 1600px, 70px)
+│     .logo · nav.nav-tabs (horizontal router-links) · <LanguageSwitcher> · <ProfileMenu>
+├── <FilterBar />        (sticky top:70px, z 90)
+└── main.main-content    (max 1600px, padding 1.5rem 2rem) → <router-view>
+```
+
+## Target shell
+
+```
+.app (flex row)
+├── aside.sidebar (fixed width, full height, z --z-sidebar)
+│     .sidebar-brand   → logo + subtitle
+│     nav.sidebar-nav  → vertical router-links (icon + label)
+│     .sidebar-footer  → <LanguageSwitcher> + <ProfileMenu>
+└── .main (flex column, flex:1, min-width:0)
+      <FilterBar />           (sticky top:0, z --z-filterbar)
+      main.main-content       (max --content-max, centered) → <router-view>
+```
+
+## Template
+
+```vue
+<template>
+  <div class="app">
+    <aside class="sidebar">
+      <div class="sidebar-brand">
+        <h1>{{ t('nav.companyName') }}</h1>
+        <span class="subtitle">{{ t('nav.subtitle') }}</span>
+      </div>
+
+      <nav class="sidebar-nav">
+        <router-link to="/" :class="{ active: $route.path === '/' }"
+                     :aria-current="$route.path === '/' ? 'page' : null">
+          {{ t('nav.overview') }}
+        </router-link>
+        <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }"
+                     :aria-current="$route.path === '/inventory' ? 'page' : null">
+          {{ t('nav.inventory') }}
+        </router-link>
+        <router-link to="/orders" :class="{ active: $route.path === '/orders' }"
+                     :aria-current="$route.path === '/orders' ? 'page' : null">
+          {{ t('nav.orders') }}
+        </router-link>
+        <router-link to="/spending" :class="{ active: $route.path === '/spending' }"
+                     :aria-current="$route.path === '/spending' ? 'page' : null">
+          {{ t('nav.finance') }}
+        </router-link>
+        <router-link to="/demand" :class="{ active: $route.path === '/demand' }"
+                     :aria-current="$route.path === '/demand' ? 'page' : null">
+          {{ t('nav.demandForecast') }}
+        </router-link>
+        <router-link to="/reports" :class="{ active: $route.path === '/reports' }"
+                     :aria-current="$route.path === '/reports' ? 'page' : null">
+          Reports
+        </router-link>
+      </nav>
+
+      <div class="sidebar-footer">
+        <LanguageSwitcher />
+        <ProfileMenu
+          @show-profile-details="showProfileDetails = true"
+          @show-tasks="showTasks = true"
+        />
+      </div>
+    </aside>
+
+    <div class="main">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
+
+    <!-- Modals stay at app root, above the sidebar -->
+    <ProfileDetailsModal :is-open="showProfileDetails" @close="showProfileDetails = false" />
+    <TasksModal
+      :is-open="showTasks"
+      :tasks="tasks"
+      @close="showTasks = false"
+      @add-task="addTask"
+      @delete-task="deleteTask"
+      @toggle-task="toggleTask"
+    />
+  </div>
+</template>
+```
+
+The `<script>` block is unchanged — the same imports, `setup()`, task handlers, and returns.
+Only the template and `<style>` change.
+
+## Shell CSS (uses tokens from design-tokens.md)
+
+```css
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* ---- Sidebar ---- */
+.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  height: 100vh;
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  z-index: var(--z-sidebar);
+}
+
+.sidebar-brand {
+  padding: var(--space-6) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
+}
+.sidebar-brand h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+  letter-spacing: -0.025em;
+}
+.sidebar-brand .subtitle {
+  display: block;
+  margin-top: var(--space-1);
+  font-size: 0.813rem;
+  color: var(--color-text-muted);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-3);
+  flex: 1;
+  overflow-y: auto;
+}
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.938rem;
+  transition: all 0.15s ease;
+}
+.sidebar-nav a:hover {
+  color: var(--color-text-strong);
+  background: var(--color-bg);
+}
+.sidebar-nav a.active {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  font-weight: 600;
+}
+
+.sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+/* ---- Main column ---- */
+.main {
+  flex: 1;
+  min-width: 0;              /* prevents flex overflow of wide tables */
+  display: flex;
+  flex-direction: column;
+}
+.main-content {
+  flex: 1;
+  width: 100%;
+  max-width: var(--content-max);
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-8);
+}
+
+/* ---- Responsive: collapse to icon rail, then off-canvas ---- */
+@media (max-width: 1024px) {
+  .sidebar { width: var(--sidebar-width-collapsed); }
+  .sidebar-brand .subtitle,
+  .sidebar-nav a span.label { display: none; }   /* keep icons if present */
+}
+```
+
+## FilterBar repositioning
+
+`FilterBar.vue` currently sticks at `top: 70px` (below the old header). In the new layout there
+is no top header, so it sticks to the top of the main column:
+
+- Change `.filters-bar { position: sticky; top: 70px; z-index: 90; }`
+  → `top: 0; z-index: var(--z-filterbar);`
+- Drop the old `max-width: 1600px` centering if the bar should span the main column; otherwise
+  align its inner container to `--content-max` to match `.main-content`.
+
+## Dropdown positioning note
+
+`ProfileMenu.vue` and `LanguageSwitcher.vue` open dropdowns with `position: absolute; top:
+calc(100% + 0.5rem); right: 0`. In the sidebar footer they should open **upward / rightward** so
+they aren't clipped at the bottom-left of the viewport — e.g. `bottom: calc(100% + 0.5rem); left: 0`.
+Ensure their `z-index` uses `var(--z-dropdown)` (above the sidebar, below modals).

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,43 +1,120 @@
 <template>
   <div class="app">
-    <header class="top-nav">
-      <div class="nav-container">
-        <div class="logo">
+    <aside class="sidebar" :class="{ collapsed }">
+      <div class="sidebar-brand">
+        <div class="sidebar-brand-text">
           <h1>{{ t('nav.companyName') }}</h1>
           <span class="subtitle">{{ t('nav.subtitle') }}</span>
         </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
-        <LanguageSwitcher />
+        <!-- Manual toggle only makes sense above the 1024px breakpoint; below it,
+             collapse is forced by isNarrow so the button would be a no-op -->
+        <button
+          v-if="!isNarrow"
+          class="sidebar-toggle"
+          type="button"
+          :aria-label="collapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+          :aria-expanded="!collapsed"
+          @click="toggleSidebar"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+            <path
+              v-if="collapsed"
+              d="M6.5 4L11.5 9L6.5 14"
+              stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+            />
+            <path
+              v-else
+              d="M11.5 4L6.5 9L11.5 14"
+              stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <nav class="sidebar-nav">
+        <!-- aria-current announces the active route to assistive tech; :class binding unchanged.
+             :title / :aria-label expose the label via native tooltip + a11y tree when collapsed. -->
+        <router-link to="/" :class="{ active: $route.path === '/' }"
+                     :aria-current="$route.path === '/' ? 'page' : null"
+                     :title="t('nav.overview')" :aria-label="t('nav.overview')">
+          <svg class="nav-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <rect x="3" y="3" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="11" y="3" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="3" y="11" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="11" y="11" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+          </svg>
+          <span class="label">{{ t('nav.overview') }}</span>
+        </router-link>
+        <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }"
+                     :aria-current="$route.path === '/inventory' ? 'page' : null"
+                     :title="t('nav.inventory')" :aria-label="t('nav.inventory')">
+          <svg class="nav-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M3 6.5L10 3L17 6.5L10 10L3 6.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+            <path d="M3 6.5V13.5L10 17L17 13.5V6.5" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+            <path d="M10 10V17" stroke="currentColor" stroke-width="1.5"/>
+          </svg>
+          <span class="label">{{ t('nav.inventory') }}</span>
+        </router-link>
+        <router-link to="/orders" :class="{ active: $route.path === '/orders' }"
+                     :aria-current="$route.path === '/orders' ? 'page' : null"
+                     :title="t('nav.orders')" :aria-label="t('nav.orders')">
+          <svg class="nav-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <rect x="5" y="3" width="10" height="14" rx="1.5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M7.5 3V2.5C7.5 2 8 1.5 8.5 1.5H11.5C12 1.5 12.5 2 12.5 2.5V3" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M7.5 9H12.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <path d="M7.5 12H12.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          <span class="label">{{ t('nav.orders') }}</span>
+        </router-link>
+        <router-link to="/spending" :class="{ active: $route.path === '/spending' }"
+                     :aria-current="$route.path === '/spending' ? 'page' : null"
+                     :title="t('nav.finance')" :aria-label="t('nav.finance')">
+          <svg class="nav-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M10 2.5V17.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <path d="M13.5 5.5H8.5C7.4 5.5 6.5 6.4 6.5 7.5C6.5 8.6 7.4 9.5 8.5 9.5H11.5C12.6 9.5 13.5 10.4 13.5 11.5C13.5 12.6 12.6 13.5 11.5 13.5H6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="label">{{ t('nav.finance') }}</span>
+        </router-link>
+        <router-link to="/demand" :class="{ active: $route.path === '/demand' }"
+                     :aria-current="$route.path === '/demand' ? 'page' : null"
+                     :title="t('nav.demandForecast')" :aria-label="t('nav.demandForecast')">
+          <svg class="nav-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M3 14L7.5 9.5L11 12.5L17 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M12.5 6H17V10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="label">{{ t('nav.demandForecast') }}</span>
+        </router-link>
+        <router-link to="/reports" :class="{ active: $route.path === '/reports' }"
+                     :aria-current="$route.path === '/reports' ? 'page' : null"
+                     title="Reports" aria-label="Reports">
+          <svg class="nav-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <rect x="3" y="10" width="3.5" height="7" rx="0.5" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="8.25" y="6" width="3.5" height="11" rx="0.5" stroke="currentColor" stroke-width="1.5"/>
+            <rect x="13.5" y="3" width="3.5" height="14" rx="0.5" stroke="currentColor" stroke-width="1.5"/>
+          </svg>
+          <span class="label">Reports</span>
+        </router-link>
+      </nav>
+
+      <!-- Footer dropdowns (LanguageSwitcher, ProfileMenu) open upward - see their scoped styles -->
+      <div class="sidebar-footer">
+        <LanguageSwitcher :collapsed="collapsed" />
         <ProfileMenu
+          :collapsed="collapsed"
           @show-profile-details="showProfileDetails = true"
           @show-tasks="showTasks = true"
         />
       </div>
-    </header>
-    <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    </aside>
 
+    <div class="main">
+      <FilterBar />
+      <main class="main-content">
+        <router-view />
+      </main>
+    </div>
+
+    <!-- Modals stay mounted at .app root so they layer above the sidebar via --z-modal -->
     <ProfileDetailsModal
       :is-open="showProfileDetails"
       @close="showProfileDetails = false"
@@ -55,7 +132,7 @@
 </template>
 
 <script>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
@@ -80,6 +157,26 @@ export default {
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
+
+    // Sidebar collapse state.
+    // `collapsed` is deliberately ONE derived boolean (userCollapsed || isNarrow) rather
+    // than two independent flags, so every consumer (CSS via .collapsed class, and the
+    // `collapsed` prop passed to LanguageSwitcher/ProfileMenu) reacts identically whether
+    // the user manually toggled the rail or the viewport shrank below 1024px. This avoids
+    // divergent styling/prop states between "manually collapsed" and "forced narrow".
+    const userCollapsed = ref(localStorage.getItem('sidebarCollapsed') === 'true')
+    const narrowQuery = window.matchMedia('(max-width: 1024px)')
+    const isNarrow = ref(narrowQuery.matches)
+    const collapsed = computed(() => userCollapsed.value || isNarrow.value)
+
+    const handleNarrowChange = (e) => {
+      isNarrow.value = e.matches
+    }
+
+    const toggleSidebar = () => {
+      userCollapsed.value = !userCollapsed.value
+      localStorage.setItem('sidebarCollapsed', String(userCollapsed.value))
+    }
 
     // Merge mock tasks from currentUser with API tasks
     const tasks = computed(() => {
@@ -146,7 +243,14 @@ export default {
       }
     }
 
-    onMounted(loadTasks)
+    onMounted(() => {
+      loadTasks()
+      narrowQuery.addEventListener('change', handleNarrowChange)
+    })
+
+    onBeforeUnmount(() => {
+      narrowQuery.removeEventListener('change', handleNarrowChange)
+    })
 
     return {
       t,
@@ -155,13 +259,78 @@ export default {
       tasks,
       addTask,
       deleteTask,
-      toggleTask
+      toggleTask,
+      collapsed,
+      toggleSidebar,
+      isNarrow
     }
   }
 }
 </script>
 
 <style>
+/* ==== Design tokens ====
+   Single source of truth for color/spacing/radius/shadow/z-index. Palette values are
+   lifted 1:1 from the previous hardcoded literals below - no new colors introduced. */
+:root {
+  /* ---- Neutrals (slate) ---- */
+  --color-bg:            #f8fafc;  /* app background, subtle surfaces */
+  --color-surface:       #ffffff;  /* cards, sidebar, nav */
+  --color-border:        #e2e8f0;  /* default borders / dividers */
+  --color-border-strong: #cbd5e1;  /* hover borders */
+  --color-text:          #334155;  /* body text */
+  --color-text-strong:   #0f172a;  /* headings */
+  --color-text-muted:    #64748b;  /* secondary / labels */
+  --color-text-subtle:   #475569;  /* table headers */
+
+  /* ---- Brand ---- */
+  --color-primary:       #2563eb;
+  --color-primary-dark:  #1e40af;
+  --color-primary-soft:  #eff6ff;  /* active nav background */
+  --color-focus-ring:    rgba(59, 130, 246, 0.1);
+
+  /* ---- Semantic (text on tinted bg) ---- */
+  --color-success:     #059669;  --color-success-bg:  #d1fae5;  --color-success-ink: #065f46;
+  --color-warning:     #ea580c;  --color-warning-bg:  #fed7aa;  --color-warning-ink: #92400e;
+  --color-danger:      #dc2626;  --color-danger-bg:   #fecaca;  --color-danger-ink:  #991b1b;
+  --color-info:        #2563eb;  --color-info-bg:     #dbeafe;  --color-info-ink:    #1e40af;
+
+  /* ---- Spacing scale (4px base, 8px rhythm) ---- */
+  --space-1: 0.25rem;  /*  4px */
+  --space-2: 0.5rem;   /*  8px */
+  --space-3: 0.75rem;  /* 12px */
+  --space-4: 1rem;     /* 16px */
+  --space-5: 1.25rem;  /* 20px */
+  --space-6: 1.5rem;   /* 24px */
+  --space-8: 2rem;     /* 32px */
+  --space-12: 3rem;    /* 48px */
+
+  /* ---- Radius ---- */
+  --radius-sm: 6px;    /* buttons, inputs, badges */
+  --radius-md: 10px;   /* cards, panels */
+  --radius-full: 9999px;
+
+  /* ---- Shadows ---- */
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
+
+  /* ---- Typography ---- */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+               Ubuntu, Cantarell, sans-serif;
+
+  /* ---- Layout ---- */
+  --sidebar-width: 248px;
+  --sidebar-width-collapsed: 68px;
+  --content-max: 1440px;
+
+  /* ---- Z-index scale ---- */
+  --z-sidebar: 50;
+  --z-filterbar: 40;
+  --z-dropdown: 200;
+  --z-modal: 1000;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -169,201 +338,277 @@ export default {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
+  font-family: var(--font-sans);
+  background: var(--color-bg);
+  color: var(--color-text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 .app {
   display: flex;
-  flex-direction: column;
   min-height: 100vh;
 }
 
-.top-nav {
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+/* ---- Sidebar ---- */
+.sidebar {
   position: sticky;
   top: 0;
-  z-index: 100;
+  align-self: flex-start;
+  height: 100vh;
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  z-index: var(--z-sidebar);
+  transition: width 0.2s ease;
 }
 
-.nav-container {
-  max-width: 1600px;
-  margin: 0 auto;
+.sidebar.collapsed {
+  width: var(--sidebar-width-collapsed);
+}
+
+.sidebar-brand {
+  padding: var(--space-6) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
   display: flex;
   align-items: center;
-  padding: 0 2rem;
-  height: 70px;
+  gap: var(--space-1);
 }
 
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.nav-container > .language-switcher {
-  margin-right: 1rem;
-}
-
-.logo {
+.sidebar-brand-text {
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+  overflow: hidden;
 }
 
-.logo h1 {
-  font-size: 1.375rem;
+.sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.sidebar-toggle:hover {
+  background: var(--color-bg);
+  color: var(--color-text-strong);
+  border-color: var(--color-border-strong);
+}
+
+.sidebar-toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Collapsed rail: hide brand text, center the toggle */
+.sidebar.collapsed .sidebar-brand {
+  padding: var(--space-6) var(--space-3);
+  justify-content: center;
+}
+
+.sidebar.collapsed .sidebar-brand-text {
+  display: none;
+}
+
+.sidebar-brand h1 {
+  font-size: 1.25rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-strong);
   letter-spacing: -0.025em;
 }
 
-.subtitle {
+.sidebar-brand .subtitle {
+  display: block;
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-weight: 400;
-  padding-left: 0.75rem;
-  border-left: 1px solid #e2e8f0;
 }
 
-.nav-tabs {
+.sidebar-nav {
   display: flex;
-  gap: 0.25rem;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-3);
+  flex: 1;
+  overflow-y: auto;
 }
 
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
   text-decoration: none;
   font-weight: 500;
   font-size: 0.938rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  position: relative;
+  transition: all 0.15s ease;
 }
 
-.nav-tabs a:hover {
-  color: #0f172a;
-  background: #f1f5f9;
+.sidebar-nav a:hover {
+  color: var(--color-text-strong);
+  background: var(--color-bg);
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
+.sidebar-nav a.active {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  font-weight: 600;
 }
 
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
+.nav-icon {
+  flex-shrink: 0;
+}
+
+/* Collapsed rail: hide text labels, center icons, keep tap target size */
+.sidebar.collapsed .sidebar-nav a {
+  justify-content: center;
+  padding: var(--space-3);
+}
+
+.sidebar.collapsed .sidebar-nav .label {
+  display: none;
+}
+
+.sidebar-nav a:focus-visible,
+.sidebar-footer button:focus-visible,
+.reset-filters-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.sidebar.collapsed .sidebar-footer {
+  align-items: center;
+}
+
+/* ---- Main column ---- */
+.main {
+  flex: 1;
+  min-width: 0;              /* prevents flex overflow of wide tables */
+  display: flex;
+  flex-direction: column;
 }
 
 .main-content {
   flex: 1;
-  max-width: 1600px;
   width: 100%;
+  max-width: var(--content-max);
   margin: 0 auto;
-  padding: 1.5rem 2rem;
+  padding: var(--space-6) var(--space-8);
 }
 
 .page-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .page-header h2 {
   font-size: 1.875rem;
   font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 0.375rem;
+  color: var(--color-text-strong);
+  margin-bottom: var(--space-2);
   letter-spacing: -0.025em;
 }
 
 .page-header p {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.938rem;
 }
 
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: var(--space-5);
+  margin-bottom: var(--space-6);
 }
 
 .stat-card {
-  background: white;
-  padding: 1.25rem;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
+  background: var(--color-surface);
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
   transition: all 0.2s ease;
 }
 
 .stat-card:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-md);
 }
 
 .stat-label {
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.875rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 0.625rem;
+  margin-bottom: var(--space-2);
 }
 
 .stat-value {
   font-size: 2.25rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-strong);
   letter-spacing: -0.025em;
 }
 
 .stat-card.warning .stat-value {
-  color: #ea580c;
+  color: var(--color-warning);
 }
 
 .stat-card.success .stat-value {
-  color: #059669;
+  color: var(--color-success);
 }
 
 .stat-card.danger .stat-value {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .stat-card.info .stat-value {
-  color: #2563eb;
+  color: var(--color-info);
 }
 
 .card {
-  background: white;
-  border-radius: 10px;
-  padding: 1.25rem;
-  border: 1px solid #e2e8f0;
-  margin-bottom: 1.25rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--space-5);
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 0.875rem;
-  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .card-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-strong);
   letter-spacing: -0.025em;
 }
 
@@ -377,25 +622,25 @@ table {
 }
 
 thead {
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 th {
   text-align: left;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 td {
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid #f1f5f9;
-  color: #334155;
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text);
   font-size: 0.875rem;
 }
 
@@ -404,13 +649,13 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background: #f8fafc;
+  background: var(--color-bg);
 }
 
 .badge {
   display: inline-block;
-  padding: 0.313rem 0.75rem;
-  border-radius: 6px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -418,33 +663,33 @@ tbody tr:hover {
 }
 
 .badge.success {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--color-success-bg);
+  color: var(--color-success-ink);
 }
 
 .badge.warning {
-  background: #fed7aa;
-  color: #92400e;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-ink);
 }
 
 .badge.danger {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--color-danger-bg);
+  color: var(--color-danger-ink);
 }
 
 .badge.info {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--color-info-bg);
+  color: var(--color-info-ink);
 }
 
 .badge.increasing {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--color-success-bg);
+  color: var(--color-success-ink);
 }
 
 .badge.decreasing {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--color-danger-bg);
+  color: var(--color-danger-ink);
 }
 
 .badge.stable {
@@ -453,34 +698,34 @@ tbody tr:hover {
 }
 
 .badge.high {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--color-danger-bg);
+  color: var(--color-danger-ink);
 }
 
 .badge.medium {
-  background: #fed7aa;
-  color: #92400e;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-ink);
 }
 
 .badge.low {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--color-info-bg);
+  color: var(--color-info-ink);
 }
 
 .loading {
   text-align: center;
-  padding: 3rem;
-  color: #64748b;
+  padding: var(--space-12);
+  color: var(--color-text-muted);
   font-size: 0.938rem;
 }
 
 .error {
   background: #fef2f2;
-  border: 1px solid #fecaca;
-  color: #991b1b;
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
+  border: 1px solid var(--color-danger-bg);
+  color: var(--color-danger-ink);
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
+  margin: var(--space-4) 0;
   font-size: 0.938rem;
 }
 </style>

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -102,50 +102,51 @@ export default {
 
 <style scoped>
 .filters-bar {
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
-  padding: 0.75rem 0;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-3) 0;
+  /* No top header anymore - sticks to the top of the main column, below the sidebar's z-index */
   position: sticky;
-  top: 70px;
-  z-index: 90;
+  top: 0;
+  z-index: var(--z-filterbar);
 }
 
 .filters-container {
-  max-width: 1600px;
+  max-width: var(--content-max);
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 var(--space-8);
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .filters-grid {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
   flex: 1;
 }
 
 .filter-group {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .filter-group label {
   font-size: 0.75rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .filter-select {
-  padding: 0.4rem 0.75rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
   font-size: 0.813rem;
-  color: #0f172a;
-  background: white;
+  color: var(--color-text-strong);
+  background: var(--color-surface);
   cursor: pointer;
   transition: all 0.2s;
   font-weight: 500;
@@ -158,28 +159,33 @@ export default {
 
 .filter-select:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
 .reset-filters-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.4rem;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  color: #64748b;
+  padding: var(--space-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: all 0.2s;
   flex-shrink: 0;
 }
 
 .reset-filters-btn:hover:not(:disabled) {
-  background: #f8fafc;
-  border-color: #cbd5e1;
-  color: #0f172a;
+  background: var(--color-bg);
+  border-color: var(--color-border-strong);
+  color: var(--color-text-strong);
+}
+
+.reset-filters-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .reset-filters-btn:disabled {

--- a/client/src/components/LanguageSwitcher.vue
+++ b/client/src/components/LanguageSwitcher.vue
@@ -2,6 +2,9 @@
   <div class="language-switcher">
     <button
       class="language-button"
+      :class="{ collapsed }"
+      :title="collapsed ? localeName : null"
+      :aria-label="collapsed ? localeName : null"
       @click="toggleDropdown"
       @blur="handleBlur"
     >
@@ -11,23 +14,27 @@
         viewBox="0 0 20 20"
         fill="none"
         class="globe-icon"
+        aria-hidden="true"
       >
         <circle cx="10" cy="10" r="7.5" stroke="currentColor" stroke-width="1.5"/>
         <path d="M3 10H17" stroke="currentColor" stroke-width="1.5"/>
         <path d="M10 3C10 3 7.5 5.5 7.5 10C7.5 14.5 10 17 10 17" stroke="currentColor" stroke-width="1.5"/>
         <path d="M10 3C10 3 12.5 5.5 12.5 10C12.5 14.5 10 17 10 17" stroke="currentColor" stroke-width="1.5"/>
       </svg>
-      <span class="language-label">{{ localeName }}</span>
-      <svg
-        class="chevron"
-        :class="{ 'chevron-open': isDropdownOpen }"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        fill="none"
-      >
-        <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-      </svg>
+      <template v-if="!collapsed">
+        <span class="language-label">{{ localeName }}</span>
+        <svg
+          class="chevron"
+          :class="{ 'chevron-open': isDropdownOpen }"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </template>
     </button>
 
     <div v-if="isDropdownOpen" class="dropdown-menu">
@@ -57,6 +64,10 @@
 <script setup>
 import { ref } from 'vue'
 import { useI18n } from '../composables/useI18n'
+
+defineProps({
+  collapsed: { type: Boolean, default: false }
+})
 
 const { currentLocale, setLocale, availableLocales, localeName } = useI18n()
 
@@ -94,37 +105,54 @@ const selectLanguage = (locale) => {
 }
 
 .language-button {
+  width: 100%;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.875rem;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.2s ease;
   font-family: inherit;
   font-size: 0.875rem;
-  color: #334155;
+  color: var(--color-text);
 }
 
 .language-button:hover {
-  background: #f8fafc;
-  border-color: #cbd5e1;
+  background: var(--color-bg);
+  border-color: var(--color-border-strong);
+}
+
+.language-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Icon-only rail: fixed square button, no text/chevron overflow */
+.language-button.collapsed {
+  width: 36px;
+  justify-content: center;
+  padding: var(--space-2);
 }
 
 .globe-icon {
-  color: #64748b;
+  color: var(--color-text-muted);
   flex-shrink: 0;
 }
 
 .language-label {
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chevron {
-  color: #64748b;
+  color: var(--color-text-muted);
   transition: transform 0.2s ease;
+  margin-left: auto;
   flex-shrink: 0;
 }
 
@@ -132,16 +160,18 @@ const selectLanguage = (locale) => {
   transform: rotate(180deg);
 }
 
+/* Sidebar footer sits at the bottom of the viewport - open upward so the dropdown
+   isn't clipped below the fold. */
 .dropdown-menu {
   position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
+  bottom: calc(100% + var(--space-2));
+  left: 0;
   min-width: 160px;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-dropdown);
   overflow: hidden;
 }
 
@@ -150,8 +180,8 @@ const selectLanguage = (locale) => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
   background: none;
   border: none;
   text-align: left;
@@ -160,16 +190,21 @@ const selectLanguage = (locale) => {
   font-family: inherit;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #334155;
+  color: var(--color-text);
 }
 
 .dropdown-item:hover {
-  background: #f8fafc;
+  background: var(--color-bg);
+}
+
+.dropdown-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 .dropdown-item.active {
-  background: #eff6ff;
-  color: #2563eb;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
 }
 
 .language-name {
@@ -177,7 +212,7 @@ const selectLanguage = (locale) => {
 }
 
 .check-icon {
-  color: #2563eb;
+  color: var(--color-primary);
   flex-shrink: 0;
 }
 </style>

--- a/client/src/components/ProfileMenu.vue
+++ b/client/src/components/ProfileMenu.vue
@@ -2,23 +2,29 @@
   <div class="profile-menu">
     <button
       class="profile-button"
+      :class="{ collapsed }"
+      :title="collapsed ? currentUser.name : null"
+      :aria-label="collapsed ? currentUser.name : null"
       @click="toggleDropdown"
       @blur="handleBlur"
     >
       <div class="avatar">
         {{ getInitials(currentUser.name) }}
       </div>
-      <span class="profile-name">{{ currentUser.name }}</span>
-      <svg
-        class="chevron"
-        :class="{ 'chevron-open': isDropdownOpen }"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        fill="none"
-      >
-        <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-      </svg>
+      <template v-if="!collapsed">
+        <span class="profile-name">{{ currentUser.name }}</span>
+        <svg
+          class="chevron"
+          :class="{ 'chevron-open': isDropdownOpen }"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </template>
     </button>
 
     <div v-if="isDropdownOpen" class="dropdown-menu">
@@ -78,6 +84,10 @@ import { ref, computed } from 'vue'
 import { useAuth } from '../composables/useAuth'
 import { useI18n } from '../composables/useI18n'
 
+defineProps({
+  collapsed: { type: Boolean, default: false }
+})
+
 const { currentUser, logout, getInitials } = useAuth()
 const { t } = useI18n()
 
@@ -121,28 +131,41 @@ const handleLogout = () => {
 }
 
 .profile-button {
+  width: 100%;
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding: 0.5rem 0.875rem;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.2s ease;
   font-family: inherit;
 }
 
 .profile-button:hover {
-  background: #f8fafc;
-  border-color: #cbd5e1;
+  background: var(--color-bg);
+  border-color: var(--color-border-strong);
+}
+
+.profile-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Icon-only rail: just the avatar circle, no name/chevron overflow */
+.profile-button.collapsed {
+  width: 36px;
+  justify-content: center;
+  padding: var(--space-2);
 }
 
 .avatar {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
   color: white;
   display: flex;
   align-items: center;
@@ -150,49 +173,57 @@ const handleLogout = () => {
   font-weight: 600;
   font-size: 0.75rem;
   letter-spacing: 0.025em;
+  flex-shrink: 0;
 }
 
 .profile-name {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #0f172a;
+  color: var(--color-text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chevron {
-  color: #64748b;
+  color: var(--color-text-muted);
   transition: transform 0.2s ease;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .chevron-open {
   transform: rotate(180deg);
 }
 
+/* Sidebar footer sits at the bottom of the viewport - open upward/rightward so the
+   dropdown isn't clipped below the fold. */
 .dropdown-menu {
   position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
+  bottom: calc(100% + var(--space-2));
+  left: 0;
   min-width: 280px;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-dropdown);
   overflow: hidden;
 }
 
 .dropdown-header {
-  padding: 1rem;
+  padding: var(--space-4);
   display: flex;
-  gap: 0.875rem;
+  gap: var(--space-3);
   align-items: center;
-  background: #f8fafc;
+  background: var(--color-bg);
 }
 
 .avatar-large {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
   color: white;
   display: flex;
   align-items: center;
@@ -210,14 +241,14 @@ const handleLogout = () => {
 
 .user-name {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-strong);
   font-size: 0.938rem;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 .user-email {
   font-size: 0.813rem;
-  color: #64748b;
+  color: var(--color-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -225,16 +256,16 @@ const handleLogout = () => {
 
 .dropdown-divider {
   height: 1px;
-  background: #e2e8f0;
-  margin: 0.5rem 0;
+  background: var(--color-border);
+  margin: var(--space-2) 0;
 }
 
 .dropdown-item {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
   background: none;
   border: none;
   text-align: left;
@@ -243,24 +274,29 @@ const handleLogout = () => {
   font-family: inherit;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #334155;
+  color: var(--color-text);
 }
 
 .dropdown-item:hover {
-  background: #f8fafc;
+  background: var(--color-bg);
+}
+
+.dropdown-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 .dropdown-item svg {
-  color: #64748b;
+  color: var(--color-text-muted);
   flex-shrink: 0;
 }
 
 .dropdown-item.logout {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .dropdown-item.logout svg {
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 .dropdown-item.logout:hover {
@@ -269,12 +305,12 @@ const handleLogout = () => {
 
 .task-badge {
   margin-left: auto;
-  background: #2563eb;
+  background: var(--color-primary);
   color: white;
   font-size: 0.75rem;
   font-weight: 600;
-  padding: 0.125rem 0.5rem;
-  border-radius: 12px;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
   min-width: 20px;
   text-align: center;
 }

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Architecture — Factory Inventory Management System</title>
+<style>
+  :root {
+    --ink: #0f172a;
+    --muted: #64748b;
+    --line: #e2e8f0;
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --blue: #2563eb;
+    --blue-soft: #eff6ff;
+    --green: #16a34a;
+    --green-soft: #f0fdf4;
+    --amber: #d97706;
+    --amber-soft: #fffbeb;
+    --red: #dc2626;
+    --violet: #7c3aed;
+    --violet-soft: #f5f3ff;
+    --radius: 10px;
+    --shadow: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  header.page {
+    background: var(--ink);
+    color: #fff;
+    padding: 40px 32px 36px;
+    border-bottom: 4px solid var(--blue);
+  }
+  header.page .wrap { max-width: 1100px; margin: 0 auto; }
+  header.page h1 { margin: 0 0 6px; font-size: 26px; font-weight: 700; letter-spacing: -0.01em; }
+  header.page p { margin: 0; color: #cbd5e1; font-size: 15px; max-width: 720px; }
+  header.page .meta { margin-top: 18px; display: flex; flex-wrap: wrap; gap: 8px; }
+  header.page .meta span {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.02em;
+    background: rgba(255,255,255,0.08); color: #e2e8f0;
+    padding: 5px 11px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.14);
+  }
+
+  main { max-width: 1100px; margin: 0 auto; padding: 40px 32px 72px; }
+
+  section { margin-bottom: 52px; }
+  .section-head { margin-bottom: 20px; }
+  .section-head h2 {
+    margin: 0; font-size: 19px; font-weight: 700;
+    display: flex; align-items: center; gap: 10px;
+  }
+  .section-head h2 .idx {
+    font-size: 12px; font-weight: 700; color: var(--blue);
+    background: var(--blue-soft); border: 1px solid #bfdbfe;
+    width: 26px; height: 26px; border-radius: 7px;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .section-head p { margin: 8px 0 0; color: var(--muted); font-size: 14px; }
+
+  /* ---------- Tech stack ---------- */
+  .stack-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px;
+  }
+  .stack-card {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 18px 18px 16px; box-shadow: var(--shadow);
+  }
+  .stack-card .tag {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--muted); margin-bottom: 8px;
+  }
+  .stack-card h3 { margin: 0 0 10px; font-size: 16px; }
+  .stack-card ul { margin: 0; padding-left: 18px; color: #334155; font-size: 13.5px; }
+  .stack-card ul li { margin-bottom: 4px; }
+  .stack-card .accent { height: 3px; width: 36px; border-radius: 3px; margin-bottom: 12px; }
+
+  /* ---------- Layered architecture ---------- */
+  .arch { display: flex; flex-direction: column; gap: 0; }
+  .layer {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 18px 20px; box-shadow: var(--shadow); position: relative;
+  }
+  .layer-label {
+    position: absolute; top: -10px; left: 18px;
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+    background: var(--ink); color: #fff; padding: 3px 10px; border-radius: 999px;
+  }
+  .layer h3 { margin: 6px 0 4px; font-size: 15px; }
+  .layer .sub { color: var(--muted); font-size: 13px; margin-bottom: 14px; }
+  .node-row { display: flex; flex-wrap: wrap; gap: 10px; }
+  .node {
+    font-size: 13px; font-weight: 600; padding: 8px 13px; border-radius: 8px;
+    border: 1px solid var(--line); background: var(--bg); color: #1e293b;
+  }
+  .node.blue { background: var(--blue-soft); border-color: #bfdbfe; color: #1d4ed8; }
+  .node.green { background: var(--green-soft); border-color: #bbf7d0; color: #15803d; }
+  .node.amber { background: var(--amber-soft); border-color: #fde68a; color: #b45309; }
+  .node.violet { background: var(--violet-soft); border-color: #ddd6fe; color: #6d28d9; }
+
+  .connector { display: flex; flex-direction: column; align-items: center; padding: 4px 0; }
+  .connector .arrow { color: var(--muted); font-size: 20px; line-height: 1; }
+  .connector .label {
+    font-size: 12px; color: var(--muted); font-weight: 600;
+    background: var(--bg); padding: 2px 10px; border: 1px solid var(--line);
+    border-radius: 999px; margin-bottom: 2px;
+  }
+
+  /* ---------- Data flow ---------- */
+  .flow { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 14px; }
+  .flow-step {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 16px; box-shadow: var(--shadow); position: relative;
+  }
+  .flow-step .num {
+    width: 24px; height: 24px; border-radius: 50%; background: var(--blue); color: #fff;
+    font-size: 12px; font-weight: 700; display: flex; align-items: center; justify-content: center;
+    margin-bottom: 10px;
+  }
+  .flow-step h4 { margin: 0 0 5px; font-size: 13.5px; }
+  .flow-step p { margin: 0; font-size: 12.5px; color: var(--muted); }
+  .flow-step code { font-size: 11.5px; background: var(--bg); padding: 1px 5px; border-radius: 4px; color: #475569; }
+
+  /* ---------- Tables ---------- */
+  .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); }
+  table { width: 100%; border-collapse: collapse; background: var(--card); font-size: 13px; }
+  th, td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { background: var(--bg); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); font-weight: 700; }
+  tr:last-child td { border-bottom: none; }
+  td code { font-size: 12px; background: var(--bg); padding: 2px 6px; border-radius: 4px; color: #1e293b; font-weight: 600; }
+  .method { font-weight: 700; color: var(--green); font-size: 12px; }
+  .pill { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; background: var(--blue-soft); color: #1d4ed8; border: 1px solid #bfdbfe; margin: 1px 2px 1px 0; }
+  .pill.none { background: var(--bg); color: var(--muted); border-color: var(--line); }
+
+  footer { max-width: 1100px; margin: 0 auto; padding: 0 32px 48px; color: var(--muted); font-size: 12.5px; }
+  footer .rule { border-top: 1px solid var(--line); padding-top: 18px; }
+  code.path { color: #475569; }
+
+  @media (max-width: 640px) {
+    header.page, main { padding-left: 20px; padding-right: 20px; }
+  }
+</style>
+</head>
+<body>
+
+<header class="page">
+  <div class="wrap">
+    <h1>Factory Inventory Management System</h1>
+    <p>System architecture, technology stack, and data flow for the full-stack inventory, orders, demand, and spending analytics demo.</p>
+    <div class="meta">
+      <span>Vue 3 + Vite</span>
+      <span>Python FastAPI</span>
+      <span>In-memory JSON data</span>
+      <span>REST over HTTP</span>
+      <span>Read-only API</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+  <!-- 1. OVERVIEW -->
+  <section>
+    <div class="section-head">
+      <h2><span class="idx">01</span> Overview</h2>
+      <p>A three-tier single-page application. A Vue 3 client renders dashboards and tables; a FastAPI backend serves a read-only REST API; data lives entirely in memory, loaded from JSON files at startup — there is no database.</p>
+    </div>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="accent" style="background: var(--green);"></div>
+        <div class="tag">Presentation</div>
+        <h3>Vue 3 SPA</h3>
+        <ul>
+          <li>7 page views, 9 reusable components</li>
+          <li>Client-side routing (vue-router)</li>
+          <li>Global filter &amp; i18n state</li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="accent" style="background: var(--blue);"></div>
+        <div class="tag">Application</div>
+        <h3>FastAPI Service</h3>
+        <ul>
+          <li>~15 REST endpoints</li>
+          <li>Pydantic response validation</li>
+          <li>In-memory filtering &amp; aggregation</li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="accent" style="background: var(--amber);"></div>
+        <div class="tag">Data</div>
+        <h3>JSON Mock Store</h3>
+        <ul>
+          <li>7 JSON files loaded at boot</li>
+          <li>Held in memory (no persistence)</li>
+          <li>Restart to reload from disk</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2. TECH STACK -->
+  <section>
+    <div class="section-head">
+      <h2><span class="idx">02</span> Technology Stack</h2>
+      <p>Frameworks, libraries, and tooling on each tier.</p>
+    </div>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <div class="accent" style="background: var(--green);"></div>
+        <div class="tag">Frontend · port 3000</div>
+        <h3>Client</h3>
+        <ul>
+          <li><strong>Vue 3.4</strong> — Composition API</li>
+          <li><strong>Vue Router 4</strong> — web history</li>
+          <li><strong>Axios 1.6</strong> — HTTP client</li>
+          <li><strong>Vite 5</strong> — dev server &amp; build</li>
+          <li>Custom SVG charts, scoped CSS</li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="accent" style="background: var(--blue);"></div>
+        <div class="tag">Backend · port 8001</div>
+        <h3>Server</h3>
+        <ul>
+          <li><strong>Python 3.11+</strong></li>
+          <li><strong>FastAPI 0.110+</strong> — routing</li>
+          <li><strong>Uvicorn 0.24+</strong> — ASGI server</li>
+          <li><strong>Pydantic 2.5+</strong> — validation</li>
+          <li>CORS middleware (wildcard, dev)</li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="accent" style="background: var(--amber);"></div>
+        <div class="tag">Data layer</div>
+        <h3>Storage</h3>
+        <ul>
+          <li>JSON files in <code class="path">server/data/</code></li>
+          <li>Loaded via <code class="path">mock_data.py</code></li>
+          <li>Inventory, orders, demand, backlog</li>
+          <li>Spending, transactions, purchase orders</li>
+          <li>No database, no ORM</li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <div class="accent" style="background: var(--violet);"></div>
+        <div class="tag">Tooling</div>
+        <h3>Dev &amp; Ops</h3>
+        <ul>
+          <li><code class="path">uv</code> — Python env &amp; deps</li>
+          <li><code class="path">npm</code> — client deps</li>
+          <li>OpenAPI docs at <code class="path">/docs</code></li>
+          <li>pytest — backend tests</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. SYSTEM ARCHITECTURE -->
+  <section>
+    <div class="section-head">
+      <h2><span class="idx">03</span> System Architecture</h2>
+      <p>Layered view of the runtime. Each tier communicates only with the one directly below it.</p>
+    </div>
+
+    <div class="arch">
+      <!-- Browser layer -->
+      <div class="layer">
+        <span class="layer-label">Browser · localhost:3000</span>
+        <h3>Vue 3 Single-Page Application</h3>
+        <div class="sub">App shell (<code>App.vue</code>) renders a header, global filter bar, and the active route view.</div>
+        <div class="node-row">
+          <span class="node green">Dashboard</span>
+          <span class="node green">Inventory</span>
+          <span class="node green">Orders</span>
+          <span class="node green">Spending</span>
+          <span class="node green">Demand</span>
+          <span class="node green">Reports</span>
+          <span class="node green">Backlog</span>
+        </div>
+        <div style="height:12px"></div>
+        <div class="node-row">
+          <span class="node">FilterBar (4 filters)</span>
+          <span class="node">Detail modals ×5</span>
+          <span class="node">Profile / Tasks</span>
+          <span class="node">LanguageSwitcher</span>
+        </div>
+        <div style="height:12px"></div>
+        <div class="node-row">
+          <span class="node violet">useFilters()</span>
+          <span class="node violet">useI18n()</span>
+          <span class="node violet">useAuth()</span>
+          <span class="node blue">api.js (Axios client)</span>
+        </div>
+      </div>
+
+      <div class="connector">
+        <span class="label">HTTP · REST · JSON</span>
+        <span class="arrow">&#8645;</span>
+      </div>
+
+      <!-- API layer -->
+      <div class="layer">
+        <span class="layer-label">Backend · localhost:8001</span>
+        <h3>FastAPI Application <code style="font-weight:400;font-size:12px;color:var(--muted)">(main.py)</code></h3>
+        <div class="sub">CORS middleware &rarr; route handlers &rarr; filter utilities &rarr; Pydantic response models.</div>
+        <div class="node-row">
+          <span class="node blue">/api/inventory</span>
+          <span class="node blue">/api/orders</span>
+          <span class="node blue">/api/dashboard/summary</span>
+          <span class="node blue">/api/demand</span>
+          <span class="node blue">/api/backlog</span>
+          <span class="node blue">/api/spending/*</span>
+          <span class="node blue">/api/reports/*</span>
+        </div>
+        <div style="height:12px"></div>
+        <div class="node-row">
+          <span class="node">apply_filters()</span>
+          <span class="node">filter_by_month()</span>
+          <span class="node">Pydantic models (validation)</span>
+        </div>
+      </div>
+
+      <div class="connector">
+        <span class="label">in-memory read</span>
+        <span class="arrow">&#8645;</span>
+      </div>
+
+      <!-- Data layer -->
+      <div class="layer">
+        <span class="layer-label">Data · loaded at startup</span>
+        <h3>In-Memory Mock Store <code style="font-weight:400;font-size:12px;color:var(--muted)">(mock_data.py)</code></h3>
+        <div class="sub">JSON files read once into memory. Reads are served from these structures; nothing is written back.</div>
+        <div class="node-row">
+          <span class="node amber">inventory.json</span>
+          <span class="node amber">orders.json</span>
+          <span class="node amber">demand_forecasts.json</span>
+          <span class="node amber">backlog_items.json</span>
+          <span class="node amber">spending.json</span>
+          <span class="node amber">transactions.json</span>
+          <span class="node amber">purchase_orders.json</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 4. DATA FLOW -->
+  <section>
+    <div class="section-head">
+      <h2><span class="idx">04</span> Data Flow</h2>
+      <p>A single request cycle, e.g. a user changing the Warehouse filter on the Orders page.</p>
+    </div>
+    <div class="flow">
+      <div class="flow-step">
+        <div class="num">1</div>
+        <h4>User changes a filter</h4>
+        <p>A dropdown in <code>FilterBar.vue</code> updates a shared ref in <code>useFilters()</code>.</p>
+      </div>
+      <div class="flow-step">
+        <div class="num">2</div>
+        <h4>Reactive watch fires</h4>
+        <p>Views <code>watch</code> the filter refs and call their <code>loadData()</code> method.</p>
+      </div>
+      <div class="flow-step">
+        <div class="num">3</div>
+        <h4>API request</h4>
+        <p><code>api.js</code> maps filters to query params and issues an Axios <code>GET</code>.</p>
+      </div>
+      <div class="flow-step">
+        <div class="num">4</div>
+        <h4>FastAPI filters</h4>
+        <p>Handler runs <code>apply_filters()</code> / <code>filter_by_month()</code> over in-memory lists.</p>
+      </div>
+      <div class="flow-step">
+        <div class="num">5</div>
+        <h4>Validate &amp; respond</h4>
+        <p>Pydantic models shape the JSON response returned to the client.</p>
+      </div>
+      <div class="flow-step">
+        <div class="num">6</div>
+        <h4>Render</h4>
+        <p>Response fills reactive refs; computed properties drive tables &amp; SVG charts.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5. API SURFACE -->
+  <section>
+    <div class="section-head">
+      <h2><span class="idx">05</span> API Surface</h2>
+      <p>Core read-only endpoints and the filters each accepts. Four global filters — <code>warehouse</code>, <code>category</code>, <code>status</code>, <code>month</code> — map from the UI filter bar.</p>
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr><th>Endpoint</th><th>Method</th><th>Returns</th><th>Filters</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>/api/inventory</code></td><td class="method">GET</td>
+            <td>Inventory items (SKU, stock, reorder point, cost, location)</td>
+            <td><span class="pill">warehouse</span><span class="pill">category</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/orders</code></td><td class="method">GET</td>
+            <td>Orders with line items &amp; status</td>
+            <td><span class="pill">warehouse</span><span class="pill">category</span><span class="pill">status</span><span class="pill">month</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/dashboard/summary</code></td><td class="method">GET</td>
+            <td>Aggregated KPIs (inventory value, low stock, pending orders, backlog)</td>
+            <td><span class="pill">warehouse</span><span class="pill">category</span><span class="pill">status</span><span class="pill">month</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/demand</code></td><td class="method">GET</td>
+            <td>Demand forecasts (current vs. forecasted, trend)</td>
+            <td><span class="pill none">none</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/backlog</code></td><td class="method">GET</td>
+            <td>Backlog items enriched with <code>has_purchase_order</code></td>
+            <td><span class="pill none">none</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/spending/{summary,monthly,categories,transactions}</code></td><td class="method">GET</td>
+            <td>Spending totals, 12-month breakdown, by category, and transactions</td>
+            <td><span class="pill none">none</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/reports/{quarterly,monthly-trends}</code></td><td class="method">GET</td>
+            <td>Quarterly performance &amp; month-over-month trends (computed from orders)</td>
+            <td><span class="pill none">none</span></td>
+          </tr>
+          <tr>
+            <td><code>/api/inventory/{id}</code> · <code>/api/orders/{id}</code></td><td class="method">GET</td>
+            <td>Single item / order by id (404 if absent)</td>
+            <td><span class="pill none">path param</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- 6. FILTER SYSTEM -->
+  <section>
+    <div class="section-head">
+      <h2><span class="idx">06</span> The Four-Filter System</h2>
+      <p>A single global filter bar drives every data view. Filter state is a shared singleton in <code>useFilters()</code>; "all" values are omitted from the query string.</p>
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr><th>UI Filter</th><th>Composable ref</th><th>API param</th><th>Applies to</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Time Period</td><td><code>selectedPeriod</code></td><td><code>month</code></td><td>Orders, Dashboard, Spending</td></tr>
+          <tr><td>Location (Warehouse)</td><td><code>selectedLocation</code></td><td><code>warehouse</code></td><td>Inventory, Orders, Dashboard</td></tr>
+          <tr><td>Category</td><td><code>selectedCategory</code></td><td><code>category</code></td><td>Inventory, Orders, Dashboard</td></tr>
+          <tr><td>Order Status</td><td><code>selectedStatus</code></td><td><code>status</code></td><td>Orders, Dashboard</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <div class="rule">
+    Generated architecture reference for the Factory Inventory Management System demo ·
+    Frontend <code class="path">client/</code> (Vue 3, port 3000) ·
+    Backend <code class="path">server/</code> (FastAPI, port 8001) ·
+    Data <code class="path">server/data/*.json</code>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/server/main.py
+++ b/server/main.py
@@ -120,6 +120,19 @@ class CreatePurchaseOrderRequest(BaseModel):
     expected_delivery_date: str
     notes: Optional[str] = None
 
+class Task(BaseModel):
+    id: str
+    title: str
+    priority: str
+    # camelCase to match the frontend task shape (TasksModal / useAuth mock tasks)
+    dueDate: str
+    status: str
+
+class CreateTaskRequest(BaseModel):
+    title: str
+    priority: str = "medium"
+    dueDate: str
+
 # API endpoints
 @app.get("/")
 def root():
@@ -303,6 +316,54 @@ def get_monthly_trends():
     result = list(months.values())
     result.sort(key=lambda x: x['month'])
     return result
+
+# In-memory task store. Tasks are mutable (create/delete/toggle), unlike the
+# read-only JSON-backed data, so they live here and reset on server restart.
+# String ids ("task-N") never collide with the frontend's numeric mock task ids.
+tasks_store = [
+    {"id": "task-1", "title": "Reconcile supplier invoices", "priority": "high", "dueDate": "2025-07-10", "status": "pending"},
+    {"id": "task-2", "title": "Audit safety stock thresholds", "priority": "low", "dueDate": "2025-07-18", "status": "completed"},
+]
+_next_task_id = 3
+
+@app.get("/api/tasks", response_model=List[Task])
+def get_tasks():
+    """Get all user-created tasks."""
+    return tasks_store
+
+@app.post("/api/tasks", response_model=Task, status_code=201)
+def create_task(request: CreateTaskRequest):
+    """Create a new task (starts in 'pending' status)."""
+    global _next_task_id
+    new_task = {
+        "id": f"task-{_next_task_id}",
+        "title": request.title,
+        "priority": request.priority,
+        "dueDate": request.dueDate,
+        "status": "pending",
+    }
+    _next_task_id += 1
+    # Prepend so the newest task appears first, matching the frontend's unshift()
+    tasks_store.insert(0, new_task)
+    return new_task
+
+@app.patch("/api/tasks/{task_id}", response_model=Task)
+def toggle_task(task_id: str):
+    """Toggle a task's status between 'pending' and 'completed'."""
+    task = next((t for t in tasks_store if t["id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    task["status"] = "completed" if task["status"] == "pending" else "pending"
+    return task
+
+@app.delete("/api/tasks/{task_id}")
+def delete_task(task_id: str):
+    """Delete a task."""
+    task = next((t for t in tasks_store if t["id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    tasks_store.remove(task)
+    return {"success": True, "id": task_id}
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/backend/test_tasks.py
+++ b/tests/backend/test_tasks.py
@@ -1,0 +1,130 @@
+"""
+Tests for tasks API endpoints (GET/POST/PATCH/DELETE /api/tasks).
+
+Tasks live in a mutable in-memory store, so each test creates the tasks it
+needs and cleans them up to stay independent of ordering and seed state.
+"""
+import pytest
+
+
+class TestTasksEndpoints:
+    """Test suite for task-related endpoints."""
+
+    def _create_task(self, client, title="Test task", priority="medium",
+                     due_date="2025-08-15"):
+        """Helper: create a task and return its JSON body."""
+        response = client.post(
+            "/api/tasks",
+            json={"title": title, "priority": priority, "dueDate": due_date},
+        )
+        assert response.status_code == 201
+        return response.json()
+
+    def test_get_all_tasks(self, client):
+        """Test getting all tasks returns a well-formed list."""
+        response = client.get("/api/tasks")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+
+        # Verify structure of every task
+        for task in data:
+            assert "id" in task
+            assert "title" in task
+            assert "priority" in task
+            assert "dueDate" in task
+            assert "status" in task
+            assert task["status"] in ("pending", "completed")
+
+    def test_create_task(self, client):
+        """Test creating a task returns 201 with a pending task."""
+        task = self._create_task(
+            client, title="Reorder connectors", priority="high",
+            due_date="2025-09-01",
+        )
+        try:
+            assert task["title"] == "Reorder connectors"
+            assert task["priority"] == "high"
+            assert task["dueDate"] == "2025-09-01"
+            # New tasks always start pending, regardless of request
+            assert task["status"] == "pending"
+            assert isinstance(task["id"], str)
+            assert task["id"].startswith("task-")
+        finally:
+            client.delete(f"/api/tasks/{task['id']}")
+
+    def test_create_task_defaults_priority(self, client):
+        """Test priority defaults to 'medium' when omitted."""
+        response = client.post(
+            "/api/tasks", json={"title": "No priority", "dueDate": "2025-09-02"}
+        )
+        assert response.status_code == 201
+        task = response.json()
+        try:
+            assert task["priority"] == "medium"
+        finally:
+            client.delete(f"/api/tasks/{task['id']}")
+
+    def test_created_task_appears_in_list(self, client):
+        """Test a created task is retrievable via GET."""
+        task = self._create_task(client, title="Appears in list")
+        try:
+            data = client.get("/api/tasks").json()
+            assert any(t["id"] == task["id"] for t in data)
+        finally:
+            client.delete(f"/api/tasks/{task['id']}")
+
+    def test_toggle_task(self, client):
+        """Test PATCH toggles status between pending and completed."""
+        task = self._create_task(client, title="Toggle me")
+        try:
+            assert task["status"] == "pending"
+
+            # pending -> completed
+            response = client.patch(f"/api/tasks/{task['id']}")
+            assert response.status_code == 200
+            assert response.json()["status"] == "completed"
+
+            # completed -> pending
+            response = client.patch(f"/api/tasks/{task['id']}")
+            assert response.status_code == 200
+            assert response.json()["status"] == "pending"
+        finally:
+            client.delete(f"/api/tasks/{task['id']}")
+
+    def test_delete_task(self, client):
+        """Test deleting a task removes it from the store."""
+        task = self._create_task(client, title="Delete me")
+
+        response = client.delete(f"/api/tasks/{task['id']}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["id"] == task["id"]
+
+        # Confirm it is gone
+        data = client.get("/api/tasks").json()
+        assert all(t["id"] != task["id"] for t in data)
+
+    def test_toggle_nonexistent_task(self, client):
+        """Test toggling a task that doesn't exist returns 404."""
+        response = client.patch("/api/tasks/nonexistent-999")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_delete_nonexistent_task(self, client):
+        """Test deleting a task that doesn't exist returns 404."""
+        response = client.delete("/api/tasks/nonexistent-999")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_create_task_missing_required_field(self, client):
+        """Test creating a task without required fields returns 422."""
+        # Missing dueDate
+        response = client.post("/api/tasks", json={"title": "Incomplete"})
+        assert response.status_code == 422
+
+        # Missing title
+        response = client.post("/api/tasks", json={"dueDate": "2025-09-01"})
+        assert response.status_code == 422


### PR DESCRIPTION
Replace the top nav bar with a left vertical navigation sidebar and apply a consistent design-token system across the shell and shared components:

- App.vue: sidebar layout ("Catalyst Components" brand), design tokens, consistent spacing and polished professional styling
- FilterBar, LanguageSwitcher, ProfileMenu: restyled to match the new sidebar shell
- Add docs/architecture.html documenting the app architecture
- Add saas-ui-redesign skill used to drive the redesign

Note: App.vue now calls api.getTasks() on mount but the backend has no /tasks route yet (returns 404 on every page). Tracked as a follow-up.