### PR TITLE
Add Restocking tab with budget-based restock ordering

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,12 +8,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.6.7",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0",
-    "axios": "^1.6.7"
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "vite": "^5.2.0"
+  },
+  "overrides": {
+    "esbuild": "npm:esbuild-wasm@0.21.5"
   }
 }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,6 +22,7 @@
           <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
             {{ t('nav.demandForecast') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">{{ t('nav.restocking') }}</router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -94,6 +94,21 @@ export const api = {
     return response.data
   },
 
+  async getRestockingRecommendations() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/recommendations`)
+    return response.data
+  },
+
+  async getRestockingOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restocking/orders`)
+    return response.data
+  },
+
+  async createRestockingOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/restocking/orders`, orderData)
+    return response.data
+  },
+
   async createPurchaseOrder(purchaseOrderData) {
     const response = await axios.post(`${API_BASE_URL}/purchase-orders`, purchaseOrderData)
     return response.data

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -126,7 +127,46 @@ export default {
       status: 'Status',
       expectedDelivery: 'Expected Delivery',
       actualDelivery: 'Actual Delivery'
-    }
+    },
+    submittedOrders: 'Submitted Orders',
+    noSubmittedOrders: 'No restocking orders have been submitted yet.',
+    submittedDate: 'Submitted',
+    leadTime: 'Lead Time',
+    leadTimeDays: '{days} days'
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking',
+    description: 'Allocate your budget to restock items with growing demand',
+    budgetLabel: 'Available Budget',
+    allocated: 'Allocated',
+    remaining: 'Remaining',
+    fundedItems: 'Funded Items',
+    recommendationsTitle: 'Restock Recommendations',
+    table: {
+      rank: 'Rank',
+      sku: 'SKU',
+      item: 'Item Name',
+      trend: 'Trend',
+      currentDemand: 'Current Demand',
+      forecastedDemand: 'Forecasted Demand',
+      gap: 'Gap',
+      gapPercent: 'Gap %',
+      unitCost: 'Unit Cost',
+      orderQty: 'Order Qty',
+      estCost: 'Est. Cost',
+      leadTime: 'Lead Time',
+      fundingStatus: 'Status'
+    },
+    funded: 'Funded',
+    notFunded: 'Not Funded',
+    cutoffLabel: 'Budget cut-off — items below are not funded',
+    placeOrder: 'Place Order',
+    placingOrder: 'Placing Order...',
+    orderPlaced: 'Order {orderNumber} submitted successfully.',
+    viewInOrders: 'View in Orders',
+    noRecommendations: 'No items currently need restocking.'
   },
 
   // Finance/Spending
@@ -204,6 +244,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    submitted: 'Submitted',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -126,7 +127,46 @@ export default {
       status: 'ステータス',
       expectedDelivery: '予定配達日',
       actualDelivery: '実際の配達日'
-    }
+    },
+    submittedOrders: '提出済み注文',
+    noSubmittedOrders: '補充注文はまだ提出されていません。',
+    submittedDate: '提出日',
+    leadTime: 'リードタイム',
+    leadTimeDays: '{days}日'
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充',
+    description: '需要が増加している品目の補充に予算を割り当てます',
+    budgetLabel: '利用可能予算',
+    allocated: '割当済み',
+    remaining: '残額',
+    fundedItems: '対象品目数',
+    recommendationsTitle: '補充推奨',
+    table: {
+      rank: '順位',
+      sku: 'SKU',
+      item: '品目名',
+      trend: 'トレンド',
+      currentDemand: '現在の需要',
+      forecastedDemand: '予測需要',
+      gap: 'ギャップ',
+      gapPercent: 'ギャップ%',
+      unitCost: '単価',
+      orderQty: '注文数量',
+      estCost: '見積費用',
+      leadTime: 'リードタイム',
+      fundingStatus: 'ステータス'
+    },
+    funded: '予算内',
+    notFunded: '予算外',
+    cutoffLabel: '予算上限 — これ以下の品目は対象外です',
+    placeOrder: '注文する',
+    placingOrder: '注文中...',
+    orderPlaced: '注文 {orderNumber} が正常に送信されました。',
+    viewInOrders: '注文で表示',
+    noRecommendations: '現在補充が必要な品目はありません。'
   },
 
   // Finance/Spending
@@ -204,6 +244,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    submitted: '提出済み',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -15,6 +16,7 @@ const router = createRouter({
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
+    { path: '/restocking', component: Restocking },
     { path: '/spending', component: Spending },
     { path: '/reports', component: Reports }
   ]

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -74,6 +74,56 @@
           </table>
         </div>
       </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('orders.submittedOrders') }} ({{ restockingOrders.length }})</h3>
+        </div>
+        <div v-if="restockingOrders.length === 0" class="empty-state">
+          {{ t('orders.noSubmittedOrders') }}
+        </div>
+        <div v-else class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-items">{{ t('orders.table.items') }}</th>
+                <th class="col-status">{{ t('orders.table.status') }}</th>
+                <th class="col-date">{{ t('orders.submittedDate') }}</th>
+                <th class="col-date">{{ t('orders.leadTime') }}</th>
+                <th class="col-date">{{ t('orders.table.expectedDelivery') }}</th>
+                <th class="col-value">{{ t('orders.table.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in restockingOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="item in order.items" :key="item.sku" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_cost }}</span>
+                        <span class="item-meta">{{ t('orders.leadTimeDays', { days: item.lead_time_days }) }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-status">
+                  <span class="badge info">{{ t('status.submitted') }}</span>
+                </td>
+                <td class="col-date">{{ formatDate(order.created_date) }}</td>
+                <td class="col-date">{{ t('orders.leadTimeDays', { days: order.lead_time_days }) }}</td>
+                <td class="col-date">{{ formatDate(order.expected_delivery) }}</td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_cost.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -95,6 +145,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const restockingOrders = ref([])
 
     // Use shared filters
     const {
@@ -109,7 +160,10 @@ export default {
       try {
         loading.value = true
         const filters = getCurrentFilters()
-        const fetchedOrders = await api.getOrders(filters)
+        const [fetchedOrders, fetchedRestockingOrders] = await Promise.all([
+          api.getOrders(filters),
+          api.getRestockingOrders()
+        ])
 
         // Sort orders by order_date (earliest first)
         orders.value = fetchedOrders.sort((a, b) => {
@@ -117,6 +171,8 @@ export default {
           const dateB = new Date(b.order_date)
           return dateA - dateB
         })
+
+        restockingOrders.value = fetchedRestockingOrders
       } catch (err) {
         error.value = 'Failed to load orders: ' + err.message
       } finally {
@@ -160,6 +216,7 @@ export default {
       loading,
       error,
       orders,
+      restockingOrders,
       getOrdersByStatus,
       getOrderStatusClass,
       formatDate,
@@ -275,5 +332,12 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.938rem;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,389 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Budget allocation card -->
+      <div class="card budget-card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.budgetLabel') }}</h3>
+        </div>
+        <div class="budget-content">
+          <div class="budget-slider-row">
+            <span class="slider-bound">{{ formatCurrency(0, currentCurrency) }}</span>
+            <input
+              type="range"
+              min="0"
+              max="20000"
+              step="500"
+              v-model.number="budget"
+              class="budget-slider"
+            >
+            <span class="slider-bound">{{ formatCurrency(20000, currentCurrency) }}</span>
+          </div>
+          <div class="budget-value">{{ formatCurrency(budget, currentCurrency) }}</div>
+
+          <div class="stats-grid">
+            <div class="stat-card success">
+              <div class="stat-label">{{ t('restocking.allocated') }}</div>
+              <div class="stat-value">{{ formatCurrency(allocatedTotal, currentCurrency) }}</div>
+            </div>
+            <div class="stat-card info">
+              <div class="stat-label">{{ t('restocking.remaining') }}</div>
+              <div class="stat-value">{{ formatCurrency(remainingBudget, currentCurrency) }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">{{ t('restocking.fundedItems') }}</div>
+              <div class="stat-value">{{ fundedItems.length }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Success banner after order placement -->
+      <div v-if="placedOrder" class="order-success-banner">
+        <span>{{ t('restocking.orderPlaced', { orderNumber: placedOrder.order_number }) }}</span>
+        <router-link to="/orders">{{ t('restocking.viewInOrders') }}</router-link>
+      </div>
+
+      <!-- Recommendations table -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.recommendationsTitle') }}</h3>
+        </div>
+
+        <div v-if="recommendations.length === 0" class="no-data">
+          {{ t('restocking.noRecommendations') }}
+        </div>
+        <template v-else>
+          <div class="table-container">
+            <table>
+              <thead>
+                <tr>
+                  <th>{{ t('restocking.table.rank') }}</th>
+                  <th>{{ t('restocking.table.sku') }}</th>
+                  <th>{{ t('restocking.table.item') }}</th>
+                  <th>{{ t('restocking.table.trend') }}</th>
+                  <th>{{ t('restocking.table.currentDemand') }}</th>
+                  <th>{{ t('restocking.table.forecastedDemand') }}</th>
+                  <th>{{ t('restocking.table.gap') }}</th>
+                  <th>{{ t('restocking.table.gapPercent') }}</th>
+                  <th>{{ t('restocking.table.unitCost') }}</th>
+                  <th>{{ t('restocking.table.orderQty') }}</th>
+                  <th>{{ t('restocking.table.estCost') }}</th>
+                  <th>{{ t('restocking.table.leadTime') }}</th>
+                  <th>{{ t('restocking.table.fundingStatus') }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template v-for="(rec, index) in recommendations" :key="rec.sku">
+                  <tr :class="{ 'unfunded-row': !rec.funded }">
+                    <td>{{ index + 1 }}</td>
+                    <td><strong>{{ rec.sku }}</strong></td>
+                    <td>{{ rec.name }}</td>
+                    <td>
+                      <span :class="['badge', rec.trend]">
+                        {{ t(`trends.${rec.trend}`) }}
+                      </span>
+                    </td>
+                    <td>{{ rec.current_demand }}</td>
+                    <td>{{ rec.forecasted_demand }}</td>
+                    <td>{{ rec.gap }}</td>
+                    <td>{{ rec.gap_pct }}%</td>
+                    <td>{{ formatCurrency(rec.unit_cost, currentCurrency) }}</td>
+                    <td>{{ rec.gap }}</td>
+                    <td><strong>{{ formatCurrency(rec.estimated_cost, currentCurrency) }}</strong></td>
+                    <td>{{ t('orders.leadTimeDays', { days: rec.lead_time_days }) }}</td>
+                    <td>
+                      <span :class="['badge', rec.funded ? 'success' : 'dimmed']">
+                        {{ rec.funded ? t('restocking.funded') : t('restocking.notFunded') }}
+                      </span>
+                    </td>
+                  </tr>
+                  <!-- Divider row marks the strict budget cut-off point between the
+                       last funded item and the first unfunded item -->
+                  <tr v-if="isCutoffRow(rec, index)" class="cutoff-row">
+                    <td colspan="13">{{ t('restocking.cutoffLabel') }}</td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="place-order-row">
+            <button
+              class="place-order-btn"
+              :disabled="fundedItems.length === 0 || placingOrder"
+              @click="placeOrder"
+            >
+              {{ placingOrder ? t('restocking.placingOrder') : t('restocking.placeOrder') }}
+            </button>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api'
+import { useI18n } from '../composables/useI18n'
+import { formatCurrency } from '../utils/currency'
+
+export default {
+  name: 'Restocking',
+  setup() {
+    const { t, currentCurrency } = useI18n()
+
+    const loading = ref(true)
+    const error = ref(null)
+    const allRecommendations = ref([])
+
+    const budget = ref(10000)
+    const placingOrder = ref(false)
+    const placedOrder = ref(null)
+
+    const loadRecommendations = async () => {
+      try {
+        loading.value = true
+        error.value = null
+        allRecommendations.value = await api.getRestockingRecommendations()
+      } catch (err) {
+        error.value = 'Failed to load restocking recommendations: ' + err.message
+      } finally {
+        loading.value = false
+      }
+    }
+
+    // Greedy budget allocation with a STRICT cut-off: walk the server-ranked
+    // recommendations in order, accumulating cost. Once an item doesn't fit
+    // the remaining budget, funding stops permanently — later items are never
+    // funded even if they'd individually fit — so there's a single clean
+    // cut-off line in the table rather than a scattered mix of funded/unfunded rows.
+    const recommendations = computed(() => {
+      let remaining = budget.value
+      let cutoffReached = false
+
+      return allRecommendations.value.map(rec => {
+        if (!cutoffReached && rec.estimated_cost <= remaining) {
+          remaining -= rec.estimated_cost
+          return { ...rec, funded: true }
+        }
+        cutoffReached = true
+        return { ...rec, funded: false }
+      })
+    })
+
+    const fundedItems = computed(() => recommendations.value.filter(r => r.funded))
+
+    const allocatedTotal = computed(() =>
+      fundedItems.value.reduce((sum, r) => sum + r.estimated_cost, 0)
+    )
+
+    const remainingBudget = computed(() => budget.value - allocatedTotal.value)
+
+    // True only for the funded row immediately preceding the first unfunded row
+    const isCutoffRow = (rec, index) => {
+      if (!rec.funded) return false
+      const next = recommendations.value[index + 1]
+      return !!next && !next.funded
+    }
+
+    const placeOrder = async () => {
+      if (fundedItems.value.length === 0) return
+      placingOrder.value = true
+      error.value = null
+      try {
+        const order = await api.createRestockingOrder({
+          budget: budget.value,
+          items: fundedItems.value.map(r => ({ sku: r.sku, quantity: r.gap }))
+        })
+        placedOrder.value = order
+      } catch (err) {
+        error.value = 'Failed to place restocking order: ' + err.message
+      } finally {
+        placingOrder.value = false
+      }
+    }
+
+    onMounted(loadRecommendations)
+
+    return {
+      t,
+      currentCurrency,
+      formatCurrency,
+      loading,
+      error,
+      budget,
+      recommendations,
+      fundedItems,
+      allocatedTotal,
+      remainingBudget,
+      isCutoffRow,
+      placingOrder,
+      placedOrder,
+      placeOrder
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-card {
+  margin-bottom: 1.5rem;
+}
+
+.budget-content {
+  padding: 1.5rem;
+}
+
+.budget-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.slider-bound {
+  font-size: 0.813rem;
+  color: #64748b;
+  font-weight: 600;
+  min-width: 3.5rem;
+  flex-shrink: 0;
+}
+
+.budget-slider {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+  accent-color: #3b82f6;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.budget-slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #3b82f6;
+  cursor: pointer;
+  margin-top: -6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.budget-slider::-moz-range-track {
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #3b82f6;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.budget-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #0f172a;
+  text-align: center;
+  margin-bottom: 1.25rem;
+}
+
+.no-data {
+  padding: 2rem;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.875rem;
+}
+
+.unfunded-row {
+  opacity: 0.5;
+}
+
+.cutoff-row td {
+  border-top: 2px dashed #cbd5e1;
+  border-bottom: none;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.813rem;
+  font-style: italic;
+  padding: 0.5rem;
+  background: #f8fafc;
+}
+
+.badge.dimmed {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.place-order-row {
+  padding: 1.25rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.place-order-btn {
+  padding: 0.75rem 1.5rem;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.938rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.place-order-btn:hover:not(:disabled) {
+  background: #2563eb;
+  transform: translateY(-1px);
+}
+
+.place-order-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.order-success-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #166534;
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 0.938rem;
+}
+
+.order-success-banner a {
+  color: #166534;
+  font-weight: 600;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecture — Factory Inventory Management System</title>
+<style>
+  :root {
+    --ink: #0f172a;
+    --muted: #64748b;
+    --line: #e2e8f0;
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --accent: #2563eb;
+    --green: #16a34a;
+    --yellow: #ca8a04;
+    --mono: "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--ink);
+    line-height: 1.6;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 48px 32px 96px; }
+  header.page { border-bottom: 1px solid var(--line); padding-bottom: 28px; margin-bottom: 44px; }
+  header.page h1 { font-size: 1.9rem; font-weight: 700; letter-spacing: -0.02em; }
+  header.page p.sub { color: var(--muted); margin-top: 6px; font-size: 1.02rem; }
+  .meta { display: flex; gap: 20px; margin-top: 14px; flex-wrap: wrap; }
+  .meta span { font-size: 0.82rem; color: var(--muted); background: var(--card); border: 1px solid var(--line); border-radius: 6px; padding: 3px 10px; }
+  section { margin-bottom: 56px; }
+  h2 { font-size: 1.25rem; font-weight: 650; margin-bottom: 6px; letter-spacing: -0.01em; }
+  p.lead { color: var(--muted); margin-bottom: 22px; max-width: 72ch; }
+
+  /* Architecture diagram */
+  .diagram { display: flex; flex-direction: column; gap: 0; align-items: stretch; }
+  .tier { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 20px 24px; }
+  .tier .tier-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-bottom: 10px; font-weight: 600; }
+  .tier-title { font-weight: 650; font-size: 1.02rem; }
+  .tier-sub { color: var(--muted); font-size: 0.88rem; }
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+  .chip { font-size: 0.8rem; border: 1px solid var(--line); background: var(--bg); border-radius: 6px; padding: 3px 10px; color: var(--ink); }
+  .chip.mono { font-family: var(--mono); font-size: 0.75rem; }
+  .arrow { display: flex; flex-direction: column; align-items: center; padding: 6px 0; color: var(--muted); }
+  .arrow .line { width: 2px; height: 16px; background: var(--muted); }
+  .arrow .head { width: 0; height: 0; border-left: 6px solid transparent; border-right: 6px solid transparent; border-top: 8px solid var(--muted); }
+  .arrow .note { font-size: 0.78rem; font-family: var(--mono); color: var(--muted); padding: 2px 0; }
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 720px) { .cols { grid-template-columns: 1fr; } }
+
+  /* Tech stack cards */
+  .stack-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 16px; }
+  .stack-card { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 20px 22px; }
+  .stack-card h3 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-bottom: 12px; }
+  .stack-card ul { list-style: none; }
+  .stack-card li { padding: 5px 0; border-bottom: 1px solid var(--bg); font-size: 0.92rem; display: flex; justify-content: space-between; gap: 12px; }
+  .stack-card li:last-child { border-bottom: none; }
+  .stack-card li .v { color: var(--muted); font-family: var(--mono); font-size: 0.8rem; white-space: nowrap; }
+
+  /* Data flow */
+  .flow { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 22px 24px; }
+  .flow .step { background: var(--bg); border: 1px solid var(--line); border-radius: 8px; padding: 8px 14px; font-size: 0.86rem; text-align: center; }
+  .flow .step small { display: block; color: var(--muted); font-size: 0.72rem; font-family: var(--mono); }
+  .flow .fa { color: var(--muted); font-size: 1.0rem; }
+  .flow-note { color: var(--muted); font-size: 0.86rem; margin-top: 12px; max-width: 80ch; }
+
+  /* Tables */
+  table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--line); border-radius: 10px; overflow: hidden; font-size: 0.9rem; }
+  .table-scroll { overflow-x: auto; border-radius: 10px; }
+  th { text-align: left; font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); background: var(--bg); padding: 10px 16px; border-bottom: 1px solid var(--line); }
+  td { padding: 9px 16px; border-bottom: 1px solid var(--bg); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  code, .code { font-family: var(--mono); font-size: 0.82rem; background: var(--bg); border: 1px solid var(--line); border-radius: 4px; padding: 1px 6px; white-space: nowrap; }
+  .method { font-family: var(--mono); font-size: 0.72rem; font-weight: 700; border-radius: 4px; padding: 2px 7px; }
+  .get { background: #eff6ff; color: var(--accent); }
+  .muted { color: var(--muted); }
+
+  /* Callout */
+  .callout { border: 1px solid #fde68a; background: #fffbeb; border-radius: 10px; padding: 16px 20px; font-size: 0.9rem; }
+  .callout strong { color: #92400e; }
+
+  footer { color: var(--muted); font-size: 0.8rem; border-top: 1px solid var(--line); padding-top: 20px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="page">
+    <h1>Factory Inventory Management System</h1>
+    <p class="sub">Architecture overview — a full-stack demo application with a Vue 3 SPA, a FastAPI backend, and in-memory mock data (no database).</p>
+    <div class="meta">
+      <span>Frontend: localhost:3000</span>
+      <span>Backend: localhost:8001</span>
+      <span>Branch: new_features</span>
+      <span>Generated: July 6, 2026</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>System Architecture</h2>
+    <p class="lead">Three tiers, one direction of dependency: the browser SPA calls the REST API over HTTP; the API serves data loaded into memory from JSON files at startup. Nothing persists — restarting the server resets all state.</p>
+    <div class="diagram">
+      <div class="tier">
+        <div class="tier-label">Client — Vue 3 SPA (Vite dev server, port 3000)</div>
+        <div class="cols">
+          <div>
+            <div class="tier-title">Views (routed pages)</div>
+            <div class="chips">
+              <span class="chip">Dashboard /</span>
+              <span class="chip">Inventory</span>
+              <span class="chip">Orders</span>
+              <span class="chip">Demand</span>
+              <span class="chip">Spending</span>
+              <span class="chip">Reports</span>
+            </div>
+          </div>
+          <div>
+            <div class="tier-title">Shared state (composables)</div>
+            <div class="chips">
+              <span class="chip mono">useFilters (singleton refs)</span>
+              <span class="chip mono">useI18n (en / ja)</span>
+              <span class="chip mono">useAuth (mock user)</span>
+            </div>
+          </div>
+        </div>
+        <div class="chips" style="margin-top:14px">
+          <span class="chip">FilterBar</span>
+          <span class="chip">Detail modals (Inventory, Product, Backlog, Cost, Tasks, Profile)</span>
+          <span class="chip">Custom SVG charts</span>
+          <span class="chip mono">api.js — central Axios client</span>
+        </div>
+      </div>
+
+      <div class="arrow">
+        <div class="line"></div>
+        <div class="note">HTTP GET — filters as query params (warehouse, category, status, month)</div>
+        <div class="line"></div>
+        <div class="head"></div>
+      </div>
+
+      <div class="tier">
+        <div class="tier-label">API — FastAPI (Uvicorn, port 8001)</div>
+        <div class="cols">
+          <div>
+            <div class="tier-title">main.py — all routes</div>
+            <div class="tier-sub">CORS open for dev; shared helpers <span class="code">apply_filters()</span> and <span class="code">filter_by_month()</span> (months and Q1–Q4 quarters)</div>
+          </div>
+          <div>
+            <div class="tier-title">Pydantic models</div>
+            <div class="chips">
+              <span class="chip mono">InventoryItem</span>
+              <span class="chip mono">Order</span>
+              <span class="chip mono">DemandForecast</span>
+              <span class="chip mono">BacklogItem</span>
+              <span class="chip mono">PurchaseOrder</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">
+        <div class="line"></div>
+        <div class="note">loaded once at startup by mock_data.py</div>
+        <div class="line"></div>
+        <div class="head"></div>
+      </div>
+
+      <div class="tier">
+        <div class="tier-label">Data — JSON files, held in memory (server/data/)</div>
+        <div class="chips">
+          <span class="chip mono">inventory.json</span>
+          <span class="chip mono">orders.json</span>
+          <span class="chip mono">demand_forecasts.json</span>
+          <span class="chip mono">backlog_items.json</span>
+          <span class="chip mono">spending.json</span>
+          <span class="chip mono">transactions.json</span>
+          <span class="chip mono">purchase_orders.json</span>
+        </div>
+        <div class="tier-sub" style="margin-top:10px">Regenerable via <span class="code">generate_data.py</span>. Edits require a server restart to take effect.</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Tech Stack</h2>
+    <p class="lead">Deliberately minimal: no database, no state library, no chart library, no CSS framework.</p>
+    <div class="stack-grid">
+      <div class="stack-card">
+        <h3>Frontend</h3>
+        <ul>
+          <li>Vue (Composition API) <span class="v">^3.4</span></li>
+          <li>Vue Router <span class="v">^4.3</span></li>
+          <li>Axios <span class="v">^1.6</span></li>
+          <li>Vite <span class="v">^5.2</span></li>
+          <li>Custom SVG charts <span class="v">no library</span></li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <h3>Backend</h3>
+        <ul>
+          <li>Python <span class="v">&ge;3.11</span></li>
+          <li>FastAPI <span class="v">&ge;0.110</span></li>
+          <li>Pydantic <span class="v">v2</span></li>
+          <li>Uvicorn <span class="v">&ge;0.24</span></li>
+          <li>uv <span class="v">package runner</span></li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <h3>Data &amp; State</h3>
+        <ul>
+          <li>Mock data <span class="v">7 JSON files</span></li>
+          <li>Storage <span class="v">in-memory</span></li>
+          <li>Client state <span class="v">composables</span></li>
+          <li>i18n <span class="v">en / ja locales</span></li>
+          <li>Persistence <span class="v">none</span></li>
+        </ul>
+      </div>
+      <div class="stack-card">
+        <h3>Testing &amp; Tooling</h3>
+        <ul>
+          <li>pytest + TestClient <span class="v">tests/backend</span></li>
+          <li>httpx <span class="v">&ge;0.27</span></li>
+          <li>Browser testing <span class="v">Playwright MCP</span></li>
+          <li>API docs <span class="v">/docs (Swagger)</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Data Flow</h2>
+    <p class="lead">The core loop of the app: a user changes one of the four global filters, and every view re-fetches and re-renders. Filter state lives in module-level refs inside <code>useFilters.js</code>, so all components share one instance.</p>
+    <div class="flow">
+      <div class="step">Filter change<small>FilterBar.vue</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">Shared refs update<small>useFilters (singleton)</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">View watch fires<small>views/*.vue</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">GET with query params<small>api.js (Axios)</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">Filter in memory<small>apply_filters / filter_by_month</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">Validate response<small>Pydantic response_model</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">Raw data into refs<small>allOrders, inventoryItems</small></div>
+      <div class="fa">&#8594;</div>
+      <div class="step">Derive &amp; render<small>computed properties</small></div>
+    </div>
+    <p class="flow-note">Convention: raw API responses go into <code>ref()</code>s; everything displayed (KPIs, chart series, table rows) is derived in <code>computed()</code> properties. Filters "all" values are omitted from query params on the client and skipped on the server. Inventory has no time dimension, so the month filter does not apply to it.</p>
+  </section>
+
+  <section>
+    <h2>API Endpoints</h2>
+    <p class="lead">All read-only. Interactive documentation is served at <code>http://localhost:8001/docs</code>.</p>
+    <div class="table-scroll">
+    <table>
+      <thead><tr><th>Method</th><th>Path</th><th>Filters</th><th>Purpose</th></tr></thead>
+      <tbody>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/inventory</code></td><td class="muted">warehouse, category</td><td>Inventory items (list + <code>/{item_id}</code> detail)</td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/orders</code></td><td class="muted">warehouse, category, status, month</td><td>Orders (list + <code>/{order_id}</code> detail); month accepts <code>2025-01</code> or <code>Q1-2025</code></td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/dashboard/summary</code></td><td class="muted">all four</td><td>Aggregated KPIs: inventory value, low stock, pending orders, order revenue</td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/demand</code></td><td class="muted">none</td><td>Demand forecasts with trend direction</td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/backlog</code></td><td class="muted">none</td><td>Backlogged orders, annotated with <code>has_purchase_order</code></td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/spending/*</code></td><td class="muted">none</td><td><code>summary</code>, <code>monthly</code>, <code>categories</code>, <code>transactions</code></td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/reports/quarterly</code></td><td class="muted">none</td><td>Per-quarter revenue, order counts, fulfillment rate (computed from orders)</td></tr>
+        <tr><td><span class="method get">GET</span></td><td><code>/api/reports/monthly-trends</code></td><td class="muted">none</td><td>Month-over-month order count, revenue, deliveries</td></tr>
+      </tbody>
+    </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>Known Gap on This Branch</h2>
+    <div class="callout">
+      <strong>Client calls endpoints the server does not implement.</strong>
+      On <code>new_features</code>, <code>client/src/api.js</code> defines calls to <code>/api/tasks</code> (GET/POST/PATCH/DELETE) and <code>POST /api/purchase-orders</code>, but <code>server/main.py</code> has no matching routes. This causes the "Failed to load tasks" 404 in the browser console, and the Dashboard also references an unresolved <code>PurchaseOrderModal</code> component. These appear to be in-progress features.
+    </div>
+  </section>
+
+  <footer>
+    Sources: server/main.py, server/mock_data.py, client/src/main.js, client/src/api.js, client/src/composables/, package.json, pyproject.toml. Static page — safe to delete or regenerate.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/server/data/inventory.json
+++ b/server/data/inventory.json
@@ -297,7 +297,8 @@
     "reorder_point": 180,
     "unit_cost": 18.99,
     "location": "Warehouse A-15",
-    "last_updated": "2025-09-28T08:45:00"
+    "last_updated": "2025-09-28T08:45:00",
+    "lead_time_days": 12
   },
   {
     "id": "26",
@@ -307,7 +308,7 @@
     "warehouse": "London",
     "quantity_on_hand": 350,
     "reorder_point": 200,
-    "unit_cost": 22.50,
+    "unit_cost": 22.5,
     "location": "Warehouse B-16",
     "last_updated": "2025-09-27T13:20:00"
   },
@@ -326,7 +327,7 @@
   {
     "id": "28",
     "sku": "PSU-504",
-    "name": "Dual Output ±15V Power Supply",
+    "name": "Dual Output \u00b115V Power Supply",
     "category": "Power Supplies",
     "warehouse": "San Francisco",
     "quantity_on_hand": 190,
@@ -343,7 +344,7 @@
     "warehouse": "London",
     "quantity_on_hand": 145,
     "reorder_point": 120,
-    "unit_cost": 67.50,
+    "unit_cost": 67.5,
     "location": "Warehouse B-17",
     "last_updated": "2025-09-24T09:00:00"
   },
@@ -367,7 +368,7 @@
     "warehouse": "San Francisco",
     "quantity_on_hand": 95,
     "reorder_point": 80,
-    "unit_cost": 125.00,
+    "unit_cost": 125.0,
     "location": "Warehouse A-17",
     "last_updated": "2025-09-22T11:30:00"
   },
@@ -379,8 +380,112 @@
     "warehouse": "Tokyo",
     "quantity_on_hand": 75,
     "reorder_point": 100,
-    "unit_cost": 185.50,
+    "unit_cost": 185.5,
     "location": "Warehouse C-11",
     "last_updated": "2025-09-21T15:20:00"
+  },
+  {
+    "id": "33",
+    "sku": "WDG-001",
+    "name": "Industrial Widget Type A",
+    "category": "Actuators",
+    "warehouse": "San Francisco",
+    "quantity_on_hand": 180,
+    "reorder_point": 150,
+    "unit_cost": 55.0,
+    "location": "Warehouse A-20",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 7
+  },
+  {
+    "id": "34",
+    "sku": "BRG-102",
+    "name": "Steel Bearing Assembly",
+    "category": "Actuators",
+    "warehouse": "Tokyo",
+    "quantity_on_hand": 220,
+    "reorder_point": 100,
+    "unit_cost": 67.0,
+    "location": "Warehouse C-10",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 14
+  },
+  {
+    "id": "35",
+    "sku": "GSK-203",
+    "name": "High-Temperature Gasket",
+    "category": "Actuators",
+    "warehouse": "London",
+    "quantity_on_hand": 340,
+    "reorder_point": 250,
+    "unit_cost": 42.0,
+    "location": "Warehouse B-11",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 10
+  },
+  {
+    "id": "36",
+    "sku": "MTR-304",
+    "name": "Electric Motor 5HP",
+    "category": "Actuators",
+    "warehouse": "Tokyo",
+    "quantity_on_hand": 60,
+    "reorder_point": 25,
+    "unit_cost": 890.0,
+    "location": "Warehouse C-11",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 30
+  },
+  {
+    "id": "37",
+    "sku": "FLT-405",
+    "name": "Oil Filter Cartridge",
+    "category": "Actuators",
+    "warehouse": "San Francisco",
+    "quantity_on_hand": 520,
+    "reorder_point": 400,
+    "unit_cost": 28.5,
+    "location": "Warehouse A-21",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 5
+  },
+  {
+    "id": "38",
+    "sku": "VLV-506",
+    "name": "Pressure Relief Valve",
+    "category": "Actuators",
+    "warehouse": "London",
+    "quantity_on_hand": 140,
+    "reorder_point": 60,
+    "unit_cost": 156.0,
+    "location": "Warehouse B-12",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 21
+  },
+  {
+    "id": "39",
+    "sku": "SNR-420",
+    "name": "Temperature Sensor Module",
+    "category": "Sensors",
+    "warehouse": "Tokyo",
+    "quantity_on_hand": 200,
+    "reorder_point": 90,
+    "unit_cost": 89.5,
+    "location": "Warehouse C-12",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 18
+  },
+  {
+    "id": "40",
+    "sku": "CTL-330",
+    "name": "Logic Controller Board",
+    "category": "Controllers",
+    "warehouse": "San Francisco",
+    "quantity_on_hand": 110,
+    "reorder_point": 50,
+    "unit_cost": 210.0,
+    "location": "Warehouse A-22",
+    "last_updated": "2025-09-30T12:00:00",
+    "lead_time_days": 25
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
+from datetime import datetime, timedelta
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
 
 app = FastAPI(title="Factory Inventory Management System")
@@ -67,6 +68,7 @@ class InventoryItem(BaseModel):
     unit_cost: float
     location: str
     last_updated: str
+    lead_time_days: Optional[int] = None
 
 class Order(BaseModel):
     id: str
@@ -119,6 +121,55 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockingRecommendation(BaseModel):
+    sku: str
+    name: str
+    trend: str
+    current_demand: int
+    forecasted_demand: int
+    gap: int
+    gap_pct: float
+    unit_cost: float
+    lead_time_days: int
+    estimated_cost: float
+
+class RestockingOrderItemRequest(BaseModel):
+    sku: str
+    quantity: int
+
+class CreateRestockingOrderRequest(BaseModel):
+    budget: float
+    items: List[RestockingOrderItemRequest]
+
+class RestockingOrderItem(BaseModel):
+    sku: str
+    name: str
+    quantity: int
+    unit_cost: float
+    lead_time_days: int
+    line_total: float
+
+class RestockingOrder(BaseModel):
+    id: str
+    order_number: str
+    status: str
+    created_date: str
+    budget: float
+    total_cost: float
+    lead_time_days: int
+    expected_delivery: str
+    items: List[RestockingOrderItem]
+
+# Submitted restocking orders live in memory only; a server restart resets them,
+# matching the rest of the app's mock-data convention.
+restocking_orders: list = []
+
+# Lead time fallback for inventory records that predate the lead_time_days field
+DEFAULT_LEAD_TIME_DAYS = 14
+
+def _inventory_by_sku() -> dict:
+    return {item["sku"]: item for item in inventory_items}
 
 # API endpoints
 @app.get("/")
@@ -178,6 +229,87 @@ def get_backlog():
         item_dict["has_purchase_order"] = has_po
         result.append(item_dict)
     return result
+
+@app.get("/api/restocking/recommendations", response_model=List[RestockingRecommendation])
+def get_restocking_recommendations():
+    """Get ranked restocking recommendations derived from demand forecasts"""
+    inventory_by_sku = _inventory_by_sku()
+    recommendations = []
+
+    for forecast in demand_forecasts:
+        item = inventory_by_sku.get(forecast["item_sku"])
+        # Only recommend items we can price (SKU exists in inventory) with a
+        # positive demand gap — flat or shrinking demand needs no restock
+        gap = forecast["forecasted_demand"] - forecast["current_demand"]
+        if item is None or gap <= 0:
+            continue
+
+        gap_pct = (gap / forecast["current_demand"] * 100) if forecast["current_demand"] > 0 else 0.0
+        lead_time = item.get("lead_time_days") or DEFAULT_LEAD_TIME_DAYS
+        recommendations.append({
+            "sku": forecast["item_sku"],
+            "name": forecast["item_name"],
+            "trend": forecast["trend"],
+            "current_demand": forecast["current_demand"],
+            "forecasted_demand": forecast["forecasted_demand"],
+            "gap": gap,
+            "gap_pct": round(gap_pct, 2),
+            "unit_cost": item["unit_cost"],
+            "lead_time_days": lead_time,
+            "estimated_cost": round(gap * item["unit_cost"], 2),
+        })
+
+    # Urgency ranking: increasing-trend items first, then largest relative gap.
+    # False sorts before True, so `trend != 'increasing'` puts increasing on top.
+    recommendations.sort(key=lambda r: (r["trend"] != "increasing", -r["gap_pct"]))
+    return recommendations
+
+@app.post("/api/restocking/orders", response_model=RestockingOrder, status_code=201)
+def create_restocking_order(request: CreateRestockingOrderRequest):
+    """Submit a restocking order for the given items"""
+    if not request.items:
+        raise HTTPException(status_code=400, detail="Order must contain at least one item")
+
+    inventory_by_sku = _inventory_by_sku()
+    order_items = []
+    for line in request.items:
+        if line.quantity <= 0:
+            raise HTTPException(status_code=400, detail=f"Quantity for {line.sku} must be positive")
+        item = inventory_by_sku.get(line.sku)
+        if item is None:
+            raise HTTPException(status_code=400, detail=f"Unknown SKU: {line.sku}")
+        # Price and lead time come from inventory, never from the client
+        lead_time = item.get("lead_time_days") or DEFAULT_LEAD_TIME_DAYS
+        order_items.append({
+            "sku": line.sku,
+            "name": item["name"],
+            "quantity": line.quantity,
+            "unit_cost": item["unit_cost"],
+            "lead_time_days": lead_time,
+            "line_total": round(line.quantity * item["unit_cost"], 2),
+        })
+
+    created = datetime.now()
+    # The order is only complete when its slowest item arrives
+    max_lead = max(i["lead_time_days"] for i in order_items)
+    order = {
+        "id": str(len(restocking_orders) + 1),
+        "order_number": f"RST-{created.year}-{len(restocking_orders) + 1:04d}",
+        "status": "Submitted",
+        "created_date": created.isoformat(),
+        "budget": request.budget,
+        "total_cost": round(sum(i["line_total"] for i in order_items), 2),
+        "lead_time_days": max_lead,
+        "expected_delivery": (created + timedelta(days=max_lead)).isoformat(),
+        "items": order_items,
+    }
+    restocking_orders.append(order)
+    return order
+
+@app.get("/api/restocking/orders", response_model=List[RestockingOrder])
+def get_restocking_orders():
+    """Get all submitted restocking orders (in-memory, resets on restart)"""
+    return restocking_orders
 
 @app.get("/api/dashboard/summary")
 def get_dashboard_summary(

--- a/tests/backend/test_restocking.py
+++ b/tests/backend/test_restocking.py
@@ -1,0 +1,189 @@
+"""
+Tests for restocking API endpoints (recommendations and order submission).
+"""
+import pytest
+from datetime import datetime, timedelta
+
+import main
+
+
+@pytest.fixture(autouse=True)
+def clear_restocking_orders():
+    """Restocking orders live in shared module state; reset before each test."""
+    main.restocking_orders.clear()
+    yield
+    main.restocking_orders.clear()
+
+
+class TestRestockingRecommendations:
+    """Test suite for GET /api/restocking/recommendations."""
+
+    def test_get_recommendations(self, client):
+        """Test getting restocking recommendations."""
+        response = client.get("/api/restocking/recommendations")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 8
+
+        first = data[0]
+        for field in ["sku", "name", "trend", "current_demand", "forecasted_demand",
+                      "gap", "gap_pct", "unit_cost", "lead_time_days", "estimated_cost"]:
+            assert field in first
+
+    def test_negative_gap_items_excluded(self, client):
+        """Items with decreasing demand (negative gap) should not be recommended."""
+        response = client.get("/api/restocking/recommendations")
+        skus = [r["sku"] for r in response.json()]
+        assert "MTR-304" not in skus
+
+    def test_ranking_order(self, client):
+        """Increasing-trend items rank first, ordered by gap percent descending."""
+        response = client.get("/api/restocking/recommendations")
+        data = response.json()
+
+        assert data[0]["sku"] == "WDG-001"
+        assert data[1]["sku"] == "GSK-203"
+        assert data[2]["sku"] == "FLT-405"
+
+        # All increasing-trend items must come before all stable ones
+        trends = [r["trend"] for r in data]
+        first_stable = trends.index("stable")
+        assert all(t == "increasing" for t in trends[:first_stable])
+        assert all(t != "increasing" for t in trends[first_stable:])
+
+        # Within each trend group, gap_pct is non-increasing
+        for group in ("increasing", "stable"):
+            pcts = [r["gap_pct"] for r in data if r["trend"] == group]
+            assert pcts == sorted(pcts, reverse=True)
+
+    def test_gap_and_cost_math(self, client):
+        """Gap and estimated cost are computed from forecast and inventory data."""
+        response = client.get("/api/restocking/recommendations")
+        by_sku = {r["sku"]: r for r in response.json()}
+
+        wdg = by_sku["WDG-001"]
+        assert wdg["gap"] == 150
+        assert abs(wdg["gap_pct"] - 50.0) < 0.01
+        assert abs(wdg["estimated_cost"] - 150 * wdg["unit_cost"]) < 0.01
+        assert abs(wdg["estimated_cost"] - 8250.0) < 0.01
+
+    def test_lead_time_from_inventory(self, client):
+        """Lead times come from the joined inventory record."""
+        response = client.get("/api/restocking/recommendations")
+        by_sku = {r["sku"]: r for r in response.json()}
+        assert by_sku["PSU-501"]["lead_time_days"] == 12
+        assert by_sku["WDG-001"]["lead_time_days"] == 7
+
+
+class TestCreateRestockingOrder:
+    """Test suite for POST /api/restocking/orders and GET /api/restocking/orders."""
+
+    def _valid_payload(self):
+        return {
+            "budget": 10000,
+            "items": [
+                {"sku": "WDG-001", "quantity": 150},
+                {"sku": "GSK-203", "quantity": 100},
+            ],
+        }
+
+    def test_create_order_success(self, client):
+        """Test submitting a valid restocking order."""
+        response = client.post("/api/restocking/orders", json=self._valid_payload())
+        assert response.status_code == 201
+
+        order = response.json()
+        assert order["order_number"].startswith("RST-")
+        assert order["status"] == "Submitted"
+        assert order["budget"] == 10000
+
+        # total = 150 * 55.00 + 100 * 42.00
+        assert abs(order["total_cost"] - (8250.0 + 4200.0)) < 0.01
+
+        # Order lead time is the max across items (WDG-001: 7, GSK-203: 10)
+        assert order["lead_time_days"] == 10
+
+        created = datetime.fromisoformat(order["created_date"])
+        expected = datetime.fromisoformat(order["expected_delivery"])
+        assert abs((expected - created) - timedelta(days=10)) < timedelta(seconds=1)
+
+    def test_order_items_structure(self, client):
+        """Order items echo inventory pricing and lead times."""
+        response = client.post("/api/restocking/orders", json=self._valid_payload())
+        items = response.json()["items"]
+        assert len(items) == 2
+
+        by_sku = {i["sku"]: i for i in items}
+        wdg = by_sku["WDG-001"]
+        assert wdg["name"] == "Industrial Widget Type A"
+        assert wdg["quantity"] == 150
+        assert abs(wdg["line_total"] - wdg["quantity"] * wdg["unit_cost"]) < 0.01
+        assert wdg["lead_time_days"] == 7
+
+    def test_created_order_appears_in_list(self, client):
+        """Test that a submitted order is returned by the GET endpoint."""
+        assert client.get("/api/restocking/orders").json() == []
+
+        created = client.post("/api/restocking/orders", json=self._valid_payload()).json()
+
+        orders = client.get("/api/restocking/orders").json()
+        assert len(orders) == 1
+        assert orders[0]["order_number"] == created["order_number"]
+
+    def test_order_numbers_increment(self, client):
+        """Test that consecutive orders get distinct incrementing numbers."""
+        first = client.post("/api/restocking/orders", json=self._valid_payload()).json()
+        second = client.post("/api/restocking/orders", json=self._valid_payload()).json()
+        assert first["order_number"] != second["order_number"]
+        assert first["order_number"].endswith("0001")
+        assert second["order_number"].endswith("0002")
+
+    def test_empty_items_rejected(self, client):
+        """Test that an order with no items returns 400."""
+        response = client.post("/api/restocking/orders", json={"budget": 5000, "items": []})
+        assert response.status_code == 400
+        assert "detail" in response.json()
+
+    def test_unknown_sku_rejected(self, client):
+        """Test that an unknown SKU returns 400."""
+        response = client.post("/api/restocking/orders", json={
+            "budget": 5000,
+            "items": [{"sku": "NOPE-999", "quantity": 10}],
+        })
+        assert response.status_code == 400
+        assert "NOPE-999" in response.json()["detail"]
+
+    def test_nonpositive_quantity_rejected(self, client):
+        """Test that a zero quantity returns 400."""
+        response = client.post("/api/restocking/orders", json={
+            "budget": 5000,
+            "items": [{"sku": "WDG-001", "quantity": 0}],
+        })
+        assert response.status_code == 400
+
+
+class TestInventoryLeadTime:
+    """Inventory model accepts the new optional lead_time_days field."""
+
+    def test_inventory_includes_new_skus(self, client):
+        """The 8 forecast SKUs added to inventory are served."""
+        response = client.get("/api/inventory")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 40
+
+        skus = {item["sku"] for item in data}
+        for sku in ["WDG-001", "BRG-102", "GSK-203", "MTR-304",
+                    "FLT-405", "VLV-506", "SNR-420", "CTL-330"]:
+            assert sku in skus
+
+    def test_lead_time_optional(self, client):
+        """Records without lead_time_days still validate (field is optional)."""
+        response = client.get("/api/inventory")
+        data = response.json()
+        by_sku = {item["sku"]: item for item in data}
+        # New record has it; a legacy record returns None
+        assert by_sku["WDG-001"]["lead_time_days"] == 7
+        assert by_sku["PCB-001"]["lead_time_days"] is None


### PR DESCRIPTION
## Summary
- New **Restocking** tab: a budget slider drives greedy allocation over demand-forecast gaps (increasing-trend items first, then largest gap %), with a visible funding cut-off line and a Place Order flow
- Three new backend endpoints: `GET /api/restocking/recommendations`, `POST /api/restocking/orders`, `GET /api/restocking/orders` — orders are held in memory and reset on server restart, matching the app's mock-data convention; prices and lead times are always derived server-side from inventory, never trusted from the client
- Adds the 8 forecast SKUs that were missing from `inventory.json` (with unit costs and a new optional `lead_time_days` field), and a **Submitted Orders** section in the Orders view showing lead time and expected delivery
- Full English/Japanese translations, 12 new backend tests (54 total passing), plus a static architecture overview page in `docs/`

## Test plan
- [ ] `cd server && uv run python -m pytest ../tests/backend -v` — all 54 tests pass
- [ ] Open `/restocking` at the default $10,000 budget: 8 ranked recommendations, only WDG-001 funded ($8,250 allocated / $1,750 remaining), cut-off divider below it
- [ ] Slide budget to $20,000: all 8 items funded, allocated ≈ $17,442
- [ ] Click Place Order: success banner with an `RST-…` order number
- [ ] Open Orders: "Submitted Orders (1)" shows the order with Submitted badge, lead time, expected delivery, and total
- [ ] Switch language to Japanese: nav shows 補充, currency converts to ¥
- [ ] `POST /api/restocking/orders` with an unknown SKU / empty items / zero quantity returns 400 with a descriptive message

## Notes
- `package.json` gains an `esbuild → esbuild-wasm` override so the build works in environments that block execution of the native esbuild binary; flagging for visibility since it applies to all installs
- Known follow-ups from self-review: Submitted Orders amounts don't apply the ¥ conversion that the Restocking view uses; a failed restocking fetch currently blanks the whole Orders page; order numbers could collide under concurrent submissions