### PR TITLE
Add restocking workflow and collapsible sidebar navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ Use the Task tool with these specialized subagents for appropriate tasks:
 - **ALWAYS use Playwright MCP tools** (`mcp__playwright__*`) for browser testing
   - Test against: `http://localhost:3000` (frontend), `http://localhost:8001` (API)
 
+## Development Standards
+
+- **Always document non-obvious logic changes with comments** - Add clear explanations for complex algorithms, business logic, or non-intuitive code patterns
+
 ## Stack
 - **Frontend**: Vue 3 + Composition API + Vite (port 3000)
 - **Backend**: Python FastAPI (port 8001)

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -2,30 +2,17 @@
   <div class="app">
     <header class="top-nav">
       <div class="nav-container">
+        <button
+          class="sidebar-toggle"
+          @click="toggleSidebar"
+          aria-label="Toggle sidebar"
+        >
+          <MenuIcon />
+        </button>
         <div class="logo">
           <h1>{{ t('nav.companyName') }}</h1>
           <span class="subtitle">{{ t('nav.subtitle') }}</span>
         </div>
-        <nav class="nav-tabs">
-          <router-link to="/" :class="{ active: $route.path === '/' }">
-            {{ t('nav.overview') }}
-          </router-link>
-          <router-link to="/inventory" :class="{ active: $route.path === '/inventory' }">
-            {{ t('nav.inventory') }}
-          </router-link>
-          <router-link to="/orders" :class="{ active: $route.path === '/orders' }">
-            {{ t('nav.orders') }}
-          </router-link>
-          <router-link to="/spending" :class="{ active: $route.path === '/spending' }">
-            {{ t('nav.finance') }}
-          </router-link>
-          <router-link to="/demand" :class="{ active: $route.path === '/demand' }">
-            {{ t('nav.demandForecast') }}
-          </router-link>
-          <router-link to="/reports" :class="{ active: $route.path === '/reports' }">
-            Reports
-          </router-link>
-        </nav>
         <LanguageSwitcher />
         <ProfileMenu
           @show-profile-details="showProfileDetails = true"
@@ -34,9 +21,13 @@
       </div>
     </header>
     <FilterBar />
-    <main class="main-content">
-      <router-view />
-    </main>
+    <div class="app-layout">
+      <Sidebar :is-collapsed="isCollapsed" />
+
+      <main class="main-content" :class="{ 'content-expanded': isCollapsed }">
+        <router-view />
+      </main>
+    </div>
 
     <ProfileDetailsModal
       :is-open="showProfileDetails"
@@ -55,15 +46,18 @@
 </template>
 
 <script>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { api } from './api'
 import { useAuth } from './composables/useAuth'
 import { useI18n } from './composables/useI18n'
+import { useSidebar } from './composables/useSidebar'
 import FilterBar from './components/FilterBar.vue'
 import ProfileMenu from './components/ProfileMenu.vue'
 import ProfileDetailsModal from './components/ProfileDetailsModal.vue'
 import TasksModal from './components/TasksModal.vue'
 import LanguageSwitcher from './components/LanguageSwitcher.vue'
+import Sidebar from './components/Sidebar.vue'
+import MenuIcon from './components/icons/MenuIcon.vue'
 
 export default {
   name: 'App',
@@ -72,11 +66,14 @@ export default {
     ProfileMenu,
     ProfileDetailsModal,
     TasksModal,
-    LanguageSwitcher
+    LanguageSwitcher,
+    Sidebar,
+    MenuIcon
   },
   setup() {
     const { currentUser } = useAuth()
     const { t } = useI18n()
+    const { isCollapsed, toggleSidebar, loadSavedState, handleResize } = useSidebar()
     const showProfileDetails = ref(false)
     const showTasks = ref(false)
     const apiTasks = ref([])
@@ -146,7 +143,16 @@ export default {
       }
     }
 
-    onMounted(loadTasks)
+    onMounted(() => {
+      loadTasks()
+      loadSavedState()
+      window.addEventListener('resize', handleResize)
+      handleResize()
+    })
+
+    onUnmounted(() => {
+      window.removeEventListener('resize', handleResize)
+    })
 
     return {
       t,
@@ -155,7 +161,9 @@ export default {
       tasks,
       addTask,
       deleteTask,
-      toggleTask
+      toggleTask,
+      isCollapsed,
+      toggleSidebar
     }
   }
 }
@@ -200,12 +208,8 @@ body {
   height: 70px;
 }
 
-.nav-container > .nav-tabs {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
 .nav-container > .language-switcher {
+  margin-left: auto;
   margin-right: 1rem;
 }
 
@@ -230,48 +234,54 @@ body {
   border-left: 1px solid #e2e8f0;
 }
 
-.nav-tabs {
+/* Sidebar toggle button */
+.sidebar-toggle {
   display: flex;
-  gap: 0.25rem;
-}
-
-.nav-tabs a {
-  padding: 0.625rem 1.25rem;
-  color: #64748b;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 0.938rem;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: 1px solid #e2e8f0;
   border-radius: 6px;
+  cursor: pointer;
+  color: #64748b;
   transition: all 0.2s ease;
-  position: relative;
+  margin-right: 1rem;
 }
 
-.nav-tabs a:hover {
+.sidebar-toggle:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
   color: #0f172a;
-  background: #f1f5f9;
 }
 
-.nav-tabs a.active {
-  color: #2563eb;
-  background: #eff6ff;
+/* App layout wrapper */
+.app-layout {
+  display: flex;
+  position: relative;
+  flex: 1;
 }
 
-.nav-tabs a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: #2563eb;
-}
-
+/* Main content with sidebar offset */
 .main-content {
   flex: 1;
   max-width: 1600px;
   width: 100%;
   margin: 0 auto;
   padding: 1.5rem 2rem;
+  margin-left: 240px;
+  transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.main-content.content-expanded {
+  margin-left: 70px;
+}
+
+@media (max-width: 1024px) {
+  .main-content {
+    margin-left: 70px;
+  }
 }
 
 .page-header {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -33,6 +33,11 @@ export const api = {
     return response.data
   },
 
+  async createOrder(orderData) {
+    const response = await axios.post(`${API_BASE_URL}/orders`, orderData)
+    return response.data
+  },
+
   async getDemandForecasts() {
     const response = await axios.get(`${API_BASE_URL}/demand`)
     return response.data

--- a/client/src/components/BudgetSlider.vue
+++ b/client/src/components/BudgetSlider.vue
@@ -1,0 +1,157 @@
+<template>
+  <div class="budget-slider">
+    <div class="slider-header">
+      <label>{{ label }}</label>
+      <div class="slider-value">{{ formattedValue }}</div>
+    </div>
+    <input
+      type="range"
+      :min="min"
+      :max="max"
+      :step="step"
+      :value="modelValue"
+      @input="updateValue"
+      class="slider-input"
+    />
+    <div class="slider-labels">
+      <span>{{ formatCurrency(min) }}</span>
+      <span>{{ formatCurrency(max) }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed } from 'vue'
+import { useI18n } from '../composables/useI18n'
+
+export default {
+  name: 'BudgetSlider',
+  props: {
+    modelValue: {
+      type: Number,
+      required: true
+    },
+    min: {
+      type: Number,
+      default: 0
+    },
+    max: {
+      type: Number,
+      default: 100000
+    },
+    step: {
+      type: Number,
+      default: 1000
+    },
+    label: {
+      type: String,
+      default: 'Budget'
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const { currentCurrency } = useI18n()
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? '¥' : '$'
+    })
+
+    const formatCurrency = (value) => {
+      return `${currencySymbol.value}${value.toLocaleString()}`
+    }
+
+    const formattedValue = computed(() => {
+      return formatCurrency(props.modelValue)
+    })
+
+    const updateValue = (event) => {
+      emit('update:modelValue', Number(event.target.value))
+    }
+
+    return {
+      formattedValue,
+      formatCurrency,
+      updateValue
+    }
+  }
+}
+</script>
+
+<style scoped>
+.budget-slider {
+  padding: 1rem;
+}
+
+.slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.slider-header label {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 0.938rem;
+}
+
+.slider-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2563eb;
+  letter-spacing: -0.025em;
+}
+
+.slider-input {
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(to right, #3b82f6, #93c5fd);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+}
+
+.slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: all 0.2s ease;
+}
+
+.slider-input::-webkit-slider-thumb:hover {
+  background: #1d4ed8;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.slider-input::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: all 0.2s ease;
+}
+
+.slider-input::-moz-range-thumb:hover {
+  background: #1d4ed8;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.slider-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  font-size: 0.813rem;
+  color: #64748b;
+}
+</style>

--- a/client/src/components/FilterBar.vue
+++ b/client/src/components/FilterBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="filters-bar">
-    <div class="filters-container">
+    <div class="filters-container" :class="{ 'sidebar-collapsed': isSidebarCollapsed }">
       <div class="filters-grid">
         <div class="filter-group">
           <label>{{ t('filters.timePeriod') }}</label>
@@ -47,6 +47,7 @@
           <label>{{ t('filters.orderStatus') }}</label>
           <select v-model="selectedStatus" class="filter-select">
             <option value="all">{{ t('filters.all') }}</option>
+            <option value="submitted">{{ t('status.submitted') }}</option>
             <option value="delivered">{{ t('status.delivered') }}</option>
             <option value="shipped">{{ t('status.shipped') }}</option>
             <option value="processing">{{ t('status.processing') }}</option>
@@ -72,6 +73,7 @@
 <script>
 import { useFilters } from '../composables/useFilters'
 import { useI18n } from '../composables/useI18n'
+import { useSidebar } from '../composables/useSidebar'
 
 export default {
   name: 'FilterBar',
@@ -86,6 +88,7 @@ export default {
     } = useFilters()
 
     const { t } = useI18n()
+    const { isCollapsed: isSidebarCollapsed } = useSidebar()
 
     return {
       t,
@@ -94,7 +97,8 @@ export default {
       selectedCategory,
       selectedStatus,
       hasActiveFilters,
-      resetFilters
+      resetFilters,
+      isSidebarCollapsed
     }
   }
 }
@@ -111,12 +115,23 @@ export default {
 }
 
 .filters-container {
-  max-width: 1600px;
+  max-width: calc(1600px + 240px);
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 2rem 0 calc(2rem + 240px);
   display: flex;
   align-items: center;
   gap: 1rem;
+  transition: padding-left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.filters-container.sidebar-collapsed {
+  padding-left: calc(2rem + 70px);
+}
+
+@media (max-width: 1024px) {
+  .filters-container {
+    padding-left: calc(2rem + 70px);
+  }
 }
 
 .filters-grid {

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -1,0 +1,154 @@
+<template>
+  <aside class="sidebar" :class="{ 'sidebar-collapsed': isCollapsed }">
+    <nav class="sidebar-nav" role="navigation" aria-label="Main navigation">
+      <router-link
+        v-for="item in navItems"
+        :key="item.path"
+        :to="item.path"
+        class="nav-item"
+        :class="{ 'active': isActiveRoute(item.path) }"
+        :aria-label="item.label"
+        :title="isCollapsed ? item.label : ''"
+        :aria-current="isActiveRoute(item.path) ? 'page' : undefined"
+      >
+        <component :is="item.icon" class="nav-icon" aria-hidden="true" />
+        <span v-if="!isCollapsed" class="nav-label">{{ item.label }}</span>
+      </router-link>
+    </nav>
+  </aside>
+</template>
+
+<script>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from '../composables/useI18n'
+import OverviewIcon from './icons/OverviewIcon.vue'
+import InventoryIcon from './icons/InventoryIcon.vue'
+import OrdersIcon from './icons/OrdersIcon.vue'
+import FinanceIcon from './icons/FinanceIcon.vue'
+import DemandIcon from './icons/DemandIcon.vue'
+import RestockingIcon from './icons/RestockingIcon.vue'
+import ReportsIcon from './icons/ReportsIcon.vue'
+
+export default {
+  name: 'Sidebar',
+  components: {
+    OverviewIcon,
+    InventoryIcon,
+    OrdersIcon,
+    FinanceIcon,
+    DemandIcon,
+    RestockingIcon,
+    ReportsIcon
+  },
+  props: {
+    isCollapsed: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup() {
+    const route = useRoute()
+    const { t } = useI18n()
+
+    const navItems = computed(() => [
+      { path: '/', label: t('nav.overview'), icon: 'OverviewIcon' },
+      { path: '/inventory', label: t('nav.inventory'), icon: 'InventoryIcon' },
+      { path: '/orders', label: t('nav.orders'), icon: 'OrdersIcon' },
+      { path: '/spending', label: t('nav.finance'), icon: 'FinanceIcon' },
+      { path: '/demand', label: t('nav.demandForecast'), icon: 'DemandIcon' },
+      { path: '/restocking', label: t('nav.restocking'), icon: 'RestockingIcon' },
+      { path: '/reports', label: 'Reports', icon: 'ReportsIcon' }
+    ])
+
+    const isActiveRoute = (path) => route.path === path
+
+    return { navItems, isActiveRoute }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 70px;
+  height: calc(100vh - 70px);
+  width: 240px;
+  background: #ffffff;
+  border-right: 1px solid #e2e8f0;
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 95;
+  overflow: hidden;
+}
+
+.sidebar-collapsed {
+  width: 70px;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+  gap: 0.25rem;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  color: #64748b;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.938rem;
+  transition: all 0.2s ease;
+  position: relative;
+  white-space: nowrap;
+}
+
+.sidebar-collapsed .nav-item {
+  justify-content: center;
+  padding: 0.75rem;
+}
+
+.nav-item:hover {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.nav-item.active {
+  background: #eff6ff;
+  color: #2563eb;
+}
+
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: #2563eb;
+}
+
+.nav-icon {
+  flex-shrink: 0;
+}
+
+.nav-label {
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+.sidebar-collapsed .nav-label {
+  opacity: 0;
+  width: 0;
+  overflow: hidden;
+}
+
+.nav-item:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
+}
+</style>

--- a/client/src/components/icons/DemandIcon.vue
+++ b/client/src/components/icons/DemandIcon.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+    <polyline points="17 6 23 6 23 12" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/FinanceIcon.vue
+++ b/client/src/components/icons/FinanceIcon.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" />
+    <path d="M12 18V6" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/InventoryIcon.vue
+++ b/client/src/components/icons/InventoryIcon.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+    <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+    <line x1="12" y1="22.08" x2="12" y2="12" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/MenuIcon.vue
+++ b/client/src/components/icons/MenuIcon.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/OrdersIcon.vue
+++ b/client/src/components/icons/OrdersIcon.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+    <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+    <path d="M9 14l2 2 4-4" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/OverviewIcon.vue
+++ b/client/src/components/icons/OverviewIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="3" y="3" width="7" height="7" />
+    <rect x="14" y="3" width="7" height="7" />
+    <rect x="14" y="14" width="7" height="7" />
+    <rect x="3" y="14" width="7" height="7" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/ReportsIcon.vue
+++ b/client/src/components/icons/ReportsIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />
+    <line x1="16" y1="13" x2="8" y2="13" />
+    <line x1="16" y1="17" x2="8" y2="17" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/components/icons/RestockingIcon.vue
+++ b/client/src/components/icons/RestockingIcon.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="23 4 23 10 17 10" />
+    <polyline points="1 20 1 14 7 14" />
+    <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+  </svg>
+</template>
+
+<style scoped>
+svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/client/src/composables/useSidebar.js
+++ b/client/src/composables/useSidebar.js
@@ -1,0 +1,54 @@
+import { ref, computed } from 'vue'
+
+// Singleton state
+const userCollapsed = ref(false)
+const screenWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 1920)
+
+export function useSidebar() {
+  // Mobile detection
+  const isMobile = computed(() => screenWidth.value < 1024)
+
+  // Effective state: mobile OR user preference
+  const isCollapsed = computed(() => isMobile.value || userCollapsed.value)
+
+  // Load from localStorage
+  const loadSavedState = () => {
+    if (typeof window === 'undefined') return
+    const saved = localStorage.getItem('sidebarCollapsed')
+    if (saved !== null) {
+      try {
+        userCollapsed.value = JSON.parse(saved)
+      } catch (e) {
+        console.warn('Failed to parse sidebar state:', e)
+      }
+    }
+  }
+
+  // Save to localStorage
+  const saveState = (collapsed) => {
+    userCollapsed.value = collapsed
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('sidebarCollapsed', JSON.stringify(collapsed))
+    }
+  }
+
+  // Toggle function
+  const toggleSidebar = () => {
+    saveState(!userCollapsed.value)
+  }
+
+  // Handle resize
+  const handleResize = () => {
+    if (typeof window !== 'undefined') {
+      screenWidth.value = window.innerWidth
+    }
+  }
+
+  return {
+    isCollapsed,
+    isMobile,
+    toggleSidebar,
+    loadSavedState,
+    handleResize
+  }
+}

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     orders: 'Orders',
     finance: 'Finance',
     demandForecast: 'Demand Forecast',
+    restocking: 'Restocking',
     companyName: 'Catalyst Components',
     subtitle: 'Inventory Management System'
   },
@@ -106,6 +107,8 @@ export default {
     title: 'Orders',
     description: 'View and manage customer orders',
     allOrders: 'All Orders',
+    submittedOrders: 'Submitted Orders',
+    pendingDelivery: 'Pending Delivery',
     totalOrders: 'Total Orders',
     totalRevenue: 'Total Revenue',
     avgOrderValue: 'Avg Order Value',
@@ -126,6 +129,33 @@ export default {
       status: 'Status',
       expectedDelivery: 'Expected Delivery',
       actualDelivery: 'Actual Delivery'
+    }
+  },
+
+  // Restocking
+  restocking: {
+    title: 'Restocking Recommendations',
+    description: 'Smart inventory restocking based on demand forecasts',
+    setBudget: 'Set Restocking Budget',
+    budget: 'Budget',
+    budgetRemaining: 'Budget Remaining',
+    itemsRecommended: 'Items Recommended',
+    totalCost: 'Total Cost',
+    noRecommendations: 'No items need restocking within budget',
+    submitOrder: 'Submit Restocking Order',
+    submitting: 'Submitting Order...',
+    orderSubmitted: 'Order submitted successfully!',
+    table: {
+      select: 'Select',
+      sku: 'SKU',
+      itemName: 'Item Name',
+      category: 'Category',
+      currentStock: 'Current Stock',
+      reorderPoint: 'Reorder Point',
+      trend: 'Demand Trend',
+      recommendedQty: 'Recommended Qty',
+      unitCost: 'Unit Cost',
+      totalCost: 'Total Cost'
     }
   },
 
@@ -204,6 +234,7 @@ export default {
     shipped: 'Shipped',
     processing: 'Processing',
     backordered: 'Backordered',
+    submitted: 'Submitted',
     inStock: 'In Stock',
     lowStock: 'Low Stock',
     adequate: 'Adequate'

--- a/client/src/locales/ja.js
+++ b/client/src/locales/ja.js
@@ -6,6 +6,7 @@ export default {
     orders: '注文',
     finance: '財務',
     demandForecast: '需要予測',
+    restocking: '補充',
     companyName: '触媒コンポーネンツ',
     subtitle: '在庫管理システム'
   },
@@ -106,6 +107,8 @@ export default {
     title: '注文',
     description: '顧客注文の表示と管理',
     allOrders: 'すべての注文',
+    submittedOrders: '提出済み注文',
+    pendingDelivery: '配達待ち',
     totalOrders: '総注文数',
     totalRevenue: '総収益',
     avgOrderValue: '平均注文額',
@@ -126,6 +129,33 @@ export default {
       status: 'ステータス',
       expectedDelivery: '予定配達日',
       actualDelivery: '実際の配達日'
+    }
+  },
+
+  // Restocking
+  restocking: {
+    title: '補充推奨',
+    description: '需要予測に基づくスマート在庫補充',
+    setBudget: '補充予算を設定',
+    budget: '予算',
+    budgetRemaining: '残り予算',
+    itemsRecommended: '推奨品目',
+    totalCost: '合計コスト',
+    noRecommendations: '予算内で補充が必要な品目はありません',
+    submitOrder: '補充注文を提出',
+    submitting: '注文を提出中...',
+    orderSubmitted: '注文が正常に提出されました！',
+    table: {
+      select: '選択',
+      sku: 'SKU',
+      itemName: '品目名',
+      category: 'カテゴリ',
+      currentStock: '現在の在庫',
+      reorderPoint: '再注文点',
+      trend: '需要トレンド',
+      recommendedQty: '推奨数量',
+      unitCost: '単価',
+      totalCost: '合計コスト'
     }
   },
 
@@ -204,6 +234,7 @@ export default {
     shipped: '出荷済み',
     processing: '処理中',
     backordered: 'バックオーダー',
+    submitted: '提出済み',
     inStock: '在庫あり',
     lowStock: '在庫僅少',
     adequate: '適量'

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import Orders from './views/Orders.vue'
 import Demand from './views/Demand.vue'
 import Spending from './views/Spending.vue'
 import Reports from './views/Reports.vue'
+import Restocking from './views/Restocking.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ const router = createRouter({
     { path: '/orders', component: Orders },
     { path: '/demand', component: Demand },
     { path: '/spending', component: Spending },
-    { path: '/reports', component: Reports }
+    { path: '/reports', component: Reports },
+    { path: '/restocking', component: Restocking }
   ]
 })
 

--- a/client/src/views/Orders.vue
+++ b/client/src/views/Orders.vue
@@ -27,6 +27,65 @@
         </div>
       </div>
 
+      <!-- Submitted Orders Section -->
+      <div v-if="submittedOrders.length > 0" class="card submitted-orders-card">
+        <div class="card-header">
+          <h3 class="card-title">
+            {{ t('orders.submittedOrders') }} ({{ submittedOrders.length }})
+          </h3>
+          <span class="badge info">{{ t('orders.pendingDelivery') }}</span>
+        </div>
+        <div class="table-container">
+          <table class="orders-table">
+            <thead>
+              <tr>
+                <th class="col-order-number">{{ t('orders.table.orderNumber') }}</th>
+                <th class="col-customer">{{ t('orders.table.customer') }}</th>
+                <th class="col-items">{{ t('orders.table.items') }}</th>
+                <th class="col-status">{{ t('orders.table.status') }}</th>
+                <th class="col-date">{{ t('orders.table.orderDate') }}</th>
+                <th class="col-date">{{ t('orders.table.expectedDelivery') }}</th>
+                <th class="col-value">{{ t('orders.table.totalValue') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="order in submittedOrders" :key="order.id">
+                <td class="col-order-number"><strong>{{ order.order_number }}</strong></td>
+                <td class="col-customer">{{ translateCustomerName(order.customer) }}</td>
+                <td class="col-items">
+                  <details class="items-details">
+                    <summary class="items-summary">
+                      {{ t('orders.itemsCount', { count: order.items.length }) }}
+                    </summary>
+                    <div class="items-dropdown">
+                      <div v-for="(item, idx) in order.items" :key="idx" class="item-entry">
+                        <span class="item-name">{{ translateProductName(item.name) }}</span>
+                        <span class="item-meta">{{ t('orders.quantity') }}: {{ item.quantity }} @ {{ currencySymbol }}{{ item.unit_price }}</span>
+                      </div>
+                    </div>
+                  </details>
+                </td>
+                <td class="col-status">
+                  <span :class="['badge', getOrderStatusClass(order.status)]">
+                    {{ t(`status.${order.status.toLowerCase()}`) }}
+                  </span>
+                </td>
+                <td class="col-date">{{ formatDate(order.order_date) }}</td>
+                <td class="col-date">
+                  <div class="delivery-info">
+                    <div>{{ formatDate(order.expected_delivery) }}</div>
+                    <div class="delivery-countdown">
+                      {{ getDaysUntilDelivery(order.expected_delivery) }} days
+                    </div>
+                  </div>
+                </td>
+                <td class="col-value"><strong>{{ currencySymbol }}{{ order.total_value.toLocaleString() }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card">
         <div class="card-header">
           <h3 class="card-title">{{ t('orders.allOrders') }} ({{ orders.length }})</h3>
@@ -135,12 +194,27 @@ export default {
 
     const getOrderStatusClass = (status) => {
       const statusMap = {
+        'Submitted': 'info',
         'Delivered': 'success',
         'Shipped': 'info',
         'Processing': 'warning',
         'Backordered': 'danger'
       }
       return statusMap[status] || 'info'
+    }
+
+    const submittedOrders = computed(() => {
+      return orders.value
+        .filter(order => order.status === 'Submitted')
+        .sort((a, b) => new Date(a.expected_delivery) - new Date(b.expected_delivery))
+    })
+
+    const getDaysUntilDelivery = (deliveryDate) => {
+      const today = new Date()
+      const delivery = new Date(deliveryDate)
+      const diffTime = delivery - today
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+      return diffDays
     }
 
     const formatDate = (dateString) => {
@@ -160,8 +234,10 @@ export default {
       loading,
       error,
       orders,
+      submittedOrders,
       getOrdersByStatus,
       getOrderStatusClass,
+      getDaysUntilDelivery,
       formatDate,
       currencySymbol,
       translateProductName,
@@ -275,5 +351,24 @@ export default {
 .item-meta {
   font-size: 0.813rem;
   color: #64748b;
+}
+
+/* Submitted Orders Section */
+.submitted-orders-card {
+  background: #eff6ff;
+  border-left: 4px solid #2563eb;
+  margin-bottom: 1.5rem;
+}
+
+.delivery-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.delivery-countdown {
+  font-size: 0.75rem;
+  color: #2563eb;
+  font-weight: 600;
 }
 </style>

--- a/client/src/views/Restocking.vue
+++ b/client/src/views/Restocking.vue
@@ -1,0 +1,485 @@
+<template>
+  <div class="restocking">
+    <div class="page-header">
+      <h2>{{ t('restocking.title') }}</h2>
+      <p>{{ t('restocking.description') }}</p>
+    </div>
+
+    <div v-if="loading" class="loading">{{ t('common.loading') }}</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <!-- Budget Slider Section -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ t('restocking.setBudget') }}</h3>
+        </div>
+        <BudgetSlider
+          v-model="budgetAmount"
+          :min="0"
+          :max="maxBudget"
+          :step="1000"
+          :label="t('restocking.budgetLabel')"
+        />
+      </div>
+
+      <!-- Stats Cards -->
+      <div class="stats-grid">
+        <div class="stat-card info">
+          <div class="stat-label">{{ t('restocking.itemsRecommended') }}</div>
+          <div class="stat-value">{{ displayedRecommendations.length }}</div>
+        </div>
+        <div class="stat-card warning">
+          <div class="stat-label">{{ t('restocking.totalCost') }}</div>
+          <div class="stat-value">{{ formatCurrency(selectedSummary.totalCost) }}</div>
+        </div>
+        <div class="stat-card success">
+          <div class="stat-label">{{ t('restocking.budgetRemaining') }}</div>
+          <div class="stat-value">{{ formatCurrency(budgetAmount - selectedSummary.totalCost) }}</div>
+        </div>
+      </div>
+
+      <!-- Recommendations Table -->
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">
+            {{ t('restocking.recommendations') }} ({{ displayedRecommendations.length }})
+          </h3>
+        </div>
+
+        <div v-if="displayedRecommendations.length === 0" class="empty-state">
+          {{ t('restocking.noRecommendations') }}
+        </div>
+
+        <div v-else class="table-container">
+          <table class="recommendations-table">
+            <thead>
+              <tr>
+                <th class="col-checkbox"></th>
+                <th class="col-sku">{{ t('restocking.table.sku') }}</th>
+                <th class="col-name">{{ t('restocking.table.itemName') }}</th>
+                <th class="col-category">{{ t('restocking.table.category') }}</th>
+                <th class="col-stock">{{ t('restocking.table.stock') }}</th>
+                <th class="col-trend">{{ t('restocking.table.trend') }}</th>
+                <th class="col-qty">{{ t('restocking.table.recommendedQty') }}</th>
+                <th class="col-unit-cost">{{ t('restocking.table.unitCost') }}</th>
+                <th class="col-total">{{ t('restocking.table.totalCost') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="rec in displayedRecommendations" :key="rec.sku">
+                <td class="col-checkbox">
+                  <input
+                    type="checkbox"
+                    :checked="selectedItems.has(rec.sku)"
+                    @change="toggleItem(rec.sku)"
+                    class="checkbox-input"
+                  />
+                </td>
+                <td class="col-sku"><strong>{{ rec.sku }}</strong></td>
+                <td class="col-name">{{ translateProductName(rec.name) }}</td>
+                <td class="col-category">{{ rec.category }}</td>
+                <td class="col-stock">
+                  <div class="stock-info">
+                    <span>{{ rec.currentStock }} / {{ rec.reorderPoint }}</span>
+                  </div>
+                </td>
+                <td class="col-trend">
+                  <span :class="['badge', getTrendClass(rec.trend)]">
+                    {{ t(`restocking.trends.${rec.trend}`) }}
+                  </span>
+                </td>
+                <td class="col-qty">{{ rec.recommendedQty }}</td>
+                <td class="col-unit-cost">{{ formatCurrency(rec.unitCost) }}</td>
+                <td class="col-total"><strong>{{ formatCurrency(rec.totalCost) }}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Submit Section -->
+      <div v-if="displayedRecommendations.length > 0" class="submit-section">
+        <div class="summary">
+          <div class="summary-item">
+            <span class="summary-label">{{ t('restocking.selectedItems') }}:</span>
+            <span class="summary-value">{{ selectedSummary.count }}</span>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">{{ t('restocking.totalOrderCost') }}:</span>
+            <span class="summary-value">{{ formatCurrency(selectedSummary.totalCost) }}</span>
+          </div>
+        </div>
+        <button
+          :disabled="!canSubmit"
+          @click="submitRestockingOrder"
+          class="submit-button"
+        >
+          {{ submitting ? t('restocking.submitting') : t('restocking.submitOrder') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { api } from '../api'
+import { useFilters } from '../composables/useFilters'
+import { useI18n } from '../composables/useI18n'
+import BudgetSlider from '../components/BudgetSlider.vue'
+
+export default {
+  name: 'Restocking',
+  components: {
+    BudgetSlider
+  },
+  setup() {
+    const router = useRouter()
+    const { getCurrentFilters, selectedLocation, selectedCategory } = useFilters()
+    const { t, currentCurrency, translateProductName } = useI18n()
+
+    const budgetAmount = ref(50000)
+    const maxBudget = ref(100000)
+    const demandForecasts = ref([])
+    const inventoryItems = ref([])
+    const selectedItems = ref(new Set())
+    const loading = ref(true)
+    const error = ref(null)
+    const submitting = ref(false)
+
+    const currencySymbol = computed(() => {
+      return currentCurrency.value === 'JPY' ? '¥' : '$'
+    })
+
+    const formatCurrency = (value) => {
+      return `${currencySymbol.value}${value.toLocaleString()}`
+    }
+
+    // Join demand forecasts with inventory and calculate priority
+    const recommendations = computed(() => {
+      const recs = []
+
+      for (const forecast of demandForecasts.value) {
+        const inventoryItem = inventoryItems.value.find(item => item.sku === forecast.sku)
+        if (!inventoryItem) continue
+
+        const quantityOnHand = inventoryItem.quantity_on_hand
+        const reorderPoint = inventoryItem.reorder_point
+
+        // Filter: only items where quantity_on_hand <= reorder_point * 1.5
+        if (quantityOnHand > reorderPoint * 1.5) continue
+
+        // Calculate priority score
+        const stockRatio = quantityOnHand / reorderPoint
+        const demandIncrease = (forecast.forecasted_demand - forecast.current_demand) / forecast.current_demand
+        const trendWeight = forecast.trend === 'increasing' ? 2 : (forecast.trend === 'stable' ? 1 : 0.5)
+        const priorityScore = (2 - stockRatio) * trendWeight * (1 + demandIncrease)
+
+        // Calculate recommended quantity
+        const shortage = Math.max(0, reorderPoint * 2 - quantityOnHand)
+        const demandBuffer = Math.max(0, forecast.forecasted_demand - quantityOnHand)
+        const recommendedQty = Math.max(shortage, demandBuffer, 1)
+
+        // Calculate total cost
+        const unitCost = inventoryItem.unit_cost
+        const totalCost = recommendedQty * unitCost
+
+        recs.push({
+          sku: forecast.sku,
+          name: inventoryItem.name,
+          category: inventoryItem.category,
+          warehouse: inventoryItem.warehouse,
+          currentStock: quantityOnHand,
+          reorderPoint: reorderPoint,
+          forecastedDemand: forecast.forecasted_demand,
+          trend: forecast.trend,
+          recommendedQty: recommendedQty,
+          unitCost: unitCost,
+          totalCost: totalCost,
+          priorityScore: priorityScore
+        })
+      }
+
+      // Sort by priority score descending
+      return recs.sort((a, b) => b.priorityScore - a.priorityScore)
+    })
+
+    // SKUs that fit within budget
+    const affordableRecommendations = computed(() => {
+      const affordable = []
+      let accumulatedCost = 0
+
+      for (const rec of recommendations.value) {
+        if (accumulatedCost + rec.totalCost <= budgetAmount.value) {
+          affordable.push(rec.sku)
+          accumulatedCost += rec.totalCost
+        }
+      }
+
+      return affordable
+    })
+
+    // Filter recommendations to show only affordable ones
+    const displayedRecommendations = computed(() => {
+      return recommendations.value.filter(rec => affordableRecommendations.value.includes(rec.sku))
+    })
+
+    // Calculate total for selected items
+    const selectedSummary = computed(() => {
+      const selectedRecs = recommendations.value.filter(rec => selectedItems.value.has(rec.sku))
+      return {
+        count: selectedRecs.length,
+        totalCost: selectedRecs.reduce((sum, rec) => sum + rec.totalCost, 0)
+      }
+    })
+
+    // Validation for submit button
+    const canSubmit = computed(() => {
+      return selectedItems.value.size > 0 &&
+             selectedSummary.value.totalCost <= budgetAmount.value &&
+             !submitting.value
+    })
+
+    // Auto-select affordable items when budget or recommendations change
+    watch([budgetAmount, recommendations], () => {
+      selectedItems.value = new Set(affordableRecommendations.value)
+    })
+
+    const loadData = async () => {
+      try {
+        loading.value = true
+        error.value = null
+
+        const filters = getCurrentFilters()
+        const [forecasts, inventory] = await Promise.all([
+          api.getDemandForecasts(),
+          api.getInventory({
+            warehouse: filters.warehouse,
+            category: filters.category
+          })
+        ])
+
+        demandForecasts.value = forecasts
+        inventoryItems.value = inventory
+      } catch (err) {
+        error.value = 'Failed to load data: ' + err.message
+        console.error('Load error:', err)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const toggleItem = (sku) => {
+      const newSet = new Set(selectedItems.value)
+      if (newSet.has(sku)) {
+        newSet.delete(sku)
+      } else {
+        newSet.add(sku)
+      }
+      selectedItems.value = newSet
+    }
+
+    const submitRestockingOrder = async () => {
+      try {
+        submitting.value = true
+
+        // Calculate delivery date (today + 7 days)
+        const deliveryDate = new Date()
+        deliveryDate.setDate(deliveryDate.getDate() + 7)
+
+        // Build items array from selections
+        const selectedRecs = recommendations.value.filter(rec => selectedItems.value.has(rec.sku))
+        const items = selectedRecs.map(rec => ({
+          sku: rec.sku,
+          name: rec.name,
+          quantity: rec.recommendedQty,
+          unit_price: rec.unitCost
+        }))
+
+        // Determine primary warehouse/category
+        const primaryWarehouse = selectedRecs[0]?.warehouse || 'San Francisco'
+        const primaryCategory = selectedRecs[0]?.category || 'Circuit Boards'
+
+        // Submit order
+        await api.createOrder({
+          customer: 'Internal Restocking',
+          items: items,
+          total_value: selectedSummary.value.totalCost,
+          order_type: 'restocking',
+          expected_delivery: deliveryDate.toISOString(),
+          warehouse: primaryWarehouse,
+          category: primaryCategory
+        })
+
+        // Redirect to orders
+        router.push('/orders')
+      } catch (err) {
+        error.value = 'Failed to submit order: ' + err.message
+        console.error('Submit error:', err)
+      } finally {
+        submitting.value = false
+      }
+    }
+
+    const getTrendClass = (trend) => {
+      const trendMap = {
+        'increasing': 'success',
+        'stable': 'info',
+        'decreasing': 'warning'
+      }
+      return trendMap[trend] || 'info'
+    }
+
+    // Watch for filter changes and reload data
+    watch([selectedLocation, selectedCategory], () => {
+      loadData()
+    })
+
+    onMounted(() => {
+      loadData()
+    })
+
+    return {
+      t,
+      loading,
+      error,
+      budgetAmount,
+      maxBudget,
+      displayedRecommendations,
+      selectedItems,
+      selectedSummary,
+      canSubmit,
+      submitting,
+      formatCurrency,
+      toggleItem,
+      submitRestockingOrder,
+      getTrendClass,
+      translateProductName
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* Fixed table layout */
+.recommendations-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+/* Column widths */
+.col-checkbox {
+  width: 50px;
+  text-align: center;
+}
+
+.col-sku {
+  width: 120px;
+}
+
+.col-name {
+  width: 200px;
+}
+
+.col-category {
+  width: 150px;
+}
+
+.col-stock {
+  width: 120px;
+}
+
+.col-trend {
+  width: 120px;
+}
+
+.col-qty {
+  width: 100px;
+}
+
+.col-unit-cost {
+  width: 100px;
+}
+
+.col-total {
+  width: 120px;
+}
+
+.checkbox-input {
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+  accent-color: #2563eb;
+}
+
+.stock-info {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: #64748b;
+  font-size: 0.938rem;
+}
+
+.submit-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  background: white;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  margin-top: 1.5rem;
+}
+
+.summary {
+  display: flex;
+  gap: 2rem;
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.summary-label {
+  font-size: 0.813rem;
+  color: #64748b;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.summary-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.submit-button {
+  padding: 0.875rem 2rem;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.submit-button:hover:not(:disabled) {
+  background: #1d4ed8;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+}
+
+.submit-button:disabled {
+  background: #cbd5e1;
+  cursor: not-allowed;
+}
+</style>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Factory Inventory Management - System Architecture</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #0f172a;
+            background: #f8fafc;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+
+        header {
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+            color: white;
+            padding: 2rem;
+            text-align: center;
+        }
+
+        header h1 {
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        header p {
+            color: #94a3b8;
+            font-size: 1rem;
+        }
+
+        .content {
+            padding: 2rem;
+        }
+
+        h2 {
+            color: #0f172a;
+            font-size: 1.5rem;
+            margin: 2rem 0 1rem 0;
+            padding-bottom: 0.5rem;
+            border-bottom: 2px solid #e2e8f0;
+        }
+
+        h3 {
+            color: #1e293b;
+            font-size: 1.2rem;
+            margin: 1.5rem 0 0.75rem 0;
+        }
+
+        .section {
+            margin-bottom: 2rem;
+        }
+
+        .architecture-diagram {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 1.5rem;
+            margin: 2rem 0;
+        }
+
+        .layer {
+            background: #f1f5f9;
+            border: 2px solid #cbd5e1;
+            border-radius: 8px;
+            padding: 1.5rem;
+            text-align: center;
+        }
+
+        .layer h4 {
+            color: #0f172a;
+            font-size: 1rem;
+            margin-bottom: 1rem;
+            font-weight: 600;
+        }
+
+        .layer-items {
+            list-style: none;
+        }
+
+        .layer-items li {
+            background: white;
+            padding: 0.5rem;
+            margin: 0.5rem 0;
+            border-radius: 4px;
+            font-size: 0.9rem;
+            color: #475569;
+        }
+
+        .tech-stack {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin: 1.5rem 0;
+        }
+
+        .tech-card {
+            background: #f8fafc;
+            border-left: 4px solid #3b82f6;
+            padding: 1rem;
+            border-radius: 4px;
+        }
+
+        .tech-card h4 {
+            color: #1e293b;
+            font-size: 1rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .tech-card ul {
+            list-style: none;
+            color: #64748b;
+            font-size: 0.9rem;
+        }
+
+        .tech-card li {
+            padding: 0.25rem 0;
+        }
+
+        .tech-card li:before {
+            content: "→ ";
+            color: #3b82f6;
+            font-weight: bold;
+        }
+
+        .data-flow {
+            background: #f1f5f9;
+            padding: 2rem;
+            border-radius: 8px;
+            margin: 1.5rem 0;
+        }
+
+        .flow-step {
+            display: flex;
+            align-items: center;
+            margin: 1rem 0;
+            padding: 1rem;
+            background: white;
+            border-radius: 4px;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+        }
+
+        .flow-number {
+            background: #3b82f6;
+            color: white;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            margin-right: 1rem;
+            flex-shrink: 0;
+        }
+
+        .flow-content {
+            flex: 1;
+        }
+
+        .flow-content strong {
+            color: #0f172a;
+            display: block;
+            margin-bottom: 0.25rem;
+        }
+
+        .flow-content span {
+            color: #64748b;
+            font-size: 0.9rem;
+        }
+
+        .endpoints {
+            background: #f8fafc;
+            padding: 1rem;
+            border-radius: 4px;
+            margin: 1rem 0;
+        }
+
+        .endpoint {
+            display: flex;
+            align-items: center;
+            padding: 0.5rem;
+            margin: 0.5rem 0;
+            font-family: 'Courier New', monospace;
+            font-size: 0.85rem;
+        }
+
+        .method {
+            background: #22c55e;
+            color: white;
+            padding: 0.25rem 0.5rem;
+            border-radius: 4px;
+            font-weight: bold;
+            margin-right: 0.75rem;
+            min-width: 45px;
+            text-align: center;
+        }
+
+        .path {
+            color: #475569;
+        }
+
+        .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 1rem;
+            margin: 1.5rem 0;
+        }
+
+        .feature-card {
+            background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+            padding: 1.5rem;
+            border-radius: 8px;
+            border: 1px solid #cbd5e1;
+        }
+
+        .feature-card h4 {
+            color: #0f172a;
+            margin-bottom: 0.5rem;
+            font-size: 1.1rem;
+        }
+
+        .feature-card p {
+            color: #475569;
+            font-size: 0.9rem;
+        }
+
+        .badge {
+            display: inline-block;
+            background: #3b82f6;
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            margin: 0.25rem;
+        }
+
+        .badge.port {
+            background: #8b5cf6;
+        }
+
+        footer {
+            background: #f8fafc;
+            padding: 1.5rem;
+            text-align: center;
+            color: #64748b;
+            font-size: 0.9rem;
+            border-top: 1px solid #e2e8f0;
+        }
+
+        @media (max-width: 768px) {
+            .architecture-diagram {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Factory Inventory Management System</h1>
+            <p>System Architecture Documentation</p>
+            <div style="margin-top: 1rem;">
+                <span class="badge">Vue 3</span>
+                <span class="badge">FastAPI</span>
+                <span class="badge">Python</span>
+                <span class="badge">Composition API</span>
+                <span class="badge port">Port 3000</span>
+                <span class="badge port">Port 8001</span>
+            </div>
+        </header>
+
+        <div class="content">
+            <!-- System Overview -->
+            <section class="section">
+                <h2>System Overview</h2>
+                <p>Full-stack inventory management application with Vue 3 frontend, Python FastAPI backend, and in-memory JSON data storage. Supports multi-language (EN/JP), real-time filtering, and comprehensive analytics.</p>
+            </section>
+
+            <!-- Architecture Layers -->
+            <section class="section">
+                <h2>Architecture Layers</h2>
+                <div class="architecture-diagram">
+                    <div class="layer">
+                        <h4>Frontend Layer</h4>
+                        <ul class="layer-items">
+                            <li>Vue 3 + Composition API</li>
+                            <li>Vue Router (6 routes)</li>
+                            <li>Composables (useFilters, useAuth, useI18n)</li>
+                            <li>Axios HTTP Client</li>
+                            <li>Vite Build Tool</li>
+                        </ul>
+                    </div>
+                    <div class="layer">
+                        <h4>Backend Layer</h4>
+                        <ul class="layer-items">
+                            <li>FastAPI Framework</li>
+                            <li>Pydantic Models</li>
+                            <li>Uvicorn ASGI Server</li>
+                            <li>Filter Logic</li>
+                            <li>Mock Data Loader</li>
+                        </ul>
+                    </div>
+                    <div class="layer">
+                        <h4>Data Layer</h4>
+                        <ul class="layer-items">
+                            <li>JSON Files (7 files)</li>
+                            <li>In-Memory Storage</li>
+                            <li>No Database</li>
+                            <li>Mock Data</li>
+                            <li>Read-Only (with PO creation)</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Tech Stack -->
+            <section class="section">
+                <h2>Technology Stack</h2>
+                <div class="tech-stack">
+                    <div class="tech-card">
+                        <h4>Frontend</h4>
+                        <ul>
+                            <li>Vue 3.4.21</li>
+                            <li>Vue Router 4.3.0</li>
+                            <li>Axios 1.6.7</li>
+                            <li>Vite 5.2.0</li>
+                            <li>Port: 3000</li>
+                        </ul>
+                    </div>
+                    <div class="tech-card">
+                        <h4>Backend</h4>
+                        <ul>
+                            <li>Python 3.x</li>
+                            <li>FastAPI 0.110+</li>
+                            <li>Uvicorn 0.24+</li>
+                            <li>Pydantic 2.5+</li>
+                            <li>Port: 8001</li>
+                        </ul>
+                    </div>
+                    <div class="tech-card">
+                        <h4>Testing</h4>
+                        <ul>
+                            <li>Pytest</li>
+                            <li>FastAPI TestClient</li>
+                            <li>Pytest Coverage</li>
+                            <li>HTTP Testing</li>
+                        </ul>
+                    </div>
+                    <div class="tech-card">
+                        <h4>Tools</h4>
+                        <ul>
+                            <li>npm (Frontend)</li>
+                            <li>uv (Backend)</li>
+                            <li>Git</li>
+                            <li>VS Code</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Data Flow -->
+            <section class="section">
+                <h2>Data Flow Architecture</h2>
+                <div class="data-flow">
+                    <div class="flow-step">
+                        <div class="flow-number">1</div>
+                        <div class="flow-content">
+                            <strong>User Interaction</strong>
+                            <span>User selects filters in FilterBar component (Time Period, Warehouse, Category, Status)</span>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-number">2</div>
+                        <div class="flow-content">
+                            <strong>Global State Update</strong>
+                            <span>useFilters() composable updates reactive refs shared across all components</span>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-number">3</div>
+                        <div class="flow-content">
+                            <strong>Component Reaction</strong>
+                            <span>Watchers detect filter changes and trigger API calls via api.js client</span>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-number">4</div>
+                        <div class="flow-content">
+                            <strong>HTTP Request</strong>
+                            <span>Axios sends GET request to FastAPI backend with URLSearchParams filters</span>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-number">5</div>
+                        <div class="flow-content">
+                            <strong>Backend Processing</strong>
+                            <span>FastAPI applies filters to JSON data, validates with Pydantic, returns filtered results</span>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-number">6</div>
+                        <div class="flow-content">
+                            <strong>Component Update</strong>
+                            <span>Component stores data in reactive ref, computed properties transform for display</span>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-number">7</div>
+                        <div class="flow-content">
+                            <strong>Template Rendering</strong>
+                            <span>Vue reactivity system re-renders template with v-for bindings and updated data</span>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- API Endpoints -->
+            <section class="section">
+                <h2>API Endpoints</h2>
+                <div class="endpoints">
+                    <h3>Inventory</h3>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/inventory?warehouse=X&category=Y</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/inventory/{item_id}</span>
+                    </div>
+
+                    <h3>Orders</h3>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/orders?warehouse=X&category=Y&status=Z&month=M</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/orders/{order_id}</span>
+                    </div>
+
+                    <h3>Dashboard & Analytics</h3>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/dashboard/summary</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/demand</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/backlog</span>
+                    </div>
+
+                    <h3>Spending</h3>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/spending/summary</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/spending/monthly</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/spending/categories</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/spending/transactions</span>
+                    </div>
+
+                    <h3>Reports</h3>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/reports/quarterly</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/reports/monthly-trends</span>
+                    </div>
+
+                    <h3>Tasks</h3>
+                    <div class="endpoint">
+                        <span class="method">GET</span>
+                        <span class="path">/api/tasks</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method" style="background: #3b82f6;">POST</span>
+                        <span class="path">/api/tasks</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method" style="background: #f59e0b;">PATCH</span>
+                        <span class="path">/api/tasks/{task_id}</span>
+                    </div>
+                    <div class="endpoint">
+                        <span class="method" style="background: #ef4444;">DELETE</span>
+                        <span class="path">/api/tasks/{task_id}</span>
+                    </div>
+
+                    <h3>Purchase Orders</h3>
+                    <div class="endpoint">
+                        <span class="method" style="background: #3b82f6;">POST</span>
+                        <span class="path">/api/purchase-orders</span>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Key Features -->
+            <section class="section">
+                <h2>Key Features</h2>
+                <div class="features">
+                    <div class="feature-card">
+                        <h4>Multi-Language Support</h4>
+                        <p>Full UI translation for English and Japanese, including product names, customer names, and warehouse locations. Currency auto-converts between USD and JPY.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Global Filter System</h4>
+                        <p>4 synchronized filters (Time Period, Warehouse, Category, Status) apply across all views via shared composable state.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Reactive State Management</h4>
+                        <p>No external state library. Uses Vue 3 Composition API with composables for shared state and computed properties for derived data.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Custom SVG Charts</h4>
+                        <p>Responsive donut and bar charts built with native SVG and CSS, no external charting libraries required.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Pydantic Validation</h4>
+                        <p>All API responses validated with Pydantic models ensuring type safety and consistent data structure.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Purchase Order Workflow</h4>
+                        <p>Backlog items can be linked to purchase orders, enabling tracking of procurement relationships and supplier management.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Component Structure -->
+            <section class="section">
+                <h2>Frontend Component Structure</h2>
+                <div class="tech-stack">
+                    <div class="tech-card" style="border-left-color: #8b5cf6;">
+                        <h4>Views (Routes)</h4>
+                        <ul>
+                            <li>Dashboard.vue</li>
+                            <li>Inventory.vue</li>
+                            <li>Orders.vue</li>
+                            <li>Demand.vue</li>
+                            <li>Spending.vue</li>
+                            <li>Reports.vue</li>
+                        </ul>
+                    </div>
+                    <div class="tech-card" style="border-left-color: #10b981;">
+                        <h4>Components</h4>
+                        <ul>
+                            <li>FilterBar.vue</li>
+                            <li>ProfileMenu.vue</li>
+                            <li>LanguageSwitcher.vue</li>
+                            <li>TasksModal.vue</li>
+                            <li>Detail Modals (4)</li>
+                        </ul>
+                    </div>
+                    <div class="tech-card" style="border-left-color: #f59e0b;">
+                        <h4>Composables</h4>
+                        <ul>
+                            <li>useFilters.js</li>
+                            <li>useAuth.js</li>
+                            <li>useI18n.js</li>
+                        </ul>
+                    </div>
+                    <div class="tech-card" style="border-left-color: #ef4444;">
+                        <h4>Utilities</h4>
+                        <ul>
+                            <li>api.js (HTTP client)</li>
+                            <li>currency.js</li>
+                            <li>Locales (en, ja)</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Data Models -->
+            <section class="section">
+                <h2>Data Models (Pydantic)</h2>
+                <div class="endpoints">
+                    <h3>Core Models</h3>
+                    <div style="padding: 1rem; background: white; border-radius: 4px; margin: 0.5rem 0;">
+                        <strong style="color: #0f172a;">InventoryItem</strong>
+                        <p style="color: #64748b; font-size: 0.9rem; margin-top: 0.5rem;">
+                            id, sku, name, category, warehouse, quantity_on_hand, reorder_point, unit_cost, location, last_updated
+                        </p>
+                    </div>
+                    <div style="padding: 1rem; background: white; border-radius: 4px; margin: 0.5rem 0;">
+                        <strong style="color: #0f172a;">Order</strong>
+                        <p style="color: #64748b; font-size: 0.9rem; margin-top: 0.5rem;">
+                            id, order_number, customer, items[], status, warehouse, category, order_date, expected_delivery, total_value, actual_delivery
+                        </p>
+                    </div>
+                    <div style="padding: 1rem; background: white; border-radius: 4px; margin: 0.5rem 0;">
+                        <strong style="color: #0f172a;">DemandForecast</strong>
+                        <p style="color: #64748b; font-size: 0.9rem; margin-top: 0.5rem;">
+                            id, item_sku, item_name, current_demand, forecasted_demand, trend, period
+                        </p>
+                    </div>
+                    <div style="padding: 1rem; background: white; border-radius: 4px; margin: 0.5rem 0;">
+                        <strong style="color: #0f172a;">BacklogItem</strong>
+                        <p style="color: #64748b; font-size: 0.9rem; margin-top: 0.5rem;">
+                            id, order_id, item_sku, item_name, quantity_needed, quantity_available, days_delayed, priority, has_purchase_order
+                        </p>
+                    </div>
+                    <div style="padding: 1rem; background: white; border-radius: 4px; margin: 0.5rem 0;">
+                        <strong style="color: #0f172a;">PurchaseOrder</strong>
+                        <p style="color: #64748b; font-size: 0.9rem; margin-top: 0.5rem;">
+                            id, backlog_item_id, supplier_name, quantity, unit_cost, expected_delivery_date, status, created_date, notes
+                        </p>
+                    </div>
+                </div>
+            </section>
+        </div>
+
+        <footer>
+            <p>Factory Inventory Management System - Full Stack Demo Application</p>
+            <p style="margin-top: 0.5rem;">Vue 3 + Composition API + FastAPI + Python</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/server/main.py
+++ b/server/main.py
@@ -120,6 +120,15 @@ class CreatePurchaseOrderRequest(BaseModel):
     expected_delivery_date: str
     notes: Optional[str] = None
 
+class CreateOrderRequest(BaseModel):
+    customer: str
+    items: List[dict]  # [{sku, name, quantity, unit_price}]
+    total_value: float
+    order_type: str
+    expected_delivery: str
+    warehouse: Optional[str] = None
+    category: Optional[str] = None
+
 # API endpoints
 @app.get("/")
 def root():
@@ -160,6 +169,36 @@ def get_order(order_id: str):
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
     return order
+
+@app.post("/api/orders", response_model=Order)
+def create_order(order_request: CreateOrderRequest):
+    """Create a new order (restocking or customer order)"""
+    from datetime import datetime
+
+    # Generate unique ID and order number
+    new_id = str(len(orders) + 1)
+    order_count = len([o for o in orders if 'RESTOCK' in o['order_number']]) + 1
+    order_number = f"RESTOCK-2025-{order_count:04d}"
+
+    # Create order object matching the Order model structure
+    new_order = {
+        "id": new_id,
+        "order_number": order_number,
+        "customer": order_request.customer,
+        "items": order_request.items,
+        "status": "Submitted",
+        "order_date": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        "expected_delivery": order_request.expected_delivery,
+        "total_value": order_request.total_value,
+        "actual_delivery": None,
+        "warehouse": order_request.warehouse,
+        "category": order_request.category
+    }
+
+    # Append to in-memory orders list
+    orders.append(new_order)
+
+    return new_order
 
 @app.get("/api/demand", response_model=List[DemandForecast])
 def get_demand_forecasts():


### PR DESCRIPTION
## Summary
- Replace top-nav tabs with a collapsible sidebar (persisted state, responsive collapse)
- Add a Restocking view that recommends reorders from demand forecasts against a budget slider and submits orders via a new `POST /api/orders` endpoint
- Orders page now surfaces submitted restocking orders pending delivery

## Test plan
- [ ] Verify sidebar collapse/expand persists across reloads and behaves responsively on mobile widths
- [ ] Verify Restocking view budget slider produces sensible reorder recommendations
- [ ] Submit a restocking order and confirm it appears on the Orders page as pending delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)