### PR TITLE
Add Restocking tab with budget-driven demand forecast recommendations

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,6 +22,9 @@
           <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
             {{ t('nav.demandForecast') }}
           </router-link>
+          <router-link to="/restocking" :class="{ active: $route.path === '/restocking' }">
+            Restocking
+          </router-link>
           <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
             Reports
           </router-link>
@@ -465,6 +468,27 @@ tbody tr:hover {
 .badge.low {
   background: #dbeafe;
   color: #1e40af;
+}
+
+.btn-primary {
+  padding: 0.625rem 1.25rem;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .loading {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -33,8 +33,12 @@ export const api = {
     return response.data
   },
 
-  async getDemandForecasts() {
-    const response = await axios.get(`${API_BASE_URL}/demand`)
+  async getDemandForecasts(filters = {}) {
+    const params = new URLSearchParams()
+    if (filters.warehouse && filters.warehouse !== 'all') params.append('warehouse', filters.warehouse)
+    if (filters.category && filters.category !== 'all') params.append('category', filters.category)
+
+    const response = await axios.get(`${API_BASE_URL}/demand?${params.toString()}`)
     return response.data
   },
 
@@ -101,6 +105,16 @@ export const api = {
 
   async getPurchaseOrderByBacklogItem(backlogItemId) {
     const response = await axios.get(`${API_BASE_URL}/purchase-orders/${backlogItemId}`)
+    return response.data
+  },
+
+  async getRestockOrders() {
+    const response = await axios.get(`${API_BASE_URL}/restock-orders`)
+    return response.data
+  },
+
+  async createRestockOrder(restockOrderData) {
+    const response = await axios.post(`${API_BASE_URL}/restock-orders`, restockOrderData)
     return response.data
   }
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,6 +5,7 @@ import Dashboard from './views/Dashboard.vue'
 import Inventory from './views/Inventory.vue'
 import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
+import Restocking from './views/Restocking.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
 
@@ -15,6 +16,7 @@ const router = createRouter({
     { path: '/inventory', component: Inventory },
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
+    { path: '/restocking', component: Restocking },
     { path: '/spending', component: Spending },
     { path: '/reports', component: Reports }
   ]

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -74,6 +74,53 @@
           </table>
         </div>
       </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Submitted Orders ({{ submittedOrders.length }})</h3>
+        </div>
+        <div v-if="submittedOrders.length === 0" style="padding: 2rem; text-align: center; color: #64748b;">
+          No restocking orders submitted yet
+        </div>
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Order Number</th>
+                <th>Items</th>
+                <th>Status</th>
+                <th>Order Date</th>
+                <th>Lead Time</th>
+                <th>Expected Delivery</th>
+                <th>Total Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td><strong>{{ order.order_number }}</strong></td>
+                <td>
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ order.items.length }} item{{ order.items.length === 1 ? '' : 's' }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ item.item_name }}</span>
+                        <span class="item-meta">Qty: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_cost }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td><span class="badge success">Submitted</span></td>
+                <td>{{ formatDate(order.order_date) }}</td>
+                <td>{{ getOrderLeadTime(order) }} days</td>
+                <td>{{ formatDate(order.expected_delivery) }}</td>
+                <td><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -95,6 +142,7 @@ export default {
     const loading = ref(true)
     const error = ref(null)
     const orders = ref([])
+    const submittedOrders = ref([])
 
     // Use shared filters
     const {
@@ -129,6 +177,19 @@ export default {
       loadOrders()
     })
 
+    // Restock orders are shown unfiltered - internal order log, not filterable customer data
+    const loadSubmittedOrders = async () => {
+      try {
+        submittedOrders.value = await api.getRestockOrders()
+      } catch (err) {
+        console.error('Failed to load submitted orders:', err)
+      }
+    }
+
+    const getOrderLeadTime = (order) => {
+      return Math.max(...order.items.map(i => i.lead_time_days))
+    }
+
     const getOrdersByStatus = (status) => {
       return orders.value.filter(order => order.status === status)
     }
@@ -153,15 +214,20 @@ export default {
       })
     }
 
-    onMounted(loadOrders)
+    onMounted(() => {
+      loadOrders()
+      loadSubmittedOrders()
+    })
 
     return {
       t,
       loading,
       error,
       orders,
+      submittedOrders,
       getOrdersByStatus,
       getOrderStatusClass,
+      getOrderLeadTime,
       formatDate,
       currencySymbol,
       translateProductName,

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,320 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>Restocking</h2>
+      <p>Budget-driven restock recommendations based on demand forecasts</p>
+    </div>
+
+    <div v-if="loading" class="loading">Loading demand forecasts...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Restock Budget</h3>
+        </div>
+        <div class="budget-control">
+          <label for="budget-slider">Available Budget</label>
+          <input
+            id="budget-slider"
+            type="range"
+            min="0"
+            :max="maxBudget || 0"
+            step="50"
+            v-model.number="budget"
+            :disabled="maxBudget === 0"
+            class="budget-slider"
+          />
+          <div class="budget-readout">${{ budget.toLocaleString() }}</div>
+        </div>
+        <p v-if="maxBudget === 0" class="empty-note">
+          No recommendations available for the current filters.
+        </p>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card">
+          <div class="stat-label">Budget</div>
+          <div class="stat-value">${{ budget.toLocaleString() }}</div>
+        </div>
+        <div class="stat-card info">
+          <div class="stat-label">Items Recommended</div>
+          <div class="stat-value">{{ orderItems.length }}</div>
+        </div>
+        <div class="stat-card success">
+          <div class="stat-label">Est. Order Total</div>
+          <div class="stat-value">${{ orderTotal.toLocaleString() }}</div>
+        </div>
+        <div class="stat-card warning">
+          <div class="stat-label">Est. Delivery</div>
+          <div class="stat-value">{{ estimatedDelivery ? `${estimatedDelivery} days` : '—' }}</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Recommended Restock Items</h3>
+        </div>
+        <div v-if="evaluatedItems.length === 0" style="padding: 3rem; text-align: center; color: #64748b;">
+          No demand forecasts match the current filters.
+        </div>
+        <div v-else class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Item Name</th>
+                <th>Trend</th>
+                <th>Recommended Qty</th>
+                <th>Unit Cost</th>
+                <th>Line Cost</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in evaluatedItems" :key="item.id">
+                <td><strong>{{ item.item_sku }}</strong></td>
+                <td>{{ item.item_name }}</td>
+                <td><span class="badge" :class="item.trend">{{ item.trend }}</span></td>
+                <td>{{ item.recommended_qty }}</td>
+                <td>${{ item.unit_cost.toLocaleString() }}</td>
+                <td>${{ item.line_cost.toLocaleString() }}</td>
+                <td>
+                  <span v-if="item.included" class="badge success">Included</span>
+                  <span v-else class="badge warning">Skipped</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="order-actions">
+          <button
+            class="btn-primary"
+            :disabled="orderItems.length === 0 || submitting"
+            @click="placeOrder"
+          >
+            {{ submitting ? 'Placing Order...' : 'Place Order' }}
+          </button>
+
+          <div v-if="submitSuccess" class="success-banner">
+            Order {{ submitSuccess }} placed successfully — check the Orders tab for delivery details.
+          </div>
+          <div v-if="submitError" class="error">{{ submitError }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useFilters } from '../composables/useFilters'
+import { api } from '../api'
+
+const { selectedLocation, selectedCategory } = useFilters()
+
+const loading = ref(true)
+const error = ref(null)
+const allDemandForecasts = ref([])
+const budget = ref(5000)
+const submitting = ref(false)
+const submitSuccess = ref(null)
+const submitError = ref(null)
+
+const TREND_ORDER = { increasing: 0, stable: 1, decreasing: 2 }
+
+const loadDemandForecasts = async () => {
+  try {
+    loading.value = true
+    error.value = null
+    allDemandForecasts.value = await api.getDemandForecasts({
+      warehouse: selectedLocation.value,
+      category: selectedCategory.value
+    })
+  } catch (err) {
+    error.value = 'Failed to load demand forecasts: ' + err.message
+  } finally {
+    loading.value = false
+  }
+}
+
+const rankedRecommendations = computed(() => {
+  const items = allDemandForecasts.value.map(item => {
+    const growth_pct = item.current_demand > 0
+      ? (item.forecasted_demand - item.current_demand) / item.current_demand * 100
+      : 0
+    const recommended_qty = Math.max(
+      item.forecasted_demand - item.current_demand,
+      Math.round(item.forecasted_demand * 0.10)
+    )
+    const line_cost = recommended_qty * item.unit_cost
+
+    return { ...item, growth_pct, recommended_qty, line_cost }
+  })
+
+  return items.sort((a, b) => {
+    const trendDiff = (TREND_ORDER[a.trend] ?? 1) - (TREND_ORDER[b.trend] ?? 1)
+    if (trendDiff !== 0) return trendDiff
+    return b.growth_pct - a.growth_pct
+  })
+})
+
+const maxBudget = computed(() => {
+  return rankedRecommendations.value.reduce((sum, item) => sum + item.line_cost, 0)
+})
+
+const evaluatedItems = computed(() => {
+  let remaining = budget.value
+  return rankedRecommendations.value.map(item => {
+    if (item.line_cost <= remaining) {
+      remaining -= item.line_cost
+      return { ...item, included: true }
+    }
+    return { ...item, included: false }
+  })
+})
+
+const orderItems = computed(() => evaluatedItems.value.filter(i => i.included))
+
+const orderTotal = computed(() => orderItems.value.reduce((sum, i) => sum + i.line_cost, 0))
+
+const estimatedDelivery = computed(() => {
+  if (orderItems.value.length === 0) return 0
+  return Math.max(...orderItems.value.map(i => i.lead_time_days))
+})
+
+const placeOrder = async () => {
+  if (orderItems.value.length === 0) return
+
+  submitting.value = true
+  submitSuccess.value = null
+  submitError.value = null
+
+  try {
+    const payload = {
+      items: orderItems.value.map(i => ({
+        item_sku: i.item_sku,
+        item_name: i.item_name,
+        quantity: i.recommended_qty,
+        unit_cost: i.unit_cost,
+        lead_time_days: i.lead_time_days
+      })),
+      budget: budget.value,
+      warehouse: selectedLocation.value !== 'all' ? selectedLocation.value : null,
+      category: selectedCategory.value !== 'all' ? selectedCategory.value : null
+    }
+
+    const result = await api.createRestockOrder(payload)
+    submitSuccess.value = result.order_number
+  } catch (err) {
+    submitError.value = 'Failed to place order: ' + err.message
+  } finally {
+    submitting.value = false
+  }
+}
+
+watch([selectedLocation, selectedCategory], loadDemandForecasts)
+onMounted(loadDemandForecasts)
+</script>
+
+<style scoped>
+.budget-control {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.budget-control label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #475569;
+  white-space: nowrap;
+}
+
+.budget-readout {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  min-width: 100px;
+  text-align: right;
+}
+
+.budget-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+  outline: none;
+  cursor: pointer;
+}
+
+.budget-slider:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.budget-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #3b82f6;
+  border: 2px solid white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.budget-slider::-webkit-slider-thumb:hover {
+  background: #2563eb;
+}
+
+.budget-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #3b82f6;
+  border: 2px solid white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.budget-slider::-moz-range-thumb:hover {
+  background: #2563eb;
+}
+
+.budget-slider::-moz-range-progress {
+  background: #3b82f6;
+  height: 6px;
+  border-radius: 3px;
+}
+
+.empty-note {
+  margin-top: 0.75rem;
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.order-actions {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.success-banner {
+  background: #d1fae5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+</style>

--- a/server/data/demand_forecasts.json
+++ b/server/data/demand_forecasts.json
@@ -6,7 +6,11 @@
     "current_demand": 300,
     "forecasted_demand": 450,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 42.50,
+    "lead_time_days": 18,
+    "category": "Actuators",
+    "warehouse": "San Francisco"
   },
   {
     "id": "2",
@@ -15,7 +19,11 @@
     "current_demand": 150,
     "forecasted_demand": 152,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 8.25,
+    "lead_time_days": 10,
+    "category": "Actuators",
+    "warehouse": "London"
   },
   {
     "id": "3",
@@ -24,7 +32,11 @@
     "current_demand": 500,
     "forecasted_demand": 600,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 3.15,
+    "lead_time_days": 7,
+    "category": "Actuators",
+    "warehouse": "Tokyo"
   },
   {
     "id": "4",
@@ -33,7 +45,11 @@
     "current_demand": 50,
     "forecasted_demand": 35,
     "trend": "decreasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 285.00,
+    "lead_time_days": 35,
+    "category": "Actuators",
+    "warehouse": "San Francisco"
   },
   {
     "id": "5",
@@ -42,7 +58,11 @@
     "current_demand": 800,
     "forecasted_demand": 950,
     "trend": "increasing",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 6.50,
+    "lead_time_days": 5,
+    "category": "Actuators",
+    "warehouse": "London"
   },
   {
     "id": "6",
@@ -51,7 +71,11 @@
     "current_demand": 120,
     "forecasted_demand": 121,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 24.00,
+    "lead_time_days": 14,
+    "category": "Actuators",
+    "warehouse": "Tokyo"
   },
   {
     "id": "7",
@@ -60,7 +84,11 @@
     "current_demand": 250,
     "forecasted_demand": 252,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 18.99,
+    "lead_time_days": 12,
+    "category": "Power Supplies",
+    "warehouse": "San Francisco"
   },
   {
     "id": "8",
@@ -69,7 +97,11 @@
     "current_demand": 180,
     "forecasted_demand": 182,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 15.75,
+    "lead_time_days": 9,
+    "category": "Sensors",
+    "warehouse": "London"
   },
   {
     "id": "9",
@@ -78,6 +110,10 @@
     "current_demand": 95,
     "forecasted_demand": 96,
     "trend": "stable",
-    "period": "Next 30 days"
+    "period": "Next 30 days",
+    "unit_cost": 65.00,
+    "lead_time_days": 16,
+    "category": "Controllers",
+    "warehouse": "Tokyo"
   }
 ]

--- a/server/main.py
+++ b/server/main.py
@@ -1,8 +1,12 @@
+from datetime import datetime, timedelta
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from pydantic import BaseModel
 from mock_data import inventory_items, orders, demand_forecasts, backlog_items, spending_summary, monthly_spending, category_spending, recent_transactions, purchase_orders
+
+# Restocking orders are created at runtime (not loaded from a JSON file) and reset on restart
+restock_orders: List[dict] = []
 
 app = FastAPI(title="Factory Inventory Management System")
 
@@ -89,6 +93,10 @@ class DemandForecast(BaseModel):
     forecasted_demand: int
     trend: str
     period: str
+    unit_cost: float
+    lead_time_days: int
+    category: str
+    warehouse: str
 
 class BacklogItem(BaseModel):
     id: str
@@ -119,6 +127,24 @@ class CreatePurchaseOrderRequest(BaseModel):
     unit_cost: float
     expected_delivery_date: str
     notes: Optional[str] = None
+
+class RestockOrder(BaseModel):
+    id: str
+    order_number: str
+    items: List[dict]
+    status: str
+    order_date: str
+    expected_delivery: str
+    total_value: float
+    budget: float
+    warehouse: Optional[str] = None
+    category: Optional[str] = None
+
+class CreateRestockOrderRequest(BaseModel):
+    items: List[dict]
+    budget: float
+    warehouse: Optional[str] = None
+    category: Optional[str] = None
 
 # API endpoints
 @app.get("/")
@@ -162,9 +188,12 @@ def get_order(order_id: str):
     return order
 
 @app.get("/api/demand", response_model=List[DemandForecast])
-def get_demand_forecasts():
-    """Get demand forecasts"""
-    return demand_forecasts
+def get_demand_forecasts(
+    warehouse: Optional[str] = None,
+    category: Optional[str] = None
+):
+    """Get demand forecasts with optional filtering"""
+    return apply_filters(demand_forecasts, warehouse, category)
 
 @app.get("/api/backlog", response_model=List[BacklogItem])
 def get_backlog():
@@ -178,6 +207,36 @@ def get_backlog():
         item_dict["has_purchase_order"] = has_po
         result.append(item_dict)
     return result
+
+@app.get("/api/restock-orders", response_model=List[RestockOrder])
+def get_restock_orders():
+    """Get all submitted restocking orders"""
+    return restock_orders
+
+@app.post("/api/restock-orders", response_model=RestockOrder)
+def create_restock_order(request: CreateRestockOrderRequest):
+    """Submit a new restocking order"""
+    if not request.items:
+        raise HTTPException(status_code=400, detail="Order must include at least one item")
+
+    order_date = datetime.now()
+    max_lead_time = max(item["lead_time_days"] for item in request.items)
+    total_value = sum(item["quantity"] * item["unit_cost"] for item in request.items)
+
+    new_order = {
+        "id": str(len(restock_orders) + 1),
+        "order_number": f"RSO-{order_date.strftime('%Y%m%d')}-{len(restock_orders) + 1:04d}",
+        "items": request.items,
+        "status": "Submitted",
+        "order_date": order_date.isoformat(),
+        "expected_delivery": (order_date + timedelta(days=max_lead_time)).isoformat(),
+        "total_value": round(total_value, 2),
+        "budget": request.budget,
+        "warehouse": request.warehouse,
+        "category": request.category
+    }
+    restock_orders.append(new_order)
+    return new_order
 
 @app.get("/api/dashboard/summary")
 def get_dashboard_summary(

--- a/tests/backend/test_misc_endpoints.py
+++ b/tests/backend/test_misc_endpoints.py
@@ -83,6 +83,72 @@ class TestDemandEndpoints:
                 assert item["trend"].lower() == "stable", \
                     f"New item {item['item_name']} should have stable trend"
 
+    def test_demand_forecast_restocking_fields(self, client):
+        """Test that demand forecasts include restocking data (unit_cost, lead_time_days, category, warehouse)."""
+        response = client.get("/api/demand")
+        data = response.json()
+
+        assert len(data) > 0
+
+        valid_categories = ["actuators", "power supplies", "sensors", "controllers", "circuit boards"]
+        valid_warehouses = ["San Francisco", "London", "Tokyo"]
+
+        for item in data:
+            assert "unit_cost" in item
+            assert "lead_time_days" in item
+            assert "category" in item
+            assert "warehouse" in item
+
+            assert isinstance(item["unit_cost"], (int, float))
+            assert item["unit_cost"] > 0
+
+            assert isinstance(item["lead_time_days"], int)
+            assert item["lead_time_days"] > 0
+
+            assert item["category"].lower() in valid_categories
+            assert item["warehouse"] in valid_warehouses
+
+    def test_get_demand_forecasts_by_warehouse(self, client):
+        """Test filtering demand forecasts by warehouse."""
+        response = client.get("/api/demand?warehouse=Tokyo")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 0
+
+        for item in data:
+            assert item["warehouse"] == "Tokyo"
+
+    def test_get_demand_forecasts_by_category(self, client):
+        """Test filtering demand forecasts by category."""
+        response = client.get("/api/demand?category=Actuators")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) > 0
+
+        for item in data:
+            assert item["category"].lower() == "actuators"
+
+    def test_get_demand_forecasts_multiple_filters(self, client):
+        """Test filtering demand forecasts by warehouse and category together."""
+        response = client.get("/api/demand?warehouse=San Francisco&category=Power Supplies")
+        assert response.status_code == 200
+
+        data = response.json()
+
+        for item in data:
+            assert item["warehouse"] == "San Francisco"
+            assert item["category"].lower() == "power supplies"
+
+    def test_get_demand_forecasts_no_match(self, client):
+        """Test filtering demand forecasts by a category with no matching items."""
+        response = client.get("/api/demand?category=Circuit Boards")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data == []
+
 
 class TestBacklogEndpoints:
     """Test suite for backlog endpoints."""

--- a/tests/backend/test_restock_orders.py
+++ b/tests/backend/test_restock_orders.py
@@ -1,0 +1,161 @@
+"""
+Tests for restocking order API endpoints.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+server_path = Path(__file__).parent.parent.parent / "server"
+sys.path.insert(0, str(server_path))
+
+import main
+
+
+@pytest.fixture(autouse=True)
+def reset_restock_orders():
+    """Restock orders live in a plain in-memory list, so reset it before each test
+    to keep tests independent of execution order."""
+    main.restock_orders.clear()
+    yield
+    main.restock_orders.clear()
+
+
+class TestRestockOrderEndpoints:
+    """Test suite for restocking order endpoints."""
+
+    def test_get_restock_orders_empty_initially(self, client):
+        """Test that restock orders are empty before any are created."""
+        response = client.get("/api/restock-orders")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_restock_order_success(self, client):
+        """Test successfully creating a restock order."""
+        payload = {
+            "items": [
+                {
+                    "item_sku": "WDG-001",
+                    "item_name": "Industrial Widget Type A",
+                    "quantity": 150,
+                    "unit_cost": 42.50,
+                    "lead_time_days": 18
+                }
+            ],
+            "budget": 7000,
+            "warehouse": "San Francisco",
+            "category": None
+        }
+        response = client.post("/api/restock-orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        assert order["status"] == "Submitted"
+        assert order["total_value"] == pytest.approx(150 * 42.50)
+        assert order["budget"] == 7000
+        assert order["warehouse"] == "San Francisco"
+        assert "id" in order
+        assert "order_number" in order
+        assert "order_date" in order
+        assert "expected_delivery" in order
+
+    def test_create_restock_order_empty_items_rejected(self, client):
+        """Test that an order with no items is rejected."""
+        payload = {"items": [], "budget": 100}
+        response = client.post("/api/restock-orders", json=payload)
+        assert response.status_code == 400
+
+        data = response.json()
+        assert "detail" in data
+
+    def test_created_order_appears_in_get(self, client):
+        """Test that a newly created order shows up in the GET list."""
+        payload = {
+            "items": [
+                {
+                    "item_sku": "GSK-203",
+                    "item_name": "High-Temperature Gasket",
+                    "quantity": 100,
+                    "unit_cost": 3.15,
+                    "lead_time_days": 7
+                }
+            ],
+            "budget": 500,
+            "warehouse": "Tokyo",
+            "category": "Actuators"
+        }
+        create_response = client.post("/api/restock-orders", json=payload)
+        assert create_response.status_code == 200
+        created_order_number = create_response.json()["order_number"]
+
+        list_response = client.get("/api/restock-orders")
+        assert list_response.status_code == 200
+
+        data = list_response.json()
+        assert len(data) == 1
+        assert data[0]["order_number"] == created_order_number
+
+    def test_restock_order_multiple_items_uses_max_lead_time(self, client):
+        """Test that expected_delivery reflects the max lead time across items, not sum or average."""
+        payload = {
+            "items": [
+                {
+                    "item_sku": "FLT-405",
+                    "item_name": "Oil Filter Cartridge",
+                    "quantity": 150,
+                    "unit_cost": 6.50,
+                    "lead_time_days": 5
+                },
+                {
+                    "item_sku": "MTR-304",
+                    "item_name": "Electric Motor 5HP",
+                    "quantity": 4,
+                    "unit_cost": 285.00,
+                    "lead_time_days": 35
+                }
+            ],
+            "budget": 5000,
+            "warehouse": None,
+            "category": None
+        }
+        response = client.post("/api/restock-orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+
+        from datetime import datetime
+        order_date = datetime.fromisoformat(order["order_date"])
+        expected_delivery = datetime.fromisoformat(order["expected_delivery"])
+        delta_days = (expected_delivery - order_date).days
+
+        assert delta_days == 35
+
+    def test_restock_order_total_value_calculation(self, client):
+        """Test that total_value is the sum of quantity * unit_cost across items."""
+        payload = {
+            "items": [
+                {
+                    "item_sku": "SNR-420",
+                    "item_name": "Temperature Sensor Module",
+                    "quantity": 18,
+                    "unit_cost": 15.75,
+                    "lead_time_days": 9
+                },
+                {
+                    "item_sku": "CTL-330",
+                    "item_name": "Logic Controller Board",
+                    "quantity": 10,
+                    "unit_cost": 65.00,
+                    "lead_time_days": 16
+                }
+            ],
+            "budget": 1500,
+            "warehouse": None,
+            "category": None
+        }
+        response = client.post("/api/restock-orders", json=payload)
+        assert response.status_code == 200
+
+        order = response.json()
+        expected_total = (18 * 15.75) + (10 * 65.00)
+        assert order["total_value"] == pytest.approx(expected_total)


### PR DESCRIPTION
Extends demand forecasts with cost/lead-time/category/warehouse data, adds the first mutating backend endpoints (GET/POST /api/restock-orders), and builds a Restocking view that ranks items by trend and demand growth, greedily fills a user-set budget, and submits orders that surface in the Orders tab's new Submitted Orders section with delivery lead time.